### PR TITLE
Create ILogger Interface and Base Logger Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,278 @@
+syntax: glob
+
+### VisualStudio ###
+
+# Tool Runtime Dir
+.dotnet/
+.packages/
+.tools/
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+artifacts/
+.idea/
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+msbuild.log
+msbuild.err
+msbuild.wrn
+msbuild.binlog
+.deps/
+.dirstamp
+.libs/
+*.lo
+*.o
+
+# Cross building rootfs
+cross/rootfs/
+cross/android-rootfs/
+
+# Visual Studio
+.vs/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+#NUNIT
+*.VisualState.xml
+TestResult.xml
+
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
+*_i.c
+*_p.c
+*_i.h
+*.ilk
+*.meta
+*.obj
+*.pch
+*.pdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*.log
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Chutzpah Test files
+_Chutzpah*
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+
+# TFS 2012 Local Workspace
+$tf/
+
+# Guidance Automation Toolkit
+*.gpState
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# JustCode is a .NET coding addin-in
+.JustCode
+
+# TeamCity is a build add-in
+_TeamCity*
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+
+# MightyMoose
+*.mm.*
+AutoTest.Net/
+
+# Web workbench (sass)
+.sass-cache/
+
+# Installshield output folder
+[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+*.pubxml
+*.publishproj
+
+# NuGet Packages
+*.nuget.props
+*.nuget.targets
+*.nupkg
+**/packages/*
+
+# NuGet package restore lockfiles
+project.lock.json
+
+# Windows Azure Build Output
+csx/
+*.build.csdef
+
+# Windows Store app package directory
+AppPackages/
+
+# Others
+*.Cache
+ClientBin/
+[Ss]tyle[Cc]op.*
+~$*
+*.dbmdl
+*.dbproj.schemaview
+*.pfx
+*.publishsettings
+node_modules/
+*.metaproj
+*.metaproj.tmp
+bin.localpkg/
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+
+# SQL Server files
+*.mdf
+*.ldf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+
+# Microsoft Fakes
+FakesAssemblies/
+
+### MonoDevelop ###
+
+*.pidb
+*.userprefs
+
+### Windows ###
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Linux ###
+
+*~
+
+# KDE directory preferences
+.directory
+
+### OSX ###
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# vim temporary files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+
+# Visual Studio Code
+.vscode/
+
+# Private test configuration and binaries.
+config.ps1
+**/IISApplications
+
+# VS debug support files
+launchSettings.json

--- a/Sweetener.Logging.Test/LogPattern.Test.cs
+++ b/Sweetener.Logging.Test/LogPattern.Test.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class LogPatternTest
+    {
+        [TestMethod]
+        public void ResolveExceptions()
+        {
+            #region Invalid Patterns
+            // Null Pattern
+            Assert.ThrowsException<ArgumentNullException>(() => new LogPattern(null));
+
+            // Unknown Parameter
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{msg} {foo}"));
+
+            // Missing Message
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{level}"));
+
+            // Gap In Name
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{ mess age }"));
+
+            // Invalid White Space
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{ msg\t}"));
+
+            // String Ends Prematurely
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{msg"          ));
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{msg} {tid,3"  ));
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{msg} {tid,3:X"));
+            #endregion
+
+            #region Invalid Formats in an Item
+            // Message
+            // Note: strings seem to ignore alignment and format
+            //Assert.ThrowsException<FormatException>(() => new LogPattern("{msg,k}"));
+            //Assert.ThrowsException<FormatException>(() => new LogPattern("{msg:x}"));
+
+            // Timestamp
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{ts,k}"  ));
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{ts:abc}"));
+
+            // Level
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{l,k}"));
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{l:x}"));
+
+            // ProcessId
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{pid,k}"));
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{pid:x}"));
+
+            // ProcessName
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{pn,k}"  ));
+            //Assert.ThrowsException<FormatException>(() => new LogPattern("{pn:x}"));
+
+            // ThreadId
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{tid,k}"));
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{tid:x}"));
+
+            // ThreadName
+            Assert.ThrowsException<FormatException>(() => new LogPattern("{tn,k}"  ));
+            //Assert.ThrowsException<FormatException>(() => new LogPattern("{tn:x}"));
+            #endregion
+        }
+
+        [TestMethod]
+        public void ResolveEscapedCharacters()
+        {
+            string expected = $"}}}}{{{{escaped}}}} }}}}text{{{{ {{{(int)LogPattern.Parameter.Message}}}";
+
+            Assert.AreEqual(expected, new LogPattern("}}{{escaped}} }}text{{ {msg}").CompositeFormatString);
+        }
+
+        [TestMethod]
+        public void ResolveMessage()
+        {
+            string expected = $"{{{(int)LogPattern.Parameter.Message}}}";
+
+            Assert.AreEqual(expected, new LogPattern("{msg}"    ).CompositeFormatString);
+            Assert.AreEqual(expected, new LogPattern("{message}").CompositeFormatString);
+        }
+
+        [TestMethod]
+        public void ResolveTimestamp()
+        {
+            string expected = $"{{{(int)LogPattern.Parameter.Timestamp}}} {{{(int)LogPattern.Parameter.Message}}}";
+
+            Assert.AreEqual(expected, new LogPattern("{ts} {msg}"       ).CompositeFormatString);
+            Assert.AreEqual(expected, new LogPattern("{timestamp} {msg}").CompositeFormatString);
+        }
+
+        [TestMethod]
+        public void ResolveLevel()
+        {
+            string expected = $"{{{(int)LogPattern.Parameter.Level}}} {{{(int)LogPattern.Parameter.Message}}}";
+
+            Assert.AreEqual(expected, new LogPattern("{l} {msg}"    ).CompositeFormatString);
+            Assert.AreEqual(expected, new LogPattern("{level} {msg}").CompositeFormatString);
+        }
+
+        [TestMethod]
+        public void ResolveProcessId()
+        {
+            string expected = $"{{{(int)LogPattern.Parameter.ProcessId}}} {{{(int)LogPattern.Parameter.Message}}}";
+
+            Assert.AreEqual(expected, new LogPattern("{pid} {msg}"      ).CompositeFormatString);
+            Assert.AreEqual(expected, new LogPattern("{processId} {msg}").CompositeFormatString);
+        }
+
+        [TestMethod]
+        public void ResolveProcessName()
+        {
+            string expected = $"{{{(int)LogPattern.Parameter.ProcessName}}} {{{(int)LogPattern.Parameter.Message}}}";
+
+            Assert.AreEqual(expected, new LogPattern("{pn} {msg}"         ).CompositeFormatString);
+            Assert.AreEqual(expected, new LogPattern("{processName} {msg}").CompositeFormatString);
+        }
+
+        [TestMethod]
+        public void ResolveThreadId()
+        {
+            string expected = $"{{{(int)LogPattern.Parameter.ThreadId}}} {{{(int)LogPattern.Parameter.Message}}}";
+
+            Assert.AreEqual(expected, new LogPattern("{tid} {msg}"     ).CompositeFormatString);
+            Assert.AreEqual(expected, new LogPattern("{threadId} {msg}").CompositeFormatString);
+        }
+
+        [TestMethod]
+        public void ResolveThreadName()
+        {
+            string expected = $"{{{(int)LogPattern.Parameter.ThreadName}}} {{{(int)LogPattern.Parameter.Message}}}";
+
+            Assert.AreEqual(expected, new LogPattern("{tn} {msg}"        ).CompositeFormatString);
+            Assert.AreEqual(expected, new LogPattern("{threadName} {msg}").CompositeFormatString);
+        }
+
+        [TestMethod]
+        public void ResolveMultipleParameters()
+        {
+            string expected = $"[{{{(int)LogPattern.Parameter.Timestamp}:yyyy-MM-ddTHH:mm:ss}}] [{{{(int)LogPattern.Parameter.Level},-5:F}}] ";
+            expected       += $"[Process ({{{(int)LogPattern.Parameter.ProcessId}}}): {{{(int)LogPattern.Parameter.ProcessName}}}] ";
+            expected       += $"[Thread ({{{(int)LogPattern.Parameter.ThreadId}}}): {{{(int)LogPattern.Parameter.ThreadName}}}] ";
+            expected       += $"{{{(int)LogPattern.Parameter.Message}}}";
+
+            LogPattern actual = new LogPattern("[{ts:yyyy-MM-ddTHH:mm:ss}] [{l,-5:F}] [Process ({pid}): {pn}] [Thread ({tid}): {tn}] {msg}");
+            Assert.AreEqual(expected, actual.CompositeFormatString);
+        }
+
+        [TestMethod]
+        public void ResolveRepeatParameters()
+        {
+            string expected = $"[Year: {{{(int)LogPattern.Parameter.Timestamp}:yyyy}}] ";
+            expected       += $"[Month: {{{(int)LogPattern.Parameter.Timestamp}:MM}}] ";
+            expected       += $"[Day: {{{(int)LogPattern.Parameter.Timestamp}:dd}}] ";
+            expected       += $"***{{{(int)LogPattern.Parameter.Level}:F}}*** {{{(int)LogPattern.Parameter.Message}}} ***{{{(int)LogPattern.Parameter.Level}:F}}***";
+
+            LogPattern actual = new LogPattern("[Year: {ts:yyyy}] [Month: {ts:MM}] [Day: {ts:dd}] ***{l:F}*** {msg} ***{l:F}***");
+            Assert.AreEqual(expected, actual.CompositeFormatString);
+        }
+
+        [TestMethod]
+        public void Format()
+        {
+            IFormatProvider provider = CultureInfo.InvariantCulture;
+            LogLevel[]      levels   = (LogLevel[])Enum.GetValues(typeof(LogLevel));
+            DateTime        dateTime = DateTime.UtcNow;
+            ThreadPool.SetMinThreads(levels.Length, levels.Length);
+
+            Process currentProcess = Process.GetCurrentProcess();
+            int     pid = currentProcess.Id;
+            string  pn  = currentProcess.ProcessName;
+
+            LogPattern pattern = new LogPattern("[{ts:yyyy-MM-ddTHH:mm:ss}] [{l,-5:F}] [Process ({pid}): {pn}] [Thread ({tid}): {tn}] {msg}");
+            Task[] tasks = new Task[levels.Length];
+
+            for (int i = 0; i < levels.Length; i++)
+            {
+                LogLevel level = levels[i];
+                tasks[i] = Task.Run(() =>
+                {
+                    Thread currentThread = Thread.CurrentThread;
+                    int    tid           = currentThread.ManagedThreadId;
+
+                    string tn;
+                    lock (currentThread)
+                    {
+                        if (currentThread.Name == null)
+                            currentThread.Name = $"{level:F} Thread";
+
+                        tn = currentThread.Name;
+                    }
+
+                    string expected = $"[{dateTime:yyyy-MM-ddTHH:mm:ss}] [{level,-5:F}] [Process ({pid}): {pn}] [Thread ({tid}): {tn}] success";
+                    string actual   = pattern.Format(provider, dateTime, level, "success");
+                    Assert.AreEqual(expected, actual);
+                });
+            }
+
+            Task.WaitAll(tasks);
+        }
+
+        [TestMethod]
+        public void FormatSubset()
+        {
+            IFormatProvider provider = CultureInfo.InvariantCulture;
+
+            string expected = $"#Debug# @ {Process.GetCurrentProcess().ProcessName} >> Foo Bar {{Baz}}!";
+            string actual   = new LogPattern("#{level:F}# @ {pn} >> {msg}").Format(provider, LogLevel.Debug, "Foo Bar {Baz}!");
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void FormatCulture()
+        {
+            int             tid          = Thread.CurrentThread.ManagedThreadId;
+            DateTime        dateTime     = DateTime.UtcNow;
+            IFormatProvider frenchFrench = CultureInfo.GetCultureInfo("fr-FR");
+
+            // Pretend the thread id is a currency for some interesting formatting changes
+            // The "d" format string for DateTime is also impacted by the culture
+            string expected = $"{string.Format(frenchFrench, "{0:C}", tid)} {dateTime:dd/MM/yyy} Bonjour de France";
+            string actual   = new LogPattern("{tid:C} {ts:d} {msg}").Format(frenchFrench, dateTime, LogLevel.Error, "Bonjour de France");
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/Sweetener.Logging.Test/Loggers/Logger.Test.cs
+++ b/Sweetener.Logging.Test/Loggers/Logger.Test.cs
@@ -1,0 +1,366 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public partial class LoggerTest
+    {
+        [TestMethod]
+        public void ConstructorDefaults()
+        {
+            MemoryLogger logger;
+            CultureInfo frenchFrench   = CultureInfo.GetCultureInfo("fr-FR");
+            CultureInfo spanishSpanish = CultureInfo.GetCultureInfo("es-ES");
+
+            logger = new MemoryLogger();
+            logger.Fatal("Some Message");
+            AssertDefaultLogMessage(LogLevel.Fatal, "Some Message", logger.Log.Dequeue());
+            Assert.AreEqual(LogLevel.Debug            , logger.MinimumLevel  );
+            Assert.AreEqual(CultureInfo.CurrentCulture, logger.FormatProvider);
+
+            logger = new MemoryLogger(LogLevel.Warn);
+            logger.Fatal("Another Message");
+            AssertDefaultLogMessage(LogLevel.Fatal, "Another Message", logger.Log.Dequeue());
+            Assert.AreEqual(LogLevel.Warn             , logger.MinimumLevel  );
+            Assert.AreEqual(CultureInfo.CurrentCulture, logger.FormatProvider);
+
+            logger = new MemoryLogger(LogLevel.Info, frenchFrench);
+            logger.Fatal("Yet Another Message");
+            AssertDefaultLogMessage(LogLevel.Fatal, "Yet Another Message", logger.Log.Dequeue());
+            Assert.AreEqual(LogLevel.Info, logger.MinimumLevel  );
+            Assert.AreEqual(frenchFrench , logger.FormatProvider);
+
+            logger = new MemoryLogger(LogLevel.Error, spanishSpanish, "[{tid}] {msg}");
+            logger.Fatal("Final Message");
+            Assert.AreEqual($"[{Thread.CurrentThread.ManagedThreadId}] Final Message", logger.Log.Dequeue());
+            Assert.AreEqual(LogLevel.Error, logger.MinimumLevel  );
+            Assert.AreEqual(spanishSpanish  , logger.FormatProvider);
+        }
+
+        [TestMethod]
+        public void LogThrowIfDisposed()
+        {
+            MemoryLogger logger = new MemoryLogger();
+            logger.Dispose();
+
+            // Debug
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+
+            // Info
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+
+            // Warn
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+
+            // Error
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+
+            // Fatal
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+        }
+
+        [TestMethod]
+        public void LogThrowIfNullArgument()
+        {
+            MemoryLogger logger = new MemoryLogger();
+            object[]     args   = null;
+
+            // Debug
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null               ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null, 1            ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null, 1, 2         ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null, 1, 2, 3      ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null, 1, 2, 3, 4   ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null, 1, 2, 3, 4, 5));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Debug("{0}", args        ));
+
+            // Info
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null               ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null, 1            ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null, 1, 2         ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null, 1, 2, 3      ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null, 1, 2, 3, 4   ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null, 1, 2, 3, 4, 5));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Info("{0}", args        ));
+
+            // Warn
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null               ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null, 1            ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null, 1, 2         ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null, 1, 2, 3      ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null, 1, 2, 3, 4   ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null, 1, 2, 3, 4, 5));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Warn("{0}", args        ));
+
+            // Error
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null               ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null, 1            ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null, 1, 2         ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null, 1, 2, 3      ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null, 1, 2, 3, 4   ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null, 1, 2, 3, 4, 5));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Error("{0}", args        ));
+
+            // Fatal
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null               ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null, 1            ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null, 1, 2         ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null, 1, 2, 3      ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null, 1, 2, 3, 4   ));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null, 1, 2, 3, 4, 5));
+            Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal("{0}", args        ));
+        }
+
+        [TestMethod]
+        public void LogThrowBadFormat()
+        {
+            // Use an unknown format specifier for numbers
+            MemoryLogger logger = new MemoryLogger();
+
+            // Debug
+            Assert.ThrowsException<FormatException>(() => logger.Debug("{0:Y}", 1            ));
+            Assert.ThrowsException<FormatException>(() => logger.Debug("{0:Y}", 1, 2         ));
+            Assert.ThrowsException<FormatException>(() => logger.Debug("{0:Y}", 1, 2, 3      ));
+            Assert.ThrowsException<FormatException>(() => logger.Debug("{0:Y}", 1, 2, 3, 4   ));
+            Assert.ThrowsException<FormatException>(() => logger.Debug("{0:Y}", 1, 2, 3, 4, 5));
+
+            // Info
+            Assert.ThrowsException<FormatException>(() => logger.Info("{0:Y}", 1            ));
+            Assert.ThrowsException<FormatException>(() => logger.Info("{0:Y}", 1, 2         ));
+            Assert.ThrowsException<FormatException>(() => logger.Info("{0:Y}", 1, 2, 3      ));
+            Assert.ThrowsException<FormatException>(() => logger.Info("{0:Y}", 1, 2, 3, 4   ));
+            Assert.ThrowsException<FormatException>(() => logger.Info("{0:Y}", 1, 2, 3, 4, 5));
+
+            // Warn
+            Assert.ThrowsException<FormatException>(() => logger.Warn("{0:Y}", 1            ));
+            Assert.ThrowsException<FormatException>(() => logger.Warn("{0:Y}", 1, 2         ));
+            Assert.ThrowsException<FormatException>(() => logger.Warn("{0:Y}", 1, 2, 3      ));
+            Assert.ThrowsException<FormatException>(() => logger.Warn("{0:Y}", 1, 2, 3, 4   ));
+            Assert.ThrowsException<FormatException>(() => logger.Warn("{0:Y}", 1, 2, 3, 4, 5));
+
+            // Error
+            Assert.ThrowsException<FormatException>(() => logger.Error("{0:Y}", 1            ));
+            Assert.ThrowsException<FormatException>(() => logger.Error("{0:Y}", 1, 2         ));
+            Assert.ThrowsException<FormatException>(() => logger.Error("{0:Y}", 1, 2, 3      ));
+            Assert.ThrowsException<FormatException>(() => logger.Error("{0:Y}", 1, 2, 3, 4   ));
+            Assert.ThrowsException<FormatException>(() => logger.Error("{0:Y}", 1, 2, 3, 4, 5));
+
+            // Fatal
+            Assert.ThrowsException<FormatException>(() => logger.Fatal("{0:Y}", 1            ));
+            Assert.ThrowsException<FormatException>(() => logger.Fatal("{0:Y}", 1, 2         ));
+            Assert.ThrowsException<FormatException>(() => logger.Fatal("{0:Y}", 1, 2, 3      ));
+            Assert.ThrowsException<FormatException>(() => logger.Fatal("{0:Y}", 1, 2, 3, 4   ));
+            Assert.ThrowsException<FormatException>(() => logger.Fatal("{0:Y}", 1, 2, 3, 4, 5));
+        }
+
+        [TestMethod]
+        public void IgnoreBelowMinimumLevel()
+        {
+            MemoryLogger logger;
+            foreach (LogLevel minimumLevel in (LogLevel[])Enum.GetValues(typeof(LogLevel)))
+            {
+                logger = new MemoryLogger(minimumLevel);
+
+                // Debug
+                logger.Debug("1 2 3 4 5"                          );
+                logger.Debug("{0}"                 , 1            );
+                logger.Debug("{0} {1}"             , 1, 2         );
+                logger.Debug("{0} {1} {2}"         , 1, 2, 3      );
+                logger.Debug("{0} {1} {2} {3}"     , 1, 2, 3, 4   );
+                logger.Debug("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5);
+
+                // Info
+                logger.Info("1 2 3 4 5"                          );
+                logger.Info("{0}"                 , 1            );
+                logger.Info("{0} {1}"             , 1, 2         );
+                logger.Info("{0} {1} {2}"         , 1, 2, 3      );
+                logger.Info("{0} {1} {2} {3}"     , 1, 2, 3, 4   );
+                logger.Info("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5);
+
+                // Warn
+                logger.Warn("1 2 3 4 5"                          );
+                logger.Warn("{0}"                 , 1            );
+                logger.Warn("{0} {1}"             , 1, 2         );
+                logger.Warn("{0} {1} {2}"         , 1, 2, 3      );
+                logger.Warn("{0} {1} {2} {3}"     , 1, 2, 3, 4   );
+                logger.Warn("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5);
+
+                // Error
+                logger.Error("1 2 3 4 5"                          );
+                logger.Error("{0}"                 , 1            );
+                logger.Error("{0} {1}"             , 1, 2         );
+                logger.Error("{0} {1} {2}"         , 1, 2, 3      );
+                logger.Error("{0} {1} {2} {3}"     , 1, 2, 3, 4   );
+                logger.Error("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5);
+
+                // Fatal
+                logger.Fatal("1 2 3 4 5"                          );
+                logger.Fatal("{0}"                 , 1            );
+                logger.Fatal("{0} {1}"             , 1, 2         );
+                logger.Fatal("{0} {1} {2}"         , 1, 2, 3      );
+                logger.Fatal("{0} {1} {2} {3}"     , 1, 2, 3, 4   );
+                logger.Fatal("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5);
+
+                // As the minimum level increases, it reduces the number of log entries
+                int expectedCount = (5 - (int)minimumLevel) * 6;
+                Assert.AreEqual(expectedCount, logger.Log.Count);
+            }
+        }
+
+        [TestMethod]
+        public void LogMessage()
+        {
+            MemoryLogger logger = new MemoryLogger(LogLevel.Debug, CultureInfo.InvariantCulture, "{msg} @ {l:F}");
+
+            logger.Debug("Debug");
+            logger.Info ("Info" );
+            logger.Warn ("Warn" );
+            logger.Error("Error");
+            logger.Fatal("Fatal");
+
+            Assert.AreEqual(5, logger.Log.Count);
+            Assert.AreEqual("Debug @ Debug", logger.Log.Dequeue());
+            Assert.AreEqual("Info @ Info"  , logger.Log.Dequeue());
+            Assert.AreEqual("Warn @ Warn"  , logger.Log.Dequeue());
+            Assert.AreEqual("Error @ Error", logger.Log.Dequeue());
+            Assert.AreEqual("Fatal @ Fatal", logger.Log.Dequeue());
+        }
+
+        [TestMethod]
+        public void LogFormatArg0()
+        {
+            MemoryLogger logger = new MemoryLogger(LogLevel.Debug, CultureInfo.GetCultureInfo("ja-JP"), "{msg} @ {l:F}");
+
+            logger.Debug("{0,8:C}", 11235 );
+            logger.Info ("{0,8:C}", 81321 );
+            logger.Warn ("{0,8:C}", 3455  );
+            logger.Error("{0,8:C}", 89144 );
+            logger.Fatal("{0,8:C}", 233377);
+
+            Assert.AreEqual(5, logger.Log.Count);
+            Assert.AreEqual(" ¥11,235 @ Debug", logger.Log.Dequeue());
+            Assert.AreEqual(" ¥81,321 @ Info" , logger.Log.Dequeue());
+            Assert.AreEqual("  ¥3,455 @ Warn" , logger.Log.Dequeue());
+            Assert.AreEqual(" ¥89,144 @ Error", logger.Log.Dequeue());
+            Assert.AreEqual("¥233,377 @ Fatal", logger.Log.Dequeue());
+        }
+
+        [TestMethod]
+        public void LogFormatArg0Arg1()
+        {
+            MemoryLogger logger = new MemoryLogger(LogLevel.Debug, CultureInfo.GetCultureInfo("ja-JP"), "{msg} @ {l:F}");
+
+            DateTime dateTime = new DateTime(2019, 01, 15);
+            logger.Debug("On {0:d}, made {1,11:C}", dateTime.AddDays(0),     1234);
+            logger.Info ("On {0:d}, made {1,11:C}", dateTime.AddDays(1),     5678);
+            logger.Warn ("On {0:d}, made {1,11:C}", dateTime.AddDays(2),    91011);
+            logger.Error("On {0:d}, made {1,11:C}", dateTime.AddDays(3),   121314);
+            logger.Fatal("On {0:d}, made {1,11:C}", dateTime.AddDays(4), 15161718);
+
+            Assert.AreEqual(5, logger.Log.Count);
+            Assert.AreEqual("On 2019/01/15, made      ¥1,234 @ Debug", logger.Log.Dequeue());
+            Assert.AreEqual("On 2019/01/16, made      ¥5,678 @ Info" , logger.Log.Dequeue());
+            Assert.AreEqual("On 2019/01/17, made     ¥91,011 @ Warn" , logger.Log.Dequeue());
+            Assert.AreEqual("On 2019/01/18, made    ¥121,314 @ Error", logger.Log.Dequeue());
+            Assert.AreEqual("On 2019/01/19, made ¥15,161,718 @ Fatal", logger.Log.Dequeue());
+        }
+
+        [TestMethod]
+        public void LogFormatArg0Arg1Arg2()
+        {
+            MemoryLogger logger = new MemoryLogger(LogLevel.Debug, CultureInfo.GetCultureInfo("es-ES"), "{msg} @ {l:F}");
+
+            DateTime dateTime = new DateTime(2019, 01, 15);
+            logger.Debug("On {0:d}, bought {1,7:F2} units for {2,11:C}", dateTime.AddDays(0),   24.68,    -0.25);
+            logger.Info ("On {0:d}, sold   {1,7:F2} units for {2,11:C}", dateTime.AddDays(1),   10.12,     1.33);
+            logger.Warn ("On {0:d}, sold   {1,7:F2} units for {2,11:C}", dateTime.AddDays(2), 1416   , 11975.31);
+            logger.Error("On {0:d}, bought {1,7:F2} units for {2,11:C}", dateTime.AddDays(3),   18.20,   -10   );
+            logger.Fatal("On {0:d}, sold   {1,7:F2} units for {2,11:C}", dateTime.AddDays(4), 2224   ,   115   );
+
+            Assert.AreEqual(5, logger.Log.Count);
+            Assert.AreEqual("On 15/01/2019, bought   24,68 units for     -0,25 € @ Debug", logger.Log.Dequeue());
+            Assert.AreEqual("On 16/01/2019, sold     10,12 units for      1,33 € @ Info" , logger.Log.Dequeue());
+            Assert.AreEqual("On 17/01/2019, sold   1416,00 units for 11.975,31 € @ Warn" , logger.Log.Dequeue());
+            Assert.AreEqual("On 18/01/2019, bought   18,20 units for    -10,00 € @ Error", logger.Log.Dequeue());
+            Assert.AreEqual("On 19/01/2019, sold   2224,00 units for    115,00 € @ Fatal", logger.Log.Dequeue());
+        }
+
+        [TestMethod]
+        public void LogFormatArg0Arg1Arg2Arg3()
+        {
+            MemoryLogger logger = new MemoryLogger(LogLevel.Debug, CultureInfo.GetCultureInfo("es-ES"), "{msg} @ {l:F}");
+
+            DateTime dateTime = new DateTime(2019, 01, 15);
+            logger.Debug("On {0:d}, bought {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dateTime.AddDays(0),   24.68,    -0.25,       -6.1700);
+            logger.Info ("On {0:d}, sold   {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dateTime.AddDays(1),   10.12,     1.33,       13.4596);
+            logger.Warn ("On {0:d}, sold   {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dateTime.AddDays(2), 1416.00, 11975.31, 16957039.0000);
+            logger.Error("On {0:d}, bought {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dateTime.AddDays(3),   18.20,   -10.00,     -182.0000);
+            logger.Fatal("On {0:d}, sold   {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dateTime.AddDays(4), 2224.00,   115.00,   255760.0000);
+
+            Assert.AreEqual(5, logger.Log.Count);
+            Assert.AreEqual("On 15/01/2019, bought   24,68 units for     -0,25 € (Total =         -6,17 €) @ Debug", logger.Log.Dequeue());
+            Assert.AreEqual("On 16/01/2019, sold     10,12 units for      1,33 € (Total =         13,46 €) @ Info" , logger.Log.Dequeue());
+            Assert.AreEqual("On 17/01/2019, sold   1416,00 units for 11.975,31 € (Total = 16.957.039,00 €) @ Warn" , logger.Log.Dequeue());
+            Assert.AreEqual("On 18/01/2019, bought   18,20 units for    -10,00 € (Total =       -182,00 €) @ Error", logger.Log.Dequeue());
+            Assert.AreEqual("On 19/01/2019, sold   2224,00 units for    115,00 € (Total =    255.760,00 €) @ Fatal", logger.Log.Dequeue());
+        }
+
+        [TestMethod]
+        public void LogFormatParams()
+        {
+            MemoryLogger logger = new MemoryLogger(LogLevel.Debug, CultureInfo.GetCultureInfo("es-ES"), "{msg} @ {l:F}");
+
+            DateTime dt = new DateTime(2019, 01, 15, 16, 17, 18, 19);
+            logger.Debug("On {0:d} {1:g}, bought {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(0), dt.AddHours(0).TimeOfDay,   24.68,    -0.25,       -6.1700);
+            logger.Info ("On {0:d} {1:g}, sold   {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(1), dt.AddHours(1).TimeOfDay,   10.12,     1.33,       13.4596);
+            logger.Warn ("On {0:d} {1:g}, sold   {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(2), dt.AddHours(2).TimeOfDay, 1416.00, 11975.31, 16957039.0000);
+            logger.Error("On {0:d} {1:g}, bought {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(3), dt.AddHours(3).TimeOfDay,   18.20,   -10.00,     -182.0000);
+            logger.Fatal("On {0:d} {1:g}, sold   {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(4), dt.AddHours(4).TimeOfDay, 2224.00,   115.00,   255760.0000);
+
+            Assert.AreEqual(5, logger.Log.Count);
+            Assert.AreEqual("On 15/01/2019 16:17:18,019, bought   24,68 units for     -0,25 € (Total =         -6,17 €) @ Debug", logger.Log.Dequeue());
+            Assert.AreEqual("On 16/01/2019 17:17:18,019, sold     10,12 units for      1,33 € (Total =         13,46 €) @ Info" , logger.Log.Dequeue());
+            Assert.AreEqual("On 17/01/2019 18:17:18,019, sold   1416,00 units for 11.975,31 € (Total = 16.957.039,00 €) @ Warn" , logger.Log.Dequeue());
+            Assert.AreEqual("On 18/01/2019 19:17:18,019, bought   18,20 units for    -10,00 € (Total =       -182,00 €) @ Error", logger.Log.Dequeue());
+            Assert.AreEqual("On 19/01/2019 20:17:18,019, sold   2224,00 units for    115,00 € (Total =    255.760,00 €) @ Fatal", logger.Log.Dequeue());
+        }
+
+        private static void AssertDefaultLogMessage(LogLevel expectedLevel, string expectedMessage, string logEntry)
+        {
+            // We assert the validity of the time in the LogPattern.Test.cs, so here we'll
+            // instead assert that the value is a time in the appropriate format
+            DateTime timestamp = DateTime.ParseExact(logEntry.Substring(1, logEntry.IndexOf(']') - 1), "O", null);
+            Assert.AreNotEqual(default, timestamp);
+
+            Assert.AreEqual($"[{expectedLevel,-5:F}] {expectedMessage}", logEntry.Substring(logEntry.IndexOf(']') + 2));
+        }
+    }
+}

--- a/Sweetener.Logging.Test/Sweetener.Logging.Test.csproj
+++ b/Sweetener.Logging.Test/Sweetener.Logging.Test.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sweetener.Logging\Sweetener.Logging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Sweetener.Logging.Test/TestClasses/DateTime.Extensions.cs
+++ b/Sweetener.Logging.Test/TestClasses/DateTime.Extensions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Sweetener.Logging.Test
+{
+    public static class DateTimeExtensions
+    {
+        public static DateTime Truncate(this DateTime dateTime, TimeSpan resolution)
+            => new DateTime(dateTime.Ticks - (dateTime.Ticks % resolution.Ticks));
+    }
+}

--- a/Sweetener.Logging.Test/TestClasses/MemoryLogger.cs
+++ b/Sweetener.Logging.Test/TestClasses/MemoryLogger.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Sweetener.Logging.Test
+{
+    /// <summary>
+    /// A <see cref="Logger"/> implementation used for testing.
+    /// </summary>
+    public class MemoryLogger : Logger
+    {
+        /// <summary>
+        /// A <see cref="Queue{T}"/> of written log messages.
+        /// </summary>
+        public Queue<string> Log { get; } = new Queue<string>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryLogger"/> class for the current
+        /// culture that logs all levels.
+        /// </summary>
+        public MemoryLogger()
+            : base()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryLogger"/> class with a minimum
+        /// logging level for the current culture.
+        /// </summary>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        public MemoryLogger(LogLevel minimumLevel)
+            : base(minimumLevel)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryLogger"/> class with a minimum
+        /// logging level and an <see cref="IFormatProvider"/> object for a specific culture.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c>, the formatting of the current culture is used.
+        /// </remarks>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        public MemoryLogger(LogLevel minimumLevel, IFormatProvider formatProvider)
+            : base(minimumLevel, formatProvider)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryLogger"/> class with a minimum
+        /// logging level and an <see cref="IFormatProvider"/> object for a specific culture.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c>, the formatting of the current culture is used.
+        /// </remarks>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="pattern">A format string that describes the layout of each log entry.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        /// <exception cref="FormatException">The <paramref name="pattern"/> is not formatted correctly.</exception>
+        public MemoryLogger(LogLevel minimumLevel, IFormatProvider formatProvider, string pattern)
+            : base(minimumLevel, formatProvider, pattern)
+        {  }
+
+        protected override void WriteLine(string message)
+            => Log.Enqueue(message);
+    }
+}

--- a/Sweetener.Logging/LogLevel.cs
+++ b/Sweetener.Logging/LogLevel.cs
@@ -1,0 +1,33 @@
+﻿namespace Sweetener.Logging
+{
+    /// <summary>
+    /// Specifies a priority level and semantics associated with a log entry.
+    /// </summary>
+    public enum LogLevel
+    {
+        /// <summary>
+        /// Specifies often verbose debugging information used to diagnose potential problems.
+        /// </summary>
+        Debug,
+
+        /// <summary>
+        /// Specifies standard operating information used to monitor the state of an application.
+        /// </summary>
+        Info,
+
+        /// <summary>
+        /// Specifies problematic, but not exceptional, information.
+        /// </summary>
+        Warn,
+
+        /// <summary>
+        /// Specifies exceptional and unexpected infomation that does not lead to the failure of the application.
+        /// </summary>
+        Error,
+
+        /// <summary>
+        /// Specifies exceptional and unexpected information that leads to the overall failure of the application.
+        /// </summary>
+        Fatal,
+    }
+}

--- a/Sweetener.Logging/LogPattern.cs
+++ b/Sweetener.Logging/LogPattern.cs
@@ -1,0 +1,385 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace Sweetener.Logging
+{
+    /// <summary>
+    /// Encapsulates the logic for parsing and formatting log entry patterns.
+    /// </summary>
+    internal class LogPattern
+    {
+        /// <summary>
+        /// The internal composite format string used by the <see cref="LogPattern"/>.
+        /// </summary>
+        internal readonly string CompositeFormatString;
+
+        /// <summary>
+        /// The default log layout pattern.
+        /// </summary>
+        public const string Default = "[{ts:O}] [{level:F}] {msg}";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogPattern"/> class based on
+        /// a string layout of each log entry.
+        /// </summary>
+        /// <param name="pattern">A format string that describes the layout of each log entry.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The <paramref name="pattern"/> is not formatted correctly.</exception>
+        public LogPattern(string pattern)
+        {
+            CompositeFormatString = Resolve(pattern);
+        }
+
+        /// <summary>
+        /// A delegate that yields a log entry using a pre-defined composite string.
+        /// </summary>
+        /// <param name="provider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="level">The level associated with the log entry.</param>
+        /// <param name="message">The value requested for logging.</param>
+        /// <returns>The resolved log entry based on the pattern.</returns>
+        public string Format(IFormatProvider provider, LogLevel level, string message)
+            => Format(provider, DateTime.UtcNow, level, message);
+
+        /// <summary>
+        /// A delegate that yields a log entry using a pre-defined composite string.
+        /// </summary>
+        /// <param name="provider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="timestamp">The time associated with the log entry.</param>
+        /// <param name="level">The level associated with the log entry.</param>
+        /// <param name="message">The value requested for logging.</param>
+        /// <returns>The resolved log entry based on the pattern.</returns>
+        internal string Format(IFormatProvider provider, DateTime timestamp, LogLevel level, string message)
+        {
+            // TODO: We should only retrieve process and thread information if it is going
+            //       to be logged as part of the format string.
+            Process currentProcess = Process.GetCurrentProcess();
+            Thread  currentThread  = Thread.CurrentThread;
+
+            // TODO: It seems silly to use the object[] override here when we avoid the
+            //       object[] allocation in the ILogger interface. We should figure out
+            //       how to avoid this allocation too if possible.
+            return string.Format(provider, CompositeFormatString,
+                message,                       // {0} - Message
+                timestamp,                     // {1} - Timestamp
+                level,                         // {2} - LogLevel
+                currentProcess.Id,             // {3} - Process Id
+                currentProcess.ProcessName,    // {4} - Process Name
+                currentThread.ManagedThreadId, // {5} - Thread Id
+                currentThread.Name);           // {6} - Thread Name
+        }
+
+        private static string Resolve(string pattern)
+        {
+            if (pattern == null)
+                throw new ArgumentNullException(nameof(pattern));
+
+            bool hasMessage = false;
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                char c = pattern[i];
+                switch (c)
+                {
+                    case '{':
+                        if (i + 1 < pattern.Length && pattern[i + 1] == '{')
+                        {
+                            // Escaped opened curly brace
+                            builder.Append(pattern, i, 2);
+                            i++;
+                        }
+                        else
+                        {
+                            PatternItem item = PatternItem.Parse(ref i, pattern);
+                            if (item.Parameter == Parameter.Message)
+                                hasMessage = true;
+
+                            builder.Append(item);
+                        }
+
+                        break;
+                    case '}':
+                        if (i + 1 < pattern.Length && pattern[i + 1] == '}')
+                        {
+                            // Escaped closed curly brace
+                            builder.Append(pattern, i, 2);
+                            i++;
+                        }
+                        else
+                        {
+                            throw new FormatException("Input string was not in a correct format");
+                        }
+
+                        break;
+                    default:
+                        builder.Append(c);
+                        break;
+                }
+            }
+
+            if (!hasMessage)
+                throw new FormatException("Pattern is missing the required message.");
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Represents a format item used in a logger's layout pattern.
+        /// </summary>
+        private readonly struct PatternItem
+        {
+            /// <summary>
+            /// The parameter for the item.
+            /// </summary>
+            /// <remarks>
+            /// The numeric value of the <see cref="LogPattern.Parameter"/> also serves as the item index.
+            /// </remarks>
+            public readonly Parameter Parameter;
+
+            /// <summary>
+            /// The optional alignment for the item.
+            /// </summary>
+            public readonly string Alignment;
+
+            /// <summary>
+            /// The optional format for the item.
+            /// </summary>
+            public readonly string Format;
+
+            /// <summary>
+            /// Creates a new instance of the <see cref="PatternItem"/> structure.
+            /// </summary>
+            /// <param name="parameter">The type of parameter.</param>
+            /// <param name="alignment">The optional alignment of the item.</param>
+            /// <param name="format">The optional format of the item.</param>
+            /// <exception cref="ArgumentOutOfRangeException">Unrecognized <paramref name="parameter"/> value.</exception>
+            /// <exception cref="FormatException"><paramref name="format"/> is not in a correct format</exception>
+            public PatternItem(Parameter parameter, string alignment, string format)
+            {
+                Parameter = parameter;
+                Alignment = alignment;
+                Format    = format;
+
+                // Validate
+                // TODO: We do want to check the validity of the formats aggressively and
+                //       and catch problems upon construction rather than on the first
+                //       logging call, but is there a better way to perform the validation?
+                if (Format != null)
+                {
+                    // Use Index = 0 for the item when validating with an arbitrary value of the correct type
+                    string compositeFormat = ToString(0);
+                    switch (Parameter)
+                    {
+                        // Strings
+                        case Parameter.Message:
+                        case Parameter.ProcessName:
+                        case Parameter.ThreadName:
+                            string.Format(compositeFormat, "abc");
+                            break;
+                        // DateTime
+                        case Parameter.Timestamp:
+                            string.Format(compositeFormat, DateTime.UtcNow);
+                            break;
+                        // Enum
+                        case Parameter.Level:
+                            string.Format(compositeFormat, Parameter.Level);
+                            break;
+                        // Integer
+                        case Parameter.ProcessId:
+                        case Parameter.ThreadId:
+                            string.Format(compositeFormat, 42);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(parameter));
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Gets the format string for the <see cref="LogPattern.Parameter"/>.
+            /// </summary>
+            /// <returns>The format string.</returns>
+            public override string ToString()
+                => ToString((int)Parameter);
+
+            /// <summary>
+            /// Parses a <see cref="PatternItem"/> from the given string starting
+            /// at the index.
+            /// </summary>
+            /// <param name="i">The starting index that will be updated to the end of the item as it is parsed.</param>
+            /// <param name="pattern">The string containing the <see cref="PatternItem"/>.</param>
+            /// <returns>The parsed <see cref="PatternItem"/>.</returns>
+            public static PatternItem Parse(ref int i, string pattern)
+            {
+                // Note: This struct is private, so no need to check the args' validity
+                //       like ensuring i < pattern.Length or pattern[i] is initially '{'
+                i++;
+
+                Parameter parameter = ParseParameter(ref i, pattern);
+                string    alignment = ParseAlignment(ref i, pattern);
+                string    format    = ParseFormat   (ref i, pattern);
+
+                return new PatternItem(parameter, alignment, format);
+            }
+
+            private string ToString(int index)
+            {
+                string suffix = string.Empty;
+                if (Alignment != null)
+                    suffix += $",{Alignment}";
+                if (Format != null)
+                    suffix += $":{Format}";
+
+                return $"{{{index}{suffix}}}";
+            }
+
+            private static string ParseAlignment(ref int i, string pattern)
+            {
+                // Parse the format between the comma ',' and either the colon ':' or closed curly brace '}'
+                if (pattern[i] == ',')
+                {
+                    int alignmentStart = ++i;
+                    for (; i < pattern.Length && pattern[i] != ':' && pattern[i] != '}'; i++)
+                    { }
+
+                    if (i >= pattern.Length)
+                        throw new FormatException("Input string was not in a correct format");
+
+                    return pattern.Substring(alignmentStart, i - alignmentStart);
+                }
+
+                return null;
+            }
+
+            private static string ParseFormat(ref int i, string pattern)
+            {
+                // Parse the format between the colon ':' and the closed curly brace '}'
+                if (pattern[i] == ':')
+                {
+                    int formatStart = ++i;
+                    for (; i < pattern.Length && pattern[i] != '}'; i++)
+                    { }
+
+                    if (i >= pattern.Length)
+                        throw new FormatException("Input string was not in a correct format");
+
+                    return pattern.Substring(formatStart, i - formatStart);
+                }
+
+                return null;
+            }
+
+            private static Parameter ParseParameter(ref int i, string pattern)
+            {
+                // Need to keep track of the number of characters read because it is not
+                // necessarily the same as the size of the name. Spaces are allowed before or after.
+                int nameStart = -1, nameEnd = -1;
+                for (; i < pattern.Length; i++)
+                {
+                    char c = pattern[i];
+                    // There are currently no patterns with numbers enabled
+                    if (char.IsLetter(c) && nameEnd == -1)
+                    {
+                        if (nameStart == -1)
+                            nameStart = i;
+                    }
+                    else if (c == ' ')
+                    {
+                        if (nameStart != -1 && nameEnd == -1)
+                            nameEnd = i;
+                    }
+                    else if (c == ',' || c == ':' || c == '}')
+                    {
+                        if (nameEnd == -1)
+                            nameEnd = i;
+
+                        break;
+                    }
+                    else
+                    {
+                        throw new FormatException("Input string was not in a correct format");
+                    }
+                }
+
+                // Did we reach the end without breaking?
+                if (i >= pattern.Length)
+                    throw new FormatException("Input string was not in a correct format");
+
+                string name = pattern.Substring(nameStart, nameEnd - nameStart);
+
+                // TODO: Case insensitive?
+                switch (name)
+                {
+                    case "msg":
+                    case "message":
+                        return Parameter.Message; 
+                    case "ts":
+                    case "timestamp":
+                        return Parameter.Timestamp; 
+                    case "l":
+                    case "level":
+                        return Parameter.Level;
+                    case "pid":
+                    case "processId":
+                        return Parameter.ProcessId;
+                    case "pn":
+                    case "processName":
+                        return Parameter.ProcessName;
+                    case "tid":
+                    case "threadId":
+                        return Parameter.ThreadId;
+                    case "tn":
+                    case "threadName":
+                        return Parameter.ThreadName;
+                    default:
+                        throw new FormatException($"Unrecognized pattern variable '{name}'.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// A known variable in the log layout pattern.
+        /// </summary>
+        public enum Parameter
+        {
+            /// <summary>
+            /// The log message.
+            /// </summary>
+            Message = 0,
+
+            /// <summary>
+            /// The timestamp when the log request was made.
+            /// </summary>
+            /// <remarks>
+            /// By default, the timestamp is UTC.
+            /// </remarks>
+            Timestamp = 1,
+
+            /// <summary>
+            /// The <see cref="LogLevel"/> associated with the log entry.
+            /// </summary>
+            Level = 2,
+
+            /// <summary>
+            /// The <see cref="Process.Id"/> of the process that made the log request.
+            /// </summary>
+            ProcessId = 3,
+
+            /// <summary>
+            /// The <see cref="Process.ProcessName"/> of the process that made the log request.
+            /// </summary>
+            ProcessName = 4,
+
+            /// <summary>
+            /// The <see cref="Thread.ManagedThreadId"/> of the thread that made the log request.
+            /// </summary>
+            ThreadId = 5,
+
+            /// <summary>
+            /// The <see cref="Thread.Name"/> of the thread that made the log request.
+            /// </summary>
+            ThreadName = 6,
+        }
+    }
+}

--- a/Sweetener.Logging/Loggers/ILogger{T}.cs
+++ b/Sweetener.Logging/Loggers/ILogger{T}.cs
@@ -1,0 +1,99 @@
+﻿using System;
+
+namespace Sweetener.Logging
+{
+    /// <summary>
+    /// An interface for loggers that write log entries at a given <see cref="LogLevel"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of values to be logged.</typeparam>
+    public interface ILogger<T> : IDisposable
+    {
+        /// <summary>
+        /// Gets a value indicating whether logging is synchronized (thread safe).
+        /// </summary>
+        /// <returns><c>true</c> if logging is synchronized (thread safe); otherwise, <c>false</c>.</returns>
+        bool IsSynchronized { get; }
+
+        /// <summary>
+        /// Gets the minimum level of log requests that will be fulfilled.
+        /// </summary>
+        /// <returns>The minimum <see cref="LogLevel"/> that will be fulfilled.</returns>
+        LogLevel MinimumLevel { get; }
+
+        /// <summary>
+        /// Gets an object that can be used to synchronize logging.
+        /// </summary>
+        /// <returns>An object that can be used to synchronize logging.</returns>
+        object SyncRoot { get; }
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Debug"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Debug(T obj);
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Info"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Info(T obj);
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Warn"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Warn(T obj);
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Error"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Error(T obj);
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Fatal"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Fatal(T obj);
+    }
+}

--- a/Sweetener.Logging/Loggers/ILogger{T}.tt
+++ b/Sweetener.Logging/Loggers/ILogger{T}.tt
@@ -1,0 +1,55 @@
+﻿<#@ template hostspecific="false" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System" #>
+<#@ import namespace="System" #>
+<#@ include file="..\TextTemplating\Include.t4" #>
+using System;
+
+namespace Sweetener.Logging
+{
+    /// <summary>
+    /// An interface for loggers that write log entries at a given <see cref="LogLevel"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of values to be logged.</typeparam>
+    public interface ILogger<T> : IDisposable
+    {
+        /// <summary>
+        /// Gets a value indicating whether logging is synchronized (thread safe).
+        /// </summary>
+        /// <returns><c>true</c> if logging is synchronized (thread safe); otherwise, <c>false</c>.</returns>
+        bool IsSynchronized { get; }
+
+        /// <summary>
+        /// Gets the minimum level of log requests that will be fulfilled.
+        /// </summary>
+        /// <returns>The minimum <see cref="LogLevel"/> that will be fulfilled.</returns>
+        LogLevel MinimumLevel { get; }
+
+        /// <summary>
+        /// Gets an object that can be used to synchronize logging.
+        /// </summary>
+        /// <returns>An object that can be used to synchronize logging.</returns>
+        object SyncRoot { get; }
+<#
+    foreach (string level in logLevels)
+    {
+#>
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.<#= level #>"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void <#= level #>(T obj);
+<#
+    }
+#>
+    }
+}

--- a/Sweetener.Logging/Loggers/Logger.Format.cs
+++ b/Sweetener.Logging/Loggers/Logger.Format.cs
@@ -1,0 +1,807 @@
+﻿using System;
+
+namespace Sweetener.Logging 
+{
+    /// <content>
+    /// The portion of the <see cref="Logger"/> class that defines the various formatting
+    /// overloads for its <see cref="ILogger{T}"/> methods.
+    /// </content
+    abstract partial class Logger
+    {
+        #region Debug
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Debug"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(LogLevel.Debug, message);
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Debug"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(LogLevel.Debug, string.Format(FormatProvider, format, arg0));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Debug"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(LogLevel.Debug, string.Format(FormatProvider, format, arg0, arg1));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Debug"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(LogLevel.Debug, string.Format(FormatProvider, format, arg0, arg1, arg2));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Debug"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(LogLevel.Debug, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Debug"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// -or-
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(LogLevel.Debug, string.Format(FormatProvider, format, args));
+        }
+        #endregion
+
+        #region Info
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Info"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(LogLevel.Info, message);
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Info"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(LogLevel.Info, string.Format(FormatProvider, format, arg0));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Info"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(LogLevel.Info, string.Format(FormatProvider, format, arg0, arg1));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Info"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(LogLevel.Info, string.Format(FormatProvider, format, arg0, arg1, arg2));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Info"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(LogLevel.Info, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Info"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// -or-
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(LogLevel.Info, string.Format(FormatProvider, format, args));
+        }
+        #endregion
+
+        #region Warn
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Warn"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(LogLevel.Warn, message);
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Warn"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(LogLevel.Warn, string.Format(FormatProvider, format, arg0));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Warn"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(LogLevel.Warn, string.Format(FormatProvider, format, arg0, arg1));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Warn"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(LogLevel.Warn, string.Format(FormatProvider, format, arg0, arg1, arg2));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Warn"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(LogLevel.Warn, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Warn"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// -or-
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(LogLevel.Warn, string.Format(FormatProvider, format, args));
+        }
+        #endregion
+
+        #region Error
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Error"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(LogLevel.Error, message);
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Error"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(LogLevel.Error, string.Format(FormatProvider, format, arg0));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Error"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(LogLevel.Error, string.Format(FormatProvider, format, arg0, arg1));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Error"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(LogLevel.Error, string.Format(FormatProvider, format, arg0, arg1, arg2));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Error"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(LogLevel.Error, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Error"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// -or-
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(LogLevel.Error, string.Format(FormatProvider, format, args));
+        }
+        #endregion
+
+        #region Fatal
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Fatal"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(LogLevel.Fatal, message);
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Fatal"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(LogLevel.Fatal, string.Format(FormatProvider, format, arg0));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Fatal"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(LogLevel.Fatal, string.Format(FormatProvider, format, arg0, arg1));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Fatal"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(LogLevel.Fatal, string.Format(FormatProvider, format, arg0, arg1, arg2));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Fatal"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(LogLevel.Fatal, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Fatal"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// -or-
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(LogLevel.Fatal, string.Format(FormatProvider, format, args));
+        }
+        #endregion
+
+    }
+}

--- a/Sweetener.Logging/Loggers/Logger.Format.tt
+++ b/Sweetener.Logging/Loggers/Logger.Format.tt
@@ -1,0 +1,183 @@
+﻿<#@ template hostspecific="false" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System" #>
+<#@ import namespace="System" #>
+<#@ include file="..\TextTemplating\Include.t4" #>
+using System;
+
+namespace Sweetener.Logging 
+{
+    /// <content>
+    /// The portion of the <see cref="Logger"/> class that defines the various formatting
+    /// overloads for its <see cref="ILogger{T}"/> methods.
+    /// </content
+    abstract partial class Logger
+    {
+<#
+    foreach (string level in logLevels)
+    {
+#>
+        #region <#= level #>
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.<#= level #>"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(LogLevel.<#= level #>, message);
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.<#= level #>"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(LogLevel.<#= level #>, string.Format(FormatProvider, format, arg0));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.<#= level #>"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(LogLevel.<#= level #>, string.Format(FormatProvider, format, arg0, arg1));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.<#= level #>"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(LogLevel.<#= level #>, string.Format(FormatProvider, format, arg0, arg1, arg2));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.<#= level #>"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(LogLevel.<#= level #>, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.<#= level #>"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// -or-
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(LogLevel.<#= level #>, string.Format(FormatProvider, format, args));
+        }
+        #endregion
+
+<#
+    }
+#>
+    }
+}

--- a/Sweetener.Logging/Loggers/Logger.cs
+++ b/Sweetener.Logging/Loggers/Logger.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Globalization;
+
+namespace Sweetener.Logging 
+{
+    /// <summary>
+    /// A common base implementation of the <see cref="ILogger{T}"/> interface that
+    /// logs optionally formattable string messages.
+    /// </summary>
+    public abstract partial class Logger : ILogger<string>
+    {
+        /// <summary>
+        /// Gets an object that controls formatting. 
+        /// </summary>
+        public IFormatProvider FormatProvider { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is synchronized (thread safe).
+        /// </summary>
+        /// <returns><c>true</c> if logging is synchronized (thread safe); otherwise, <c>false</c>.</returns>
+        public virtual bool IsSynchronized => false;
+
+        /// <summary>
+        /// Gets the minimum level of log requests that will be fulfilled.
+        /// </summary>
+        /// <returns>The minimum <see cref="LogLevel"/> that will be fulfilled.</returns>
+        public LogLevel MinimumLevel { get; }
+
+        /// <summary>
+        /// Gets an object that can be used to synchronize logging.
+        /// </summary>
+        /// <returns>An object that can be used to synchronize logging.</returns>
+        public object SyncRoot { get; } = new object();
+
+        private bool _disposed = false;
+        private readonly LogPattern _logPattern;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Logger"/> class for the current
+        /// culture that logs all levels.
+        /// </summary>
+        protected Logger()
+            : this(LogLevel.Debug, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Logger"/> class with a minimum
+        /// logging level for the current culture.
+        /// </summary>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        protected Logger(LogLevel minimumLevel)
+            : this(minimumLevel, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Logger"/> class with a minimum
+        /// logging level and an <see cref="IFormatProvider"/> object for a specific culture.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c>, the formatting of the current culture is used.
+        /// </remarks>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        protected Logger(LogLevel minimumLevel, IFormatProvider formatProvider)
+            : this(minimumLevel, formatProvider, LogPattern.Default)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Logger"/> class with a minimum
+        /// logging level and an <see cref="IFormatProvider"/> object for a specific culture.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c>, the formatting of the current culture is used.
+        /// </remarks>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="pattern">A format string that describes the layout of each log entry.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        /// <exception cref="FormatException">The <paramref name="pattern"/> is not formatted correctly.</exception>
+        protected Logger(LogLevel minimumLevel, IFormatProvider formatProvider, string pattern)
+        {
+            if (minimumLevel < LogLevel.Debug || minimumLevel > LogLevel.Fatal)
+                throw new ArgumentOutOfRangeException(nameof(minimumLevel), $"Unknown {nameof(LogLevel)} value '{minimumLevel}'");
+
+            if (formatProvider == null)
+                formatProvider = CultureInfo.CurrentCulture;
+
+            FormatProvider = formatProvider;
+            MinimumLevel   = minimumLevel;
+            _logPattern    = new LogPattern(pattern);
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="Logger"/> object.
+        /// </summary>
+        /// <remarks>
+        /// Call <see cref="Dispose"/> when you are finished using the <see cref="Logger"/>.
+        /// The <see cref="Dispose"/> method leaves the <see cref="Logger"/> in an unusable state.
+        /// After calling <see cref="Dispose"/>, you must release all references to the
+        /// <see cref="Logger"/> so the garbage collector can reclaim the memory that the
+        /// <see cref="Logger"/> was occupying.
+        /// </remarks>
+        public void Dispose()
+        {
+            Dispose(true);
+
+            // Still suppress, in case any derived classes use a finalizer
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the <see cref="Logger"/> and
+        /// optionally releases the managed resources.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This method is called by <see cref="Dispose"/> and possible Finalize in a
+        /// derived class. By default, this method specifies the <paramref name="disposing"/>
+        /// parameter as <c>true</c>. Any Finalize implementation specifies the
+        /// <paramref name="disposing"/> parameter as <c>false</c>.
+        /// </para>
+        /// <para>
+        /// When the <paramref name="disposing"/> parameter is <c>true</c>, this method
+        /// releases all resources held by any managed objects that this <see cref="Logger"/>
+        /// references. This method invokes the <see cref="Dispose"/> method of each referenced object.
+        /// </para>
+        /// </remarks>
+        /// <param name="disposing">
+        /// <c>true</c> to release both managed and unmanaged resources; <c>false</c>
+        /// to release only unmanaged resources.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // In the base class, this flag is used to short circuit calls before Log(...)
+            // We don't want method calls on disabled loggers to not throw exceptions
+            // because the log request was below the minimum log level!
+            if (!_disposed)
+                _disposed = true;
+        }
+
+        /// <summary>
+        /// Writes the message to the log.
+        /// </summary>
+        /// <param name="message">The value to be logged.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        protected abstract void WriteLine(string message);
+
+        private void Log(LogLevel level, string message)
+            => WriteLine(_logPattern.Format(FormatProvider, level, message));
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+                ThrowObjectDisposedException();
+
+            void ThrowObjectDisposedException() => throw new ObjectDisposedException(GetType().Name, "Cannot log to a disposed logger.");
+        }
+    }
+}

--- a/Sweetener.Logging/Sweetener.Logging.csproj
+++ b/Sweetener.Logging/Sweetener.Logging.csproj
@@ -1,0 +1,42 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>$(MSBuildProjectName).Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Loggers\ILogger{T}.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ILogger{T}.cs</LastGenOutput>
+    </None>
+    <None Update="Loggers\Logger.Format.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger.Format.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Loggers\ILogger{T}.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ILogger{T}.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Loggers\Logger.Format.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Logger.Format.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/Sweetener.Logging/TextTemplating/Include.t4
+++ b/Sweetener.Logging/TextTemplating/Include.t4
@@ -1,0 +1,5 @@
+﻿<#@ assembly name="System" #>
+<#@ import namespace="System" #>
+<#
+    string[] logLevels = new string[] { "Debug", "Info", "Warn", "Error", "Fatal" };
+#>

--- a/Sweetener.Logging/ThrowHelper.cs
+++ b/Sweetener.Logging/ThrowHelper.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Sweetener.Logging
+{
+    /// <summary>
+    /// A set of factory methods for optimally throwing common exceptions.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The use of <see cref="ThrowHelper"/> is not mandatory in all circumstances.
+    /// Instead, <see cref="ThrowHelper"/> focuses on exceptions that may be thrown in
+    /// the beginning of methods that may be called in tight loops, such as in the case
+    /// of argument validation and disposal checks. The use of <see cref="ThrowHelper"/>
+    /// reduces the size of the function's IL, which can be verbose when throwing exceptions.
+    /// For non-standard exceptions, Sweetener classes will likely wrap the throw expression
+    /// inside of the method defined in-line.
+    /// </para>
+    /// <para>
+    /// Readers may recognize the class to similar ones declared throughout CoreFx. Like
+    /// this <see cref="ThrowHelper"/>, their "ThrowHelpers" are also for internal use.
+    /// Eg. https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/System/ThrowHelper.cs
+    /// </para>
+    /// </remarks>
+    internal static class ThrowHelper
+    {
+        // TODO: Also perform resource localization
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentNullException"/> concerning the given argument.
+        /// </summary>
+        /// <param name="argument">The name of the argument.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentNullException(ExceptionArgument argument)
+            => throw new ArgumentNullException(argument.ToString()); // TODO: Are there .NET environments where this doesn't work, like AOT?
+    }
+
+    /// <summary>
+    /// The names of the exceptional arguments.
+    /// </summary>
+    internal enum ExceptionArgument
+    {
+        /// <summary>
+        /// A collection of arguments.
+        /// </summary>
+        args,
+
+        /// <summary>
+        /// A format string.
+        /// </summary>
+        format,
+    }
+}

--- a/Sweetener.sln
+++ b/Sweetener.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sweetener.Logging", "Sweetener.Logging\Sweetener.Logging.csproj", "{8B4B7850-5753-462A-ACBE-777BB119BE87}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sweetener.Logging.Test", "Sweetener.Logging.Test\Sweetener.Logging.Test.csproj", "{A631A105-131F-4E9E-B285-B635C0A29621}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8B4B7850-5753-462A-ACBE-777BB119BE87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B4B7850-5753-462A-ACBE-777BB119BE87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B4B7850-5753-462A-ACBE-777BB119BE87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B4B7850-5753-462A-ACBE-777BB119BE87}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A631A105-131F-4E9E-B285-B635C0A29621}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A631A105-131F-4E9E-B285-B635C0A29621}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A631A105-131F-4E9E-B285-B635C0A29621}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A631A105-131F-4E9E-B285-B635C0A29621}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F6F03838-0E0B-40B6-A87B-2A71309475AC}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- Define an `ILogger<T>` interface for logging arbitrary instances of type `T` at a given `LogLevel`
    - Implementations may either rely on applications to create new logger instances as needed, or they may support a single static instance to be used by applications (like many other logging libraries)
    - Implementations communicate thread-safety in the same manner as [`ICollection`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.icollection?view=netframework-4.8) using aa `IsSynchronized` flag and a `SyncRoot` for locking if the logger is not natively thread-safe
- Create a `string`-specific abstract implementation called `Logger` which provides additional formatting overloads
    - Could optionally create an `ILogger` interface specifically for `string`, but it didn't seem immediately useful. However, there may be merit in creating that level of abstraction
    - Supports a small variety of patterns, similar to [Log4J](https://logging.apache.org/log4j/2.x/), that are implemented in the `internal` `LogPattern` class
