### PR TITLE
Create ILogger Interface and Base Logger Implementation 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,186 @@
+# editorconfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style         = space
+indent_size          = 4
+
+# C# Files
+# See https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+[*.cs]
+
+# Language code styles
+# Most use "options_name = false|true : none|silent|suggestion|warning|error"
+
+# .NET code style settings 
+# "This." and "Me." qualifiers
+dotnet_style_qualification_for_field    = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method   = false:suggestion
+dotnet_style_qualification_for_event    = false:suggestion
+
+# Language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access             = true:suggestion
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warn
+csharp_preferred_modifier_order              = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+dotnet_style_readonly_field                  = true:suggestion
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+
+# Expression-level preferences
+dotnet_style_object_initializer                                  = true:suggestion
+dotnet_style_collection_initializer                              = true:suggestion
+dotnet_style_explicit_tuple_names                                = true:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names         = true:suggestion
+dotnet_style_prefer_auto_properties                              = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment       = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return           = true:suggestion
+
+# "Null" checking preferences
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation    = true:suggestion
+
+# C# code style settings
+# Implicit and explicit types
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere             = false:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods      = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators    = true:silent
+csharp_style_expression_bodied_properties   = true:suggestion
+csharp_style_expression_bodied_indexers     = true:suggestion
+csharp_style_expression_bodied_accessors    = true:suggestion
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# Inlined variable declarations
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression            = true:suggestion
+csharp_style_deconstructed_variable_declaration    = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+
+# "Null" checking preferences
+csharp_style_throw_expression          = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Code block preferences
+csharp_prefer_braces = false:suggestion
+
+# Formatting conventions
+# Most use "rule_name = false|true"
+
+# .NET formatting settings
+# Organize usings
+dotnet_sort_system_directives_first     = true
+dotnet_separate_import_directive_groups = false
+
+# C# formatting settings
+# Newline options
+csharp_new_line_before_open_brace                     = all
+csharp_new_line_before_else                           = true
+csharp_new_line_before_catch                          = true
+csharp_new_line_before_finally                        = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types     = true
+csharp_new_line_between_query_expression_clauses      = true
+
+# Indentation options
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels        = no_change
+
+# Spacing options
+csharp_space_after_cast                                                  = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+
+# Wrapping options
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks     = true
+
+# Naming conventions ("borrowed" from CoreFX)
+# See https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-naming-conventions
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_private_internal_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_private_internal_fields_should_have_prefix.symbols  = static_private_internal_fields
+dotnet_naming_rule.static_private_internal_fields_should_have_prefix.style    = static_prefix_style
+
+dotnet_naming_symbols.static_private_internal_fields.applicable_kinds           = field
+dotnet_naming_symbols.static_private_internal_fields.applicable_accessibilities = private,internal
+dotnet_naming_symbols.static_private_internal_fields.required_modifiers         = static
+
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization  = camel_case 
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+
+dotnet_naming_symbols.private_internal_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private,internal
+
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization  = camel_case
+
+# Xml project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,78 @@
+syntax: glob
+
+### VisualStudio ###
+
+# Tool Runtime Dir
+.dotnet/
+.packages/
+.tools/
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+artifacts/
+.idea/
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+msbuild.log
+msbuild.err
+msbuild.wrn
+msbuild.binlog
+.deps/
+.dirstamp
+.libs/
+*.lo
+*.o
+
+# Visual Studio
+.vs/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+*_i.c
+*_p.c
+*_i.h
+*.ilk
+*.meta
+*.obj
+*.pch
+*.pdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*.log
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+
+# NuGet Packages
+*.nuget.props
+*.nuget.targets
+*.nupkg
+**/packages/*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Will Sugarman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# Sweetener
+A collection of supplemental C# libraries that provide useful extensions.

--- a/Sweetener.Logging.Test/LogEntry{T}.Test.cs
+++ b/Sweetener.Logging.Test/LogEntry{T}.Test.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class LogEntryTest
+    {
+        [TestMethod]
+        public void CreateThrowIfOutOfRange()
+        {
+            DateTime dt = new DateTime(1999, 12, 31);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => LogEntry.Create(    (LogLevel)(-1), "Foo"         ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => LogEntry.Create(dt, (LogLevel)(-1), "Foo"         ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => LogEntry.Create(    (LogLevel)42  , Guid.NewGuid()));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => LogEntry.Create(dt, (LogLevel)42  , Guid.NewGuid()));
+        }
+
+        [TestMethod]
+        public void Constructor()
+        {
+            Task[] tasks = new Task[5];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                string threadName = $"Task #{i}";
+                tasks[i] = Task.Run(() =>
+                {
+                    DateTime min;
+                    Thread thread = Thread.CurrentThread;
+                    lock (thread)
+                    {
+                        if (thread.Name == null)
+                            thread.Name = threadName;
+                    }
+
+                    int    tid = thread.ManagedThreadId;
+                    string tn  = thread.Name;
+
+                    // Default log entry
+                    AssertLogEntry<string>(default, default, default, default, default, default);
+
+                    // Various message types
+                    min = DateTime.UtcNow;
+                    LogEntry<string> stringEntry = new LogEntry<string>(LogLevel.Warn, "Foo");
+                    AssertLogEntry(tid, tn, min, DateTime.UtcNow, LogLevel.Warn, "Foo", stringEntry);
+
+                    min = DateTime.UtcNow;
+                    LogEntry<int> intEntry = new LogEntry<int>(LogLevel.Fatal, 42);
+                    AssertLogEntry(tid, tn, min, DateTime.UtcNow, LogLevel.Fatal, 42, intEntry);
+
+                    min = DateTime.UtcNow;
+                    LogEntry<LogEntryTest> testEntry = new LogEntry<LogEntryTest>(LogLevel.Debug, this);
+                    AssertLogEntry(tid, tn, min, DateTime.UtcNow, LogLevel.Debug, this, testEntry);
+
+                    min = DateTime.UtcNow;
+                    LogEntry<DateTime> dateTimeEntry = new LogEntry<DateTime>((LogLevel)42, min); // Use invalid LogLevel
+                    AssertLogEntry(tid, tn, min, DateTime.UtcNow, (LogLevel)42, min, dateTimeEntry);
+
+                    // Various message types with a DateTime
+                    DateTime dt = new DateTime(1999, 12, 31);
+                    AssertLogEntry(tid, tn, dt, LogLevel.Warn , "Foo", new LogEntry<string>      (dt, LogLevel.Warn, "Foo"));
+                    AssertLogEntry(tid, tn, dt, LogLevel.Fatal, 42   , new LogEntry<int>         (dt, LogLevel.Fatal, 42  ));
+                    AssertLogEntry(tid, tn, dt, LogLevel.Debug, this , new LogEntry<LogEntryTest>(dt, LogLevel.Debug, this));
+                    AssertLogEntry(tid, tn, dt, (LogLevel)42  , dt   , new LogEntry<DateTime>    (dt, (LogLevel)42  , dt  ));
+                });
+            }
+
+            Task.WaitAll(tasks);
+        }
+
+        [TestMethod]
+        public void Create()
+        {
+            Task[] tasks = new Task[5];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                string threadName = $"Task #{i}";
+                tasks[i] = Task.Run(() =>
+                {
+                    DateTime min;
+                    Thread thread = Thread.CurrentThread;
+                    lock (thread)
+                    {
+                        if (thread.Name == null)
+                            thread.Name = threadName;
+                    }
+
+                    int    tid = thread.ManagedThreadId;
+                    string tn  = thread.Name;
+
+                    // Various message types
+                    min = DateTime.UtcNow;
+                    LogEntry<string> stringEntry = LogEntry.Create(LogLevel.Warn, "Foo");
+                    AssertLogEntry(tid, tn, min, DateTime.UtcNow, LogLevel.Warn, "Foo", stringEntry);
+
+                    min = DateTime.UtcNow;
+                    LogEntry<int> intEntry = LogEntry.Create(LogLevel.Fatal, 42);
+                    AssertLogEntry(tid, tn, min, DateTime.UtcNow, LogLevel.Fatal, 42, intEntry);
+
+                    min = DateTime.UtcNow;
+                    LogEntry<LogEntryTest> testEntry = LogEntry.Create(LogLevel.Debug, this);
+                    AssertLogEntry(tid, tn, min, DateTime.UtcNow, LogLevel.Debug, this, testEntry);
+
+                    // Various message types with a DateTime
+                    DateTime dt = new DateTime(1999, 12, 31);
+                    AssertLogEntry(tid, tn, dt, LogLevel.Warn , "Foo", LogEntry.Create(dt, LogLevel.Warn, "Foo"));
+                    AssertLogEntry(tid, tn, dt, LogLevel.Fatal, 42   , LogEntry.Create(dt, LogLevel.Fatal, 42  ));
+                    AssertLogEntry(tid, tn, dt, LogLevel.Debug, this , LogEntry.Create(dt, LogLevel.Debug, this));
+                });
+            }
+
+            Task.WaitAll(tasks);
+        }
+
+        private void AssertLogEntry<T>(
+            int         threadId,
+            string      threadName,
+            DateTime    timestamp,
+            LogLevel    level,
+            T           message,
+            LogEntry<T> actual)
+            => AssertLogEntry(threadId, threadName, timestamp, timestamp, level, message, actual);
+
+        private void AssertLogEntry<T>(
+            int         threadId,
+            string      threadName,
+            DateTime    min,
+            DateTime    max,
+            LogLevel    level,
+            T           message,
+            LogEntry<T> actual)
+        {
+            Assert.AreEqual(threadId  , actual.ThreadId  );
+            Assert.AreEqual(threadName, actual.ThreadName);
+            Assert.AreEqual(level     , actual.Level     );
+            Assert.AreEqual(message   , actual.Message   );
+
+            // Range is necessary for when we test the assignment of "now"
+            Assert.IsTrue(min <= actual.Timestamp && actual.Timestamp <= max);
+        }
+    }
+}

--- a/Sweetener.Logging.Test/Loggers/Logger.Test.cs
+++ b/Sweetener.Logging.Test/Loggers/Logger.Test.cs
@@ -1,0 +1,429 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class LoggerTest
+    {
+        [TestMethod]
+        public void Constructor()
+        {
+            // Argument Validation
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new MemoryLogger((LogLevel)27));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new MemoryLogger((LogLevel)27, null));
+
+            // Constructor Overloads
+            CultureInfo frenchFrench = CultureInfo.GetCultureInfo("fr-FR");
+
+            using (MemoryLogger logger = new MemoryLogger())
+            {
+                Assert.AreEqual(LogLevel.Trace            , logger.MinimumLevel  );
+                Assert.AreEqual(CultureInfo.CurrentCulture, logger.FormatProvider);
+            }
+
+            using (MemoryLogger logger = new MemoryLogger(LogLevel.Warn))
+            {
+                Assert.AreEqual(LogLevel.Warn             , logger.MinimumLevel  );
+                Assert.AreEqual(CultureInfo.CurrentCulture, logger.FormatProvider);
+            }
+
+            using (MemoryLogger logger = new MemoryLogger(LogLevel.Info, frenchFrench))
+            {
+                Assert.AreEqual(LogLevel.Info, logger.MinimumLevel  );
+                Assert.AreEqual(frenchFrench , logger.FormatProvider);
+            }
+        }
+
+        [TestMethod]
+        public void LogThrowIfDisposed()
+        {
+            MemoryLogger logger = new MemoryLogger();
+            logger.Dispose();
+
+            // Trace
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Trace("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Trace("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Trace("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Trace("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Trace("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Trace("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+
+            // Debug
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Debug("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+
+            // Info
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Info("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+
+            // Warn
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Warn("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+
+            // Error
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Error("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+
+            // Fatal
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("1 2 3 4 5"                          ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("{0}"                 , 1            ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("{0} {1}"             , 1, 2         ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("{0} {1} {2}"         , 1, 2, 3      ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("{0} {1} {2} {3}"     , 1, 2, 3, 4   ));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Fatal("{0} {1} {2} {3}, {4}", 1, 2, 3, 4, 5));
+        }
+
+        [TestMethod]
+        public void LogThrowIfNullArgument()
+        {
+            using (MemoryLogger logger = new MemoryLogger())
+            {
+                object[] args = null;
+
+                // Trace
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Trace(null               ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Trace(null, 1            ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Trace(null, 1, 2         ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Trace(null, 1, 2, 3      ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Trace(null, 1, 2, 3, 4   ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Trace(null, 1, 2, 3, 4, 5));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Trace("{0}", args        ));
+
+                // Debug
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null               ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null, 1            ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null, 1, 2         ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null, 1, 2, 3      ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null, 1, 2, 3, 4   ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Debug(null, 1, 2, 3, 4, 5));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Debug("{0}", args        ));
+
+                // Info
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null               ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null, 1            ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null, 1, 2         ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null, 1, 2, 3      ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null, 1, 2, 3, 4   ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Info(null, 1, 2, 3, 4, 5));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Info("{0}", args        ));
+
+                // Warn
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null               ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null, 1            ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null, 1, 2         ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null, 1, 2, 3      ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null, 1, 2, 3, 4   ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Warn(null, 1, 2, 3, 4, 5));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Warn("{0}", args        ));
+
+                // Error
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null               ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null, 1            ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null, 1, 2         ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null, 1, 2, 3      ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null, 1, 2, 3, 4   ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Error(null, 1, 2, 3, 4, 5));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Error("{0}", args        ));
+
+                // Fatal
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null               ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null, 1            ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null, 1, 2         ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null, 1, 2, 3      ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null, 1, 2, 3, 4   ));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal(null, 1, 2, 3, 4, 5));
+                Assert.ThrowsException<ArgumentNullException>(() => logger.Fatal("{0}", args        ));
+            }
+        }
+
+        [TestMethod]
+        public void LogThrowBadFormat()
+        {
+            // Use an unknown format specifier for numbers
+            using (MemoryLogger logger = new MemoryLogger())
+            {
+                // Trace
+                Assert.ThrowsException<FormatException>(() => logger.Trace("{0:Y}", 1            ));
+                Assert.ThrowsException<FormatException>(() => logger.Trace("{0:Y}", 1, 2         ));
+                Assert.ThrowsException<FormatException>(() => logger.Trace("{0:Y}", 1, 2, 3      ));
+                Assert.ThrowsException<FormatException>(() => logger.Trace("{0:Y}", 1, 2, 3, 4   ));
+                Assert.ThrowsException<FormatException>(() => logger.Trace("{0:Y}", 1, 2, 3, 4, 5));
+
+                // Debug
+                Assert.ThrowsException<FormatException>(() => logger.Debug("{0:Y}", 1            ));
+                Assert.ThrowsException<FormatException>(() => logger.Debug("{0:Y}", 1, 2         ));
+                Assert.ThrowsException<FormatException>(() => logger.Debug("{0:Y}", 1, 2, 3      ));
+                Assert.ThrowsException<FormatException>(() => logger.Debug("{0:Y}", 1, 2, 3, 4   ));
+                Assert.ThrowsException<FormatException>(() => logger.Debug("{0:Y}", 1, 2, 3, 4, 5));
+
+                // Info
+                Assert.ThrowsException<FormatException>(() => logger.Info("{0:Y}", 1            ));
+                Assert.ThrowsException<FormatException>(() => logger.Info("{0:Y}", 1, 2         ));
+                Assert.ThrowsException<FormatException>(() => logger.Info("{0:Y}", 1, 2, 3      ));
+                Assert.ThrowsException<FormatException>(() => logger.Info("{0:Y}", 1, 2, 3, 4   ));
+                Assert.ThrowsException<FormatException>(() => logger.Info("{0:Y}", 1, 2, 3, 4, 5));
+
+                // Warn
+                Assert.ThrowsException<FormatException>(() => logger.Warn("{0:Y}", 1            ));
+                Assert.ThrowsException<FormatException>(() => logger.Warn("{0:Y}", 1, 2         ));
+                Assert.ThrowsException<FormatException>(() => logger.Warn("{0:Y}", 1, 2, 3      ));
+                Assert.ThrowsException<FormatException>(() => logger.Warn("{0:Y}", 1, 2, 3, 4   ));
+                Assert.ThrowsException<FormatException>(() => logger.Warn("{0:Y}", 1, 2, 3, 4, 5));
+
+                // Error
+                Assert.ThrowsException<FormatException>(() => logger.Error("{0:Y}", 1            ));
+                Assert.ThrowsException<FormatException>(() => logger.Error("{0:Y}", 1, 2         ));
+                Assert.ThrowsException<FormatException>(() => logger.Error("{0:Y}", 1, 2, 3      ));
+                Assert.ThrowsException<FormatException>(() => logger.Error("{0:Y}", 1, 2, 3, 4   ));
+                Assert.ThrowsException<FormatException>(() => logger.Error("{0:Y}", 1, 2, 3, 4, 5));
+
+                // Fatal
+                Assert.ThrowsException<FormatException>(() => logger.Fatal("{0:Y}", 1            ));
+                Assert.ThrowsException<FormatException>(() => logger.Fatal("{0:Y}", 1, 2         ));
+                Assert.ThrowsException<FormatException>(() => logger.Fatal("{0:Y}", 1, 2, 3      ));
+                Assert.ThrowsException<FormatException>(() => logger.Fatal("{0:Y}", 1, 2, 3, 4   ));
+                Assert.ThrowsException<FormatException>(() => logger.Fatal("{0:Y}", 1, 2, 3, 4, 5));
+            }
+        }
+
+        [TestMethod]
+        public void IgnoreBelowMinimumLevel()
+        {
+            foreach (LogLevel minimumLevel in (LogLevel[])Enum.GetValues(typeof(LogLevel)))
+            {
+                using (MemoryLogger logger = new MemoryLogger(minimumLevel))
+                {
+                    // Trace
+                    logger.Trace("0"                                   );
+                    logger.Trace("0 {0}"                , 1            );
+                    logger.Trace("0 {0} {1}"            , 1, 2         );
+                    logger.Trace("0 {0} {1} {2}"        , 1, 2, 3      );
+                    logger.Trace("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                    logger.Trace("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                    // Debug
+                    logger.Debug("0"                                   );
+                    logger.Debug("0 {0}"                , 1            );
+                    logger.Debug("0 {0} {1}"            , 1, 2         );
+                    logger.Debug("0 {0} {1} {2}"        , 1, 2, 3      );
+                    logger.Debug("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                    logger.Debug("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                    // Info
+                    logger.Info("0"                                   );
+                    logger.Info("0 {0}"                , 1            );
+                    logger.Info("0 {0} {1}"            , 1, 2         );
+                    logger.Info("0 {0} {1} {2}"        , 1, 2, 3      );
+                    logger.Info("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                    logger.Info("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                    // Warn
+                    logger.Warn("0"                                   );
+                    logger.Warn("0 {0}"                , 1            );
+                    logger.Warn("0 {0} {1}"            , 1, 2         );
+                    logger.Warn("0 {0} {1} {2}"        , 1, 2, 3      );
+                    logger.Warn("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                    logger.Warn("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                    // Error
+                    logger.Error("0"                                   );
+                    logger.Error("0 {0}"                , 1            );
+                    logger.Error("0 {0} {1}"            , 1, 2         );
+                    logger.Error("0 {0} {1} {2}"        , 1, 2, 3      );
+                    logger.Error("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                    logger.Error("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                    // Fatal
+                    logger.Fatal("0"                                   );
+                    logger.Fatal("0 {0}"                , 1            );
+                    logger.Fatal("0 {0} {1}"            , 1, 2         );
+                    logger.Fatal("0 {0} {1} {2}"        , 1, 2, 3      );
+                    logger.Fatal("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                    logger.Fatal("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                    // As the minimum level increases, it reduces the number of log entries
+                    int logLevelCount = Enum.GetValues(typeof(LogLevel)).Length;
+                    int expectedCount = (logLevelCount - (int)minimumLevel) * logLevelCount;
+                    Assert.AreEqual(expectedCount, logger.LogQueue.Count);
+
+                    LogLevel level = minimumLevel;
+                    while (logger.LogQueue.Count > 0)
+                    {
+                        Assert.IsTrue(logger.LogQueue.Count >= 6);
+                        AssertLogEntry(level, "0"          , logger.LogQueue.Dequeue());
+                        AssertLogEntry(level, "0 1"        , logger.LogQueue.Dequeue());
+                        AssertLogEntry(level, "0 1 2"      , logger.LogQueue.Dequeue());
+                        AssertLogEntry(level, "0 1 2 3"    , logger.LogQueue.Dequeue());
+                        AssertLogEntry(level, "0 1 2 3 4"  , logger.LogQueue.Dequeue());
+                        AssertLogEntry(level, "0 1 2 3 4 5", logger.LogQueue.Dequeue());
+
+                        level++;
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void LogMessage()
+        {
+            using (MemoryLogger logger = new MemoryLogger(default, CultureInfo.InvariantCulture))
+            {
+                logger.Trace("Trace");
+                logger.Debug("Debug");
+                logger.Info ("Info" );
+                logger.Warn ("Warn" );
+                logger.Error("Error");
+                logger.Fatal("Fatal");
+
+                Assert.AreEqual(6, logger.LogQueue.Count);
+                AssertLogEntry(LogLevel.Trace, "Trace", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Debug, "Debug", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Info , "Info" , logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Warn , "Warn" , logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Error, "Error", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Fatal, "Fatal", logger.LogQueue.Dequeue());
+            }
+        }
+
+        [TestMethod]
+        public void LogFormatArg0()
+        {
+            using (MemoryLogger logger = new MemoryLogger(default, CultureInfo.GetCultureInfo("ja-JP")))
+            {
+                logger.Trace("{0,8:C}",   4321);
+                logger.Debug("{0,8:C}",  11235);
+                logger.Info ("{0,8:C}",  81321);
+                logger.Warn ("{0,8:C}",   3455);
+                logger.Error("{0,8:C}",  89144);
+                logger.Fatal("{0,8:C}", 233377);
+
+                Assert.AreEqual(6, logger.LogQueue.Count);
+                AssertLogEntry(LogLevel.Trace, "  ¥4,321", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Debug, " ¥11,235", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Info , " ¥81,321", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Warn , "  ¥3,455", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Error, " ¥89,144", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Fatal, "¥233,377", logger.LogQueue.Dequeue());
+            }
+        }
+
+        [TestMethod]
+        public void LogFormatArg0Arg1()
+        {
+            using (MemoryLogger logger = new MemoryLogger(default, CultureInfo.GetCultureInfo("ja-JP")))
+            {
+                DateTime dt = new DateTime(2019, 01, 15);
+                logger.Trace("On {0:d}, made {1,11:C}", dt.AddDays(0),      823);
+                logger.Debug("On {0:d}, made {1,11:C}", dt.AddDays(1),     1234);
+                logger.Info ("On {0:d}, made {1,11:C}", dt.AddDays(2),     5678);
+                logger.Warn ("On {0:d}, made {1,11:C}", dt.AddDays(3),    91011);
+                logger.Error("On {0:d}, made {1,11:C}", dt.AddDays(4),   121314);
+                logger.Fatal("On {0:d}, made {1,11:C}", dt.AddDays(5), 15161718);
+
+                Assert.AreEqual(6, logger.LogQueue.Count);
+                AssertLogEntry(LogLevel.Trace, "On 2019/01/15, made        ¥823", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Debug, "On 2019/01/16, made      ¥1,234", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Info , "On 2019/01/17, made      ¥5,678", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Warn , "On 2019/01/18, made     ¥91,011", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Error, "On 2019/01/19, made    ¥121,314", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Fatal, "On 2019/01/20, made ¥15,161,718", logger.LogQueue.Dequeue());
+            }
+        }
+
+        [TestMethod]
+        public void LogFormatArg0Arg1Arg2()
+        {
+            using (MemoryLogger logger = new MemoryLogger(default, CultureInfo.GetCultureInfo("es-ES")))
+            {
+                DateTime dt = new DateTime(2019, 01, 15);
+                logger.Trace("On {0:d}, bought {1,7:F2} units for {2,11:C}", dt.AddDays(0),    0.42,    13.37);
+                logger.Debug("On {0:d}, bought {1,7:F2} units for {2,11:C}", dt.AddDays(1),   24.68,    -0.25);
+                logger.Info ("On {0:d}, sold   {1,7:F2} units for {2,11:C}", dt.AddDays(2),   10.12,     1.33);
+                logger.Warn ("On {0:d}, sold   {1,7:F2} units for {2,11:C}", dt.AddDays(3), 1416.00, 11975.31);
+                logger.Error("On {0:d}, bought {1,7:F2} units for {2,11:C}", dt.AddDays(4),   18.20,   -10.00);
+                logger.Fatal("On {0:d}, sold   {1,7:F2} units for {2,11:C}", dt.AddDays(5), 2224.00,   115.00);
+
+                Assert.AreEqual(6, logger.LogQueue.Count);
+                AssertLogEntry(LogLevel.Trace, "On 15/01/2019, bought    0,42 units for     13,37 €", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Debug, "On 16/01/2019, bought   24,68 units for     -0,25 €", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Info , "On 17/01/2019, sold     10,12 units for      1,33 €", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Warn , "On 18/01/2019, sold   1416,00 units for 11.975,31 €", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Error, "On 19/01/2019, bought   18,20 units for    -10,00 €", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Fatal, "On 20/01/2019, sold   2224,00 units for    115,00 €", logger.LogQueue.Dequeue());
+            }
+        }
+
+        [TestMethod]
+        public void LogFormatArg0Arg1Arg2Arg3()
+        {
+            using (MemoryLogger logger = new MemoryLogger(default, CultureInfo.GetCultureInfo("es-ES")))
+            {
+                DateTime dt = new DateTime(2019, 01, 15);
+                logger.Trace("On {0:d}, bought {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dt.AddDays(0),    0.42,    13.37,        5.6154);
+                logger.Debug("On {0:d}, bought {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dt.AddDays(1),   24.68,    -0.25,       -6.1700);
+                logger.Info ("On {0:d}, sold   {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dt.AddDays(2),   10.12,     1.33,       13.4596);
+                logger.Warn ("On {0:d}, sold   {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dt.AddDays(3), 1416.00, 11975.31, 16957039.0000);
+                logger.Error("On {0:d}, bought {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dt.AddDays(4),   18.20,   -10.00,     -182.0000);
+                logger.Fatal("On {0:d}, sold   {1,7:F2} units for {2,11:C} (Total = {3,15:C})", dt.AddDays(5), 2224.00,   115.00,   255760.0000);
+
+                Assert.AreEqual(6, logger.LogQueue.Count);
+                AssertLogEntry(LogLevel.Trace, "On 15/01/2019, bought    0,42 units for     13,37 € (Total =          5,62 €)", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Debug, "On 16/01/2019, bought   24,68 units for     -0,25 € (Total =         -6,17 €)", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Info , "On 17/01/2019, sold     10,12 units for      1,33 € (Total =         13,46 €)", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Warn , "On 18/01/2019, sold   1416,00 units for 11.975,31 € (Total = 16.957.039,00 €)", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Error, "On 19/01/2019, bought   18,20 units for    -10,00 € (Total =       -182,00 €)", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Fatal, "On 20/01/2019, sold   2224,00 units for    115,00 € (Total =    255.760,00 €)", logger.LogQueue.Dequeue());
+            }
+        }
+
+        [TestMethod]
+        public void LogFormatParams()
+        {
+            using (MemoryLogger logger = new MemoryLogger(default, CultureInfo.GetCultureInfo("es-ES")))
+            {
+                DateTime dt = new DateTime(2019, 01, 15, 16, 17, 18, 19);
+                logger.Trace("On {0:d} {1:g}, bought {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(0), dt.AddHours(0).TimeOfDay,    0.42,    13.37,        5.6154);
+                logger.Debug("On {0:d} {1:g}, bought {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(1), dt.AddHours(1).TimeOfDay,   24.68,    -0.25,       -6.1700);
+                logger.Info ("On {0:d} {1:g}, sold   {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(2), dt.AddHours(2).TimeOfDay,   10.12,     1.33,       13.4596);
+                logger.Warn ("On {0:d} {1:g}, sold   {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(3), dt.AddHours(3).TimeOfDay, 1416.00, 11975.31, 16957039.0000);
+                logger.Error("On {0:d} {1:g}, bought {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(4), dt.AddHours(4).TimeOfDay,   18.20,   -10.00,     -182.0000);
+                logger.Fatal("On {0:d} {1:g}, sold   {2,7:F2} units for {3,11:C} (Total = {4,15:C})", dt.AddDays(5), dt.AddHours(5).TimeOfDay, 2224.00,   115.00,   255760.0000);
+
+                Assert.AreEqual(6, logger.LogQueue.Count);
+                AssertLogEntry(LogLevel.Trace, "On 15/01/2019 16:17:18,019, bought    0,42 units for     13,37 € (Total =          5,62 €)", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Debug, "On 16/01/2019 17:17:18,019, bought   24,68 units for     -0,25 € (Total =         -6,17 €)", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Info , "On 17/01/2019 18:17:18,019, sold     10,12 units for      1,33 € (Total =         13,46 €)", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Warn , "On 18/01/2019 19:17:18,019, sold   1416,00 units for 11.975,31 € (Total = 16.957.039,00 €)", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Error, "On 19/01/2019 20:17:18,019, bought   18,20 units for    -10,00 € (Total =       -182,00 €)", logger.LogQueue.Dequeue());
+                AssertLogEntry(LogLevel.Fatal, "On 20/01/2019 21:17:18,019, sold   2224,00 units for    115,00 € (Total =    255.760,00 €)", logger.LogQueue.Dequeue());
+            }
+        }
+
+        private static void AssertLogEntry(LogLevel expectedLevel, string expectedMessage, LogEntry<string> actual)
+        {
+            // We assert the validity of the time in the TemplateBuilder.Test.cs, so here we'll
+            // instead assert that the value is a time in the appropriate format
+            Assert.AreNotEqual(default        , actual.Timestamp);
+            Assert.AreEqual   (expectedLevel  , actual.Level    );
+            Assert.AreEqual   (expectedMessage, actual.Message  );
+        }
+    }
+}

--- a/Sweetener.Logging.Test/Loggers/TemplateLogger.Test.cs
+++ b/Sweetener.Logging.Test/Loggers/TemplateLogger.Test.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class TemplateLoggerTest
+    {
+        [TestMethod]
+        public void Constructor()
+        {
+            // Argument Validation
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new MemoryTemplateLogger((LogLevel)27                    ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new MemoryTemplateLogger((LogLevel)27  , null            ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new MemoryTemplateLogger(LogLevel.Trace, null, null      ));
+            Assert.ThrowsException<FormatException            >(() => new MemoryTemplateLogger(LogLevel.Trace, null, "{foobar}"));
+
+            // Constructor Overloads
+            CultureInfo frenchFrench   = CultureInfo.GetCultureInfo("fr-FR");
+            CultureInfo spanishSpanish = CultureInfo.GetCultureInfo("es-ES");
+
+            using (MemoryTemplateLogger logger = new MemoryTemplateLogger())
+            {
+                Assert.AreEqual(LogLevel.Trace                , logger.MinimumLevel        );
+                Assert.AreEqual(CultureInfo.CurrentCulture    , logger.FormatProvider      );
+                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger._template.ToString());
+            }
+
+            using (MemoryTemplateLogger logger = new MemoryTemplateLogger(LogLevel.Warn))
+            {
+                Assert.AreEqual(LogLevel.Warn                 , logger.MinimumLevel        );
+                Assert.AreEqual(CultureInfo.CurrentCulture    , logger.FormatProvider      );
+                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger._template.ToString());
+            }
+
+            using (MemoryTemplateLogger logger = new MemoryTemplateLogger(LogLevel.Info, frenchFrench))
+            {
+                Assert.AreEqual(LogLevel.Info                 , logger.MinimumLevel        );
+                Assert.AreEqual(frenchFrench                  , logger.FormatProvider      );
+                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger._template.ToString());
+            }
+
+            using (MemoryTemplateLogger logger = new MemoryTemplateLogger(LogLevel.Error, spanishSpanish, "[{tid}] {msg}"))
+            {
+                Assert.AreEqual(LogLevel.Error , logger.MinimumLevel        );
+                Assert.AreEqual(spanishSpanish , logger.FormatProvider      );
+                Assert.AreEqual("[{tid}] {msg}", logger._template.ToString());
+            }
+        }
+
+        [TestMethod]
+        public void Log()
+        {
+            // Validate Log calls WriteLine appropriately based on the template
+            // Logger.Test.cs already validates that Log is called appropriately
+            using (MemoryTemplateLogger logger = new MemoryTemplateLogger(LogLevel.Debug, CultureInfo.InvariantCulture, "{l:F} - {msg}"))
+            {
+                // Debug
+                logger.Debug("0");
+                logger.Debug("0 {0}"                , 1            );
+                logger.Debug("0 {0} {1}"            , 1, 2         );
+                logger.Debug("0 {0} {1} {2}"        , 1, 2, 3      );
+                logger.Debug("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                logger.Debug("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                // Info
+                logger.Info("0"                                   );
+                logger.Info("0 {0}"                , 1            );
+                logger.Info("0 {0} {1}"            , 1, 2         );
+                logger.Info("0 {0} {1} {2}"        , 1, 2, 3      );
+                logger.Info("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                logger.Info("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                // Warn
+                logger.Warn("0"                                   );
+                logger.Warn("0 {0}"                , 1            );
+                logger.Warn("0 {0} {1}"            , 1, 2         );
+                logger.Warn("0 {0} {1} {2}"        , 1, 2, 3      );
+                logger.Warn("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                logger.Warn("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                // Error
+                logger.Error("0"                                   );
+                logger.Error("0 {0}"                , 1            );
+                logger.Error("0 {0} {1}"            , 1, 2         );
+                logger.Error("0 {0} {1} {2}"        , 1, 2, 3      );
+                logger.Error("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                logger.Error("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                // Fatal
+                logger.Fatal("0"                                   );
+                logger.Fatal("0 {0}"                , 1            );
+                logger.Fatal("0 {0} {1}"            , 1, 2         );
+                logger.Fatal("0 {0} {1} {2}"        , 1, 2, 3      );
+                logger.Fatal("0 {0} {1} {2} {3}"    , 1, 2, 3, 4   );
+                logger.Fatal("0 {0} {1} {2} {3} {4}", 1, 2, 3, 4, 5);
+
+                Assert.AreEqual(30, logger.LogQueue.Count);
+
+                LogLevel level = LogLevel.Debug;
+                while (logger.LogQueue.Count > 0)
+                {
+                    Assert.IsTrue(logger.LogQueue.Count >= 6);
+                    Assert.AreEqual($"{level:F} - 0"          , logger.LogQueue.Dequeue());
+                    Assert.AreEqual($"{level:F} - 0 1"        , logger.LogQueue.Dequeue());
+                    Assert.AreEqual($"{level:F} - 0 1 2"      , logger.LogQueue.Dequeue());
+                    Assert.AreEqual($"{level:F} - 0 1 2 3"    , logger.LogQueue.Dequeue());
+                    Assert.AreEqual($"{level:F} - 0 1 2 3 4"  , logger.LogQueue.Dequeue());
+                    Assert.AreEqual($"{level:F} - 0 1 2 3 4 5", logger.LogQueue.Dequeue());
+
+                    level++;
+                }
+            }
+        }
+    }
+}

--- a/Sweetener.Logging.Test/Sweetener.Logging.Test.csproj
+++ b/Sweetener.Logging.Test/Sweetener.Logging.Test.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sweetener.Logging\Sweetener.Logging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Sweetener.Logging.Test/Templates/FormatItem.Test.cs
+++ b/Sweetener.Logging.Test/Templates/FormatItem.Test.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class FormatItemTest
+    {
+        [TestMethod]
+        public void Constructor()
+        {
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new FormatItem(-1, null, null));
+
+            FormatItem actual;
+
+            // No Alignment or Format
+            actual = new FormatItem(1, null, null);
+            Assert.AreEqual(1   , actual.Index    );
+            Assert.AreEqual(null, actual.Alignment);
+            Assert.AreEqual(null, actual.Format   );
+
+            // Only Alignment
+            actual = new FormatItem(2, -7, null);
+            Assert.AreEqual(2   , actual.Index    );
+            Assert.AreEqual(-7  , actual.Alignment);
+            Assert.AreEqual(null, actual.Format   );
+
+            // Only Format
+            actual = new FormatItem(3, null, "yyyyMMdd");
+            Assert.AreEqual(3         , actual.Index    );
+            Assert.AreEqual(null      , actual.Alignment);
+            Assert.AreEqual("yyyyMMdd", actual.Format   );
+
+            // Both Alignment and Format
+            actual = new FormatItem(4, 6, "C");
+            Assert.AreEqual(4  , actual.Index    );
+            Assert.AreEqual(6  , actual.Alignment);
+            Assert.AreEqual("C", actual.Format   );
+        }
+
+        [TestMethod]
+        public void ToStringOverride()
+        {
+            // No Alignment or Format
+            Assert.AreEqual("{1}", new FormatItem(1, null, null).ToString());
+
+            // Only Alignment
+            Assert.AreEqual("{2,-7}", new FormatItem(2, -7, null).ToString());
+
+            // Only Format
+            Assert.AreEqual("{3:yyyyMMdd}", new FormatItem(3, null, "yyyyMMdd").ToString());
+
+            // Both Alignment and Format
+            Assert.AreEqual("{4,5:C}", new FormatItem(4, 5, "C").ToString());
+        }
+
+        [TestMethod]
+        public void ToStringOverload()
+        {
+            // No Alignment or Format
+            Assert.AreEqual("{5}", new FormatItem(1, null, null).ToString(5));
+
+            // Only Alignment
+            Assert.AreEqual("{6,-7}", new FormatItem(2, -7, null).ToString(6));
+
+            // Only Format
+            Assert.AreEqual("{7:yyyyMMdd}", new FormatItem(3, null, "yyyyMMdd").ToString(7));
+
+            // Both Alignment and Format
+            Assert.AreEqual("{8,5:C}", new FormatItem(4, 5, "C").ToString(8));
+        }
+    }
+}

--- a/Sweetener.Logging.Test/Templates/TemplateBuilder.Test.cs
+++ b/Sweetener.Logging.Test/Templates/TemplateBuilder.Test.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class TemplateBuilderTest
+    {
+        [TestMethod]
+        public void ParseExceptions()
+        {
+            #region Invalid Templates
+            // Null Template
+            Assert.ThrowsException<ArgumentNullException>(() => new TemplateBuilder(null));
+
+            // Unknown Parameter
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{msg} {foo}"));
+
+            // Gap In Name
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{ mess age }"));
+
+            // Invalid White Space
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{ msg\t}"));
+
+            // String Ends Prematurely
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{msg"          ));
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{msg} {tid,3"  ));
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{msg} {tid,3:X"));
+            #endregion
+
+            #region Invalid Formats in an Item
+            // Message
+            // Note: strings accept any format value
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{msg,k}"));
+            //Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{msg:abc}"));
+
+            // Timestamp
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{ts,k}"  ));
+            //Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{ts:abc}")); // Unknown format characters are used as literals
+
+            // Level
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{l,k}"));
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{l:abc}"));
+
+            // ProcessId
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{pid,k}"));
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{pid:q}"));
+
+            // ProcessName
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{pn,k}"  ));
+            //Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{pn:x}"));
+
+            // ThreadId
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{tid,k}"));
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{tid:q}"));
+
+            // ThreadName
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{tn,k}"  ));
+            //Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{tn:abc}"));
+            #endregion
+        }
+
+        [TestMethod]
+        public void BuildExceptions()
+        {
+            Assert.ThrowsException<InvalidOperationException>(() => new TemplateBuilder("{ts}").Build<string>());
+        }
+
+        [TestMethod]
+        public void ParseEscapedCharacters()
+        {
+            string expected = $"}}}}{{{{escaped}}}} }}}}text{{{{";
+
+            Assert.AreEqual(expected, new TemplateBuilder("}}{{escaped}} }}text{{")._format);
+        }
+
+        [TestMethod]
+        public void GetMessageIndex()
+        {
+            string expected = $"{{{(int)TemplateParameter.Message}}}";
+
+            Assert.AreEqual(expected, new TemplateBuilder("{msg}"    )._format);
+            Assert.AreEqual(expected, new TemplateBuilder("{message}")._format);
+        }
+
+        [TestMethod]
+        public void GetTimestampIndex()
+        {
+            string expected = $"{{{(int)TemplateParameter.Timestamp}}}";
+
+            Assert.AreEqual(expected, new TemplateBuilder("{ts}"       )._format);
+            Assert.AreEqual(expected, new TemplateBuilder("{timestamp}")._format);
+        }
+
+        [TestMethod]
+        public void GetLevelIndex()
+        {
+            string expected = $"{{{(int)TemplateParameter.Level}}}";
+
+            Assert.AreEqual(expected, new TemplateBuilder("{l}"    )._format);
+            Assert.AreEqual(expected, new TemplateBuilder("{level}")._format);
+        }
+
+        [TestMethod]
+        public void GetProcessIdIndex()
+        {
+            string expected = $"{{{(int)TemplateParameter.ProcessId}}}";
+
+            Assert.AreEqual(expected, new TemplateBuilder("{pid}"      )._format);
+            Assert.AreEqual(expected, new TemplateBuilder("{processId}")._format);
+        }
+
+        [TestMethod]
+        public void GetProcessNameIndex()
+        {
+            string expected = $"{{{(int)TemplateParameter.ProcessName}}}";
+
+            Assert.AreEqual(expected, new TemplateBuilder("{pn}"         )._format);
+            Assert.AreEqual(expected, new TemplateBuilder("{processName}")._format);
+        }
+
+        [TestMethod]
+        public void GetThreadIdIndex()
+        {
+            string expected = $"{{{(int)TemplateParameter.ThreadId}}}";
+
+            Assert.AreEqual(expected, new TemplateBuilder("{tid}"     )._format);
+            Assert.AreEqual(expected, new TemplateBuilder("{threadId}")._format);
+        }
+
+        [TestMethod]
+        public void GetThreadNameIndex()
+        {
+            string expected = $"{{{(int)TemplateParameter.ThreadName}}}";
+
+            Assert.AreEqual(expected, new TemplateBuilder("{tn}"        )._format);
+            Assert.AreEqual(expected, new TemplateBuilder("{threadName}")._format);
+        }
+
+        [TestMethod]
+        public void Parse()
+        {
+            string expected = $"[{{{(int)TemplateParameter.Timestamp}:yyyy-MM-ddTHH:mm:ss}}] [{{{(int)TemplateParameter.Level},-5:F}}] ";
+            expected       += $"[Process ({{{(int)TemplateParameter.ProcessId}}}): {{{(int)TemplateParameter.ProcessName}}}] ";
+            expected       += $"[Thread ({{{(int)TemplateParameter.ThreadId}}}): {{{(int)TemplateParameter.ThreadName}}}] ";
+            expected       += $"{{{(int)TemplateParameter.Message}}}";
+
+            TemplateBuilder actual = new TemplateBuilder("[{ts:yyyy-MM-ddTHH:mm:ss}] [{l,-5:F}] [Process ({pid}): {pn}] [Thread ({tid}): {tn}] {msg}");
+            Assert.AreEqual(expected, actual._format);
+        }
+
+        [TestMethod]
+        public void ParseRepeatParameters()
+        {
+            string expected = $"[Year: {{{(int)TemplateParameter.Timestamp}:yyyy}}] ";
+            expected       += $"[Month: {{{(int)TemplateParameter.Timestamp}:MM}}] ";
+            expected       += $"[Day: {{{(int)TemplateParameter.Timestamp}:dd}}] ";
+            expected       += $"***{{{(int)TemplateParameter.Level}:F}}*** {{{(int)TemplateParameter.Message}}} ***{{{(int)TemplateParameter.Level}:F}}***";
+
+            TemplateBuilder actual = new TemplateBuilder("[Year: {ts:yyyy}] [Month: {ts:MM}] [Day: {ts:dd}] ***{l:F}*** {msg} ***{l:F}***");
+            Assert.AreEqual(expected, actual._format);
+        }
+
+        [TestMethod]
+        public void Format()
+        {
+            IFormatProvider provider = CultureInfo.InvariantCulture;
+            LogLevel[]      levels   = (LogLevel[])Enum.GetValues(typeof(LogLevel));
+            DateTime        dateTime = DateTime.UtcNow;
+            ThreadPool.SetMinThreads(levels.Length, levels.Length);
+
+            Process currentProcess = Process.GetCurrentProcess();
+            int     pid = currentProcess.Id;
+            string  pn  = currentProcess.ProcessName;
+
+            ILogEntryTemplate<string> template = new TemplateBuilder("[{ts:yyyy-MM-ddTHH:mm:ss}] [{l,-5:F}] [Process ({pid}): {pn}] [Thread ({tid}): {tn}] {msg}").Build<string>();
+            Task[] tasks = new Task[levels.Length];
+
+            for (int i = 0; i < levels.Length; i++)
+            {
+                LogLevel level = levels[i];
+                tasks[i] = Task.Run(() =>
+                {
+                    Thread currentThread = Thread.CurrentThread;
+                    int    tid           = currentThread.ManagedThreadId;
+
+                    string tn;
+                    lock (currentThread)
+                    {
+                        if (currentThread.Name == null)
+                            currentThread.Name = $"{level:F} Thread";
+
+                        tn = currentThread.Name;
+                    }
+
+                    string expected = $"[{dateTime:yyyy-MM-ddTHH:mm:ss}] [{level,-5:F}] [Process ({pid}): {pn}] [Thread ({tid}): {tn}] success";
+                    string actual   = template.Format(provider, LogEntry.Create(dateTime, level, "success"));
+                    Assert.AreEqual(expected, actual);
+                });
+            }
+
+            Task.WaitAll(tasks);
+        }
+
+        [TestMethod]
+        public void FormatEscapedFormatItem()
+        {
+            IFormatProvider provider = CultureInfo.InvariantCulture;
+
+            string expected = $"#Debug# @ {Process.GetCurrentProcess().ProcessName} >> Foo Bar {{Baz}}!";
+            string actual   = new TemplateBuilder("#{level:F}# @ {pn} >> {msg}")
+                .Build<string>()
+                .Format(provider, LogEntry.Create(LogLevel.Debug, "Foo Bar {Baz}!"));
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void FormatCulture()
+        {
+            int             tid          = Thread.CurrentThread.ManagedThreadId;
+            DateTime        dateTime     = DateTime.UtcNow;
+            IFormatProvider frenchFrench = CultureInfo.GetCultureInfo("fr-FR");
+
+            // Pretend the thread id is a currency for some interesting formatting changes
+            // The "d" format string for DateTime is also impacted by the culture
+            string expected = $"{string.Format(frenchFrench, "{0:C}", tid)} {dateTime:dd/MM/yyy} Bonjour de France";
+            string actual   = new TemplateBuilder("{tid:C} {ts:d} {msg}")
+                .Build<string>()
+                .Format(frenchFrench, LogEntry.Create(dateTime, LogLevel.Error, "Bonjour de France"));
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/Sweetener.Logging.Test/Templates/TemplateParameter.Test.cs
+++ b/Sweetener.Logging.Test/Templates/TemplateParameter.Test.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class TemplateParameterTest
+    {
+        [TestMethod]
+        public void ParseExceptions()
+        {
+            // Case-sensitive
+            Assert.ThrowsException<FormatException>(() => TemplateParameterName.Parse("MSG"));
+
+            // Unknown template parameter
+            Assert.ThrowsException<FormatException>(() => TemplateParameterName.Parse("foo"));
+        }
+
+        [TestMethod]
+        public void ParseMessage()
+        {
+            Assert.AreEqual(TemplateParameter.Message, TemplateParameterName.Parse("msg"    ));
+            Assert.AreEqual(TemplateParameter.Message, TemplateParameterName.Parse("message"));
+        }
+
+        [TestMethod]
+        public void ParseTimestamp()
+        {
+            Assert.AreEqual(TemplateParameter.Timestamp, TemplateParameterName.Parse("ts"       ));
+            Assert.AreEqual(TemplateParameter.Timestamp, TemplateParameterName.Parse("timestamp"));
+        }
+
+        [TestMethod]
+        public void ParseLevel()
+        {
+            Assert.AreEqual(TemplateParameter.Level, TemplateParameterName.Parse("l"    ));
+            Assert.AreEqual(TemplateParameter.Level, TemplateParameterName.Parse("level"));
+        }
+
+        [TestMethod]
+        public void ParseProcessId()
+        {
+            Assert.AreEqual(TemplateParameter.ProcessId, TemplateParameterName.Parse("pid"      ));
+            Assert.AreEqual(TemplateParameter.ProcessId, TemplateParameterName.Parse("processId"));
+        }
+
+        [TestMethod]
+        public void ParseProcessName()
+        {
+            Assert.AreEqual(TemplateParameter.ProcessName, TemplateParameterName.Parse("pn"         ));
+            Assert.AreEqual(TemplateParameter.ProcessName, TemplateParameterName.Parse("processName"));
+        }
+
+        [TestMethod]
+        public void ParseThreadId()
+        {
+            Assert.AreEqual(TemplateParameter.ThreadId, TemplateParameterName.Parse("tid"     ));
+            Assert.AreEqual(TemplateParameter.ThreadId, TemplateParameterName.Parse("threadId"));
+        }
+
+        [TestMethod]
+        public void ParseThreadName()
+        {
+            Assert.AreEqual(TemplateParameter.ThreadName, TemplateParameterName.Parse("tn"        ));
+            Assert.AreEqual(TemplateParameter.ThreadName, TemplateParameterName.Parse("threadName"));
+        }
+    }
+}

--- a/Sweetener.Logging.Test/TestClasses/MemoryLogger.cs
+++ b/Sweetener.Logging.Test/TestClasses/MemoryLogger.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Sweetener.Logging.Test
+{
+    /// <summary>
+    /// A <see cref="Logger"/> implementation used for testing.
+    /// </summary>
+    public class MemoryLogger : Logger
+    {
+        /// <summary>
+        /// A <see cref="Queue{T}"/> of written log entries.
+        /// </summary>
+        public Queue<LogEntry<string>> LogQueue { get; } = new Queue<LogEntry<string>>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryLogger"/> class for the current
+        /// culture that logs all levels.
+        /// </summary>
+        public MemoryLogger()
+            : base()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryLogger"/> class with a minimum
+        /// logging level for the current culture.
+        /// </summary>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        public MemoryLogger(LogLevel minimumLevel)
+            : base(minimumLevel)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryLogger"/> class with a minimum
+        /// logging level and an <see cref="IFormatProvider"/> object for a specific culture.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c>, the formatting of the current culture is used.
+        /// </remarks>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        public MemoryLogger(LogLevel minimumLevel, IFormatProvider formatProvider)
+            : base(minimumLevel, formatProvider)
+        { }
+
+        /// <summary>
+        /// Logs the specified entry to the <see cref="LogQueue"/>.
+        /// </summary>
+        /// <param name="logEntry">A log entry which consists of the message and its context.</param>
+        protected internal override void Log(LogEntry<string> logEntry)
+            => LogQueue.Enqueue(logEntry);
+    }
+}

--- a/Sweetener.Logging.Test/TestClasses/MemoryTemplateLogger.cs
+++ b/Sweetener.Logging.Test/TestClasses/MemoryTemplateLogger.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Sweetener.Logging.Test
+{
+    /// <summary>
+    /// A <see cref="TemplateLogger"/> implementation used for testing.
+    /// </summary>
+    public class MemoryTemplateLogger : TemplateLogger
+    {
+        /// <summary>
+        /// A <see cref="Queue{T}"/> of written log messages.
+        /// </summary>
+        public Queue<string> LogQueue { get; } = new Queue<string>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryTemplateLogger"/> class for the current
+        /// culture that logs all levels.
+        /// </summary>
+        public MemoryTemplateLogger()
+            : base()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryTemplateLogger"/> class with a minimum
+        /// logging level for the current culture.
+        /// </summary>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        public MemoryTemplateLogger(LogLevel minimumLevel)
+            : base(minimumLevel)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryTemplateLogger"/> class with a minimum
+        /// logging level and an <see cref="IFormatProvider"/> object for a specific culture.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c>, the formatting of the current culture is used.
+        /// </remarks>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        public MemoryTemplateLogger(LogLevel minimumLevel, IFormatProvider formatProvider)
+            : base(minimumLevel, formatProvider)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryTemplateLogger"/> class with a minimum
+        /// logging level and an <see cref="IFormatProvider"/> object for a specific culture.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c>, the formatting of the current culture is used.
+        /// </remarks>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="template"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public MemoryTemplateLogger(LogLevel minimumLevel, IFormatProvider formatProvider, string template)
+            : base(minimumLevel, formatProvider, template)
+        {  }
+
+        /// <summary>
+        /// Writes the message to the <see cref="LogQueue"/>.
+        /// </summary>
+        /// <param name="message">The value to be logged.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        protected override void WriteLine(string message)
+            => LogQueue.Enqueue(message);
+    }
+}

--- a/Sweetener.Logging.Test/ThrowHelper.Test.cs
+++ b/Sweetener.Logging.Test/ThrowHelper.Test.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class ThrowHelperTest
+    {
+        [TestMethod]
+        public void ThrowUnknownArgumentNullException()
+        {
+            // Our "Throwing" method shouldn't throw different exceptions for unknown values
+            Assert.ThrowsException<ArgumentNullException>(() =>
+            {
+                try
+                {
+                    ThrowHelper.ThrowArgumentNullException((ExceptionArgument)12345);
+                }
+                catch (ArgumentNullException ane)
+                {
+                    Assert.AreEqual("12345", ane.ParamName);
+                    throw ane;
+                }
+            });
+        }
+
+        [TestMethod]
+        public void ThrowArgumentNullException()
+        {
+            // args
+            Assert.ThrowsException<ArgumentNullException>(() =>
+            {
+                try
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+                }
+                catch (ArgumentNullException ane)
+                {
+                    Assert.AreEqual(ExceptionArgument.args.ToString(), ane.ParamName);
+                    throw ane;
+                }
+            });
+
+            // format
+            Assert.ThrowsException<ArgumentNullException>(() =>
+            {
+                try
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+                }
+                catch (ArgumentNullException ane)
+                {
+                    Assert.AreEqual(ExceptionArgument.format.ToString(), ane.ParamName);
+                    throw ane;
+                }
+            });
+        }
+    }
+}

--- a/Sweetener.Logging/LogEntry{T}.cs
+++ b/Sweetener.Logging/LogEntry{T}.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Threading;
+
+namespace Sweetener.Logging
+{
+    /// <summary>
+    /// An entry to be written to the log.
+    /// </summary>
+    /// <typeparam name="T">The type of the entry's message.</typeparam>
+    public readonly struct LogEntry<T>
+    {
+        /// <summary>
+        /// The <see cref="LogLevel"/> associated with the <see cref="Message"/>.
+        /// </summary>
+        public readonly LogLevel Level;
+
+        /// <summary>
+        /// The value to be logged.
+        /// </summary>
+        public readonly T Message;
+
+        /// <summary>
+        /// The timestamp when the log request was made.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Utc"/>.
+        /// </remarks>
+        public readonly DateTime Timestamp;
+
+        /// <summary>
+        /// The <see cref="Thread.ManagedThreadId"/> of the thread that created the log entry.
+        /// </summary>
+        public readonly int ThreadId;
+
+        /// <summary>
+        /// The <see cref="Thread.Name"/> of the thread that created the log entry.
+        /// </summary>
+        public readonly string ThreadName;
+
+        // TODO: Should process information be here? Thread information is here because
+        //       the thread that requests a log be written and the the thread that performs
+        //       the write operation may be different. Though, users could perhaps marshal
+        //       entries across the app domain into another process as well.
+
+        internal LogEntry(LogLevel level, T message)
+            : this(DateTime.UtcNow, level, message)
+        { }
+
+        internal LogEntry(DateTime timestamp, LogLevel level, T message)
+        {
+            // ctor is internal and we'll be well-behaved, so checks aren't necessary
+            Level      = level;
+            Message    = message;
+            Timestamp  = timestamp;
+
+            // Retrieving the current thread per entry is actually faster than attempting to
+            // cache the value in a [ThreadStatic] variable and checking for initialization
+            Thread currentThread = Thread.CurrentThread;
+            ThreadId   = currentThread.ManagedThreadId;
+            ThreadName = currentThread.Name;
+        }
+    }
+
+    /// <summary>
+    /// A class for creating new instances of <see cref="LogEntry{T}"/>. 
+    /// </summary>
+    public static class LogEntry
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="LogEntry{T}"/> structure with
+        /// the specified level and message.
+        /// </summary>
+        /// <param name="level">The <see cref="LogLevel"/> associated with the <paramref name="message"/>.</param>
+        /// <param name="message">The value to be logged.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is unrecognized.</exception>
+        public static LogEntry<T> Create<T>(LogLevel level, T message)
+            => Create(DateTime.UtcNow, level, message);
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="LogEntry{T}"/> structure with
+        /// the specified level and message.
+        /// </summary>
+        /// <param name="timestamp">The timestamp when the log request was made.</param>
+        /// <param name="level">The <see cref="LogLevel"/> associated with the <paramref name="message"/>.</param>
+        /// <param name="message">The value to be logged.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is unrecognized.</exception>
+        public static LogEntry<T> Create<T>(DateTime timestamp, LogLevel level, T message)
+        {
+            if (level < LogLevel.Trace || level > LogLevel.Fatal)
+                throw new ArgumentOutOfRangeException(nameof(level), $"Unknown {nameof(LogLevel)} value '{level}'");
+
+            return new LogEntry<T>(timestamp, level, message);
+        }
+    }
+}

--- a/Sweetener.Logging/LogLevel.cs
+++ b/Sweetener.Logging/LogLevel.cs
@@ -1,0 +1,39 @@
+﻿namespace Sweetener.Logging
+{
+    /// <summary>
+    /// Specifies a priority level and semantics associated with a log entry.
+    /// </summary>
+    public enum LogLevel
+    {
+        /// <summary>
+        /// Specifies highly granular information used to trace the execution of an application,
+        /// typically in a development environment.
+        /// </summary>
+        Trace,
+
+        /// <summary>
+        /// Specifies often verbose debugging information used to diagnose potential problems.
+        /// </summary>
+        Debug,
+
+        /// <summary>
+        /// Specifies standard operating information used to monitor the state of an application.
+        /// </summary>
+        Info,
+
+        /// <summary>
+        /// Specifies problematic, but not exceptional, information.
+        /// </summary>
+        Warn,
+
+        /// <summary>
+        /// Specifies exceptional and unexpected infomation that does not lead to the failure of the application.
+        /// </summary>
+        Error,
+
+        /// <summary>
+        /// Specifies exceptional and unexpected information that leads to the overall failure of the application.
+        /// </summary>
+        Fatal,
+    }
+}

--- a/Sweetener.Logging/Loggers/ILogger{T}.cs
+++ b/Sweetener.Logging/Loggers/ILogger{T}.cs
@@ -1,0 +1,114 @@
+﻿ // Generated from ILogger{T}.tt
+using System;
+
+namespace Sweetener.Logging
+{
+    /// <summary>
+    /// An interface for loggers that write log entries at a given <see cref="LogLevel"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of values to be logged.</typeparam>
+    public interface ILogger<T> : IDisposable
+    {
+        /// <summary>
+        /// Gets a value indicating whether logging is synchronized (thread safe).
+        /// </summary>
+        /// <returns><c>true</c> if logging is synchronized (thread safe); otherwise, <c>false</c>.</returns>
+        bool IsSynchronized { get; }
+
+        /// <summary>
+        /// Gets the minimum level of log requests that will be fulfilled.
+        /// </summary>
+        /// <returns>The minimum <see cref="LogLevel"/> that will be fulfilled.</returns>
+        LogLevel MinimumLevel { get; }
+
+        /// <summary>
+        /// Gets an object that can be used to synchronize logging.
+        /// </summary>
+        /// <returns>An object that can be used to synchronize logging.</returns>
+        object SyncRoot { get; }
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Trace"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Trace"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Trace(T obj);
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Debug"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Debug(T obj);
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Info"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Info(T obj);
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Warn"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Warn(T obj);
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Error"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Error(T obj);
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.Fatal"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void Fatal(T obj);
+    }
+}

--- a/Sweetener.Logging/Loggers/ILogger{T}.tt
+++ b/Sweetener.Logging/Loggers/ILogger{T}.tt
@@ -1,0 +1,55 @@
+﻿<#@ template hostspecific="false" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System" #>
+<#@ import namespace="System" #>
+<#@ include file="..\TextTemplating\Include.t4" #> // Generated from ILogger{T}.tt
+using System;
+
+namespace Sweetener.Logging
+{
+    /// <summary>
+    /// An interface for loggers that write log entries at a given <see cref="LogLevel"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of values to be logged.</typeparam>
+    public interface ILogger<T> : IDisposable
+    {
+        /// <summary>
+        /// Gets a value indicating whether logging is synchronized (thread safe).
+        /// </summary>
+        /// <returns><c>true</c> if logging is synchronized (thread safe); otherwise, <c>false</c>.</returns>
+        bool IsSynchronized { get; }
+
+        /// <summary>
+        /// Gets the minimum level of log requests that will be fulfilled.
+        /// </summary>
+        /// <returns>The minimum <see cref="LogLevel"/> that will be fulfilled.</returns>
+        LogLevel MinimumLevel { get; }
+
+        /// <summary>
+        /// Gets an object that can be used to synchronize logging.
+        /// </summary>
+        /// <returns>An object that can be used to synchronize logging.</returns>
+        object SyncRoot { get; }
+<#
+    foreach (string level in logLevels)
+    {
+#>
+
+        /// <summary>
+        /// Request to log the specified value at the <see cref="LogLevel.<#= level #>"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="obj">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <typeparamref name="T"/> is a reference type and <paramref name="obj"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        void <#= level #>(T obj);
+<#
+    }
+#>
+    }
+}

--- a/Sweetener.Logging/Loggers/Logger.Format.cs
+++ b/Sweetener.Logging/Loggers/Logger.Format.cs
@@ -1,0 +1,967 @@
+﻿ // Generated from Logger.Format.tt
+using System;
+
+namespace Sweetener.Logging 
+{
+    /// <content>
+    /// The portion of the <see cref="Logger"/> class that defines the various formatting
+    /// overloads for its <see cref="ILogger{T}"/> methods.
+    /// </content>
+    abstract partial class Logger
+    {
+        #region Trace
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Trace"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Trace"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Trace(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Trace)
+                Log(new LogEntry<string>(LogLevel.Trace, message));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Trace"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Trace"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Trace(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Trace)
+                Log(new LogEntry<string>(LogLevel.Trace, string.Format(FormatProvider, format, arg0)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Trace"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Trace"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Trace(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Trace)
+                Log(new LogEntry<string>(LogLevel.Trace, string.Format(FormatProvider, format, arg0, arg1)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Trace"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Trace"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Trace(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Trace)
+                Log(new LogEntry<string>(LogLevel.Trace, string.Format(FormatProvider, format, arg0, arg1, arg2)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Trace"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Trace"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Trace(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Trace)
+                Log(new LogEntry<string>(LogLevel.Trace, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Trace"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Trace"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Trace(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Trace)
+                Log(new LogEntry<string>(LogLevel.Trace, string.Format(FormatProvider, format, args)));
+        }
+        #endregion
+
+        #region Debug
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Debug"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(new LogEntry<string>(LogLevel.Debug, message));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Debug"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(new LogEntry<string>(LogLevel.Debug, string.Format(FormatProvider, format, arg0)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Debug"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(new LogEntry<string>(LogLevel.Debug, string.Format(FormatProvider, format, arg0, arg1)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Debug"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(new LogEntry<string>(LogLevel.Debug, string.Format(FormatProvider, format, arg0, arg1, arg2)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Debug"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(new LogEntry<string>(LogLevel.Debug, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Debug"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Debug"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Debug(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Debug)
+                Log(new LogEntry<string>(LogLevel.Debug, string.Format(FormatProvider, format, args)));
+        }
+        #endregion
+
+        #region Info
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Info"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(new LogEntry<string>(LogLevel.Info, message));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Info"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(new LogEntry<string>(LogLevel.Info, string.Format(FormatProvider, format, arg0)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Info"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(new LogEntry<string>(LogLevel.Info, string.Format(FormatProvider, format, arg0, arg1)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Info"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(new LogEntry<string>(LogLevel.Info, string.Format(FormatProvider, format, arg0, arg1, arg2)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Info"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(new LogEntry<string>(LogLevel.Info, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Info"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Info"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Info(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Info)
+                Log(new LogEntry<string>(LogLevel.Info, string.Format(FormatProvider, format, args)));
+        }
+        #endregion
+
+        #region Warn
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Warn"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(new LogEntry<string>(LogLevel.Warn, message));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Warn"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(new LogEntry<string>(LogLevel.Warn, string.Format(FormatProvider, format, arg0)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Warn"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(new LogEntry<string>(LogLevel.Warn, string.Format(FormatProvider, format, arg0, arg1)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Warn"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(new LogEntry<string>(LogLevel.Warn, string.Format(FormatProvider, format, arg0, arg1, arg2)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Warn"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(new LogEntry<string>(LogLevel.Warn, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Warn"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Warn"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Warn(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Warn)
+                Log(new LogEntry<string>(LogLevel.Warn, string.Format(FormatProvider, format, args)));
+        }
+        #endregion
+
+        #region Error
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Error"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(new LogEntry<string>(LogLevel.Error, message));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Error"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(new LogEntry<string>(LogLevel.Error, string.Format(FormatProvider, format, arg0)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Error"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(new LogEntry<string>(LogLevel.Error, string.Format(FormatProvider, format, arg0, arg1)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Error"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(new LogEntry<string>(LogLevel.Error, string.Format(FormatProvider, format, arg0, arg1, arg2)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Error"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(new LogEntry<string>(LogLevel.Error, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Error"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Error"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Error(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Error)
+                Log(new LogEntry<string>(LogLevel.Error, string.Format(FormatProvider, format, args)));
+        }
+        #endregion
+
+        #region Fatal
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.Fatal"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(new LogEntry<string>(LogLevel.Fatal, message));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.Fatal"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(new LogEntry<string>(LogLevel.Fatal, string.Format(FormatProvider, format, arg0)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Fatal"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(new LogEntry<string>(LogLevel.Fatal, string.Format(FormatProvider, format, arg0, arg1)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Fatal"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(new LogEntry<string>(LogLevel.Fatal, string.Format(FormatProvider, format, arg0, arg1, arg2)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.Fatal"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(new LogEntry<string>(LogLevel.Fatal, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.Fatal"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.Fatal"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void Fatal(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.Fatal)
+                Log(new LogEntry<string>(LogLevel.Fatal, string.Format(FormatProvider, format, args)));
+        }
+        #endregion
+
+    }
+}

--- a/Sweetener.Logging/Loggers/Logger.Format.tt
+++ b/Sweetener.Logging/Loggers/Logger.Format.tt
@@ -1,0 +1,183 @@
+﻿<#@ template hostspecific="false" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System" #>
+<#@ import namespace="System" #>
+<#@ include file="..\TextTemplating\Include.t4" #> // Generated from Logger.Format.tt
+using System;
+
+namespace Sweetener.Logging 
+{
+    /// <content>
+    /// The portion of the <see cref="Logger"/> class that defines the various formatting
+    /// overloads for its <see cref="ILogger{T}"/> methods.
+    /// </content>
+    abstract partial class Logger
+    {
+<#
+    foreach (string level in logLevels)
+    {
+#>
+        #region <#= level #>
+        /// <summary>
+        /// Request to log the specified string value at the <see cref="LogLevel.<#= level #>"/> level.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="message">The value requested for logging.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string message)
+        {
+            ThrowIfDisposed();
+
+            if (message == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(new LogEntry<string>(LogLevel.<#= level #>, message));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified object at the
+        /// <see cref="LogLevel.<#= level #>"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">An object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string format, object arg0)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(new LogEntry<string>(LogLevel.<#= level #>, string.Format(FormatProvider, format, arg0)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.<#= level #>"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string format, object arg0, object arg1)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(new LogEntry<string>(LogLevel.<#= level #>, string.Format(FormatProvider, format, arg0, arg1)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.<#= level #>"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string format, object arg0, object arg1, object arg2)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(new LogEntry<string>(LogLevel.<#= level #>, string.Format(FormatProvider, format, arg0, arg1, arg2)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified objects at the
+        /// <see cref="LogLevel.<#= level #>"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="arg0">The first object to write using <paramref name="format"/>.</param>
+        /// <param name="arg1">The second object to write using <paramref name="format"/>.</param>
+        /// <param name="arg2">The third object to write using <paramref name="format"/>.</param>
+        /// <param name="arg3">The fourth object to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">The format specification in <paramref name="format"/> is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string format, object arg0, object arg1, object arg2, object arg3)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(new LogEntry<string>(LogLevel.<#= level #>, string.Format(FormatProvider, format, arg0, arg1, arg2, arg3)));
+        }
+
+        /// <summary>
+        /// Request to log the text representation of the specified array of objects at the
+        /// <see cref="LogLevel.<#= level #>"/> level using the specified format information.
+        /// </summary>
+        /// <remarks>
+        /// The log request will only be fulfilled if the <see cref="MinimumLevel"/> is less
+        /// than or equal to <see cref="LogLevel.<#= level #>"/>.
+        /// </remarks>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write using <paramref name="format"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <c>null</c>.</exception>
+        /// <exception cref="FormatException">
+        /// <para>The format specification in <paramref name="format"/> is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The index of a format item is less than zero, or greater than or equal
+        /// to the length of the <paramref name="args"/> array.
+        /// </para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
+        public void <#= level #>(string format, params object[] args)
+        {
+            ThrowIfDisposed();
+
+            if (format == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.format);
+
+            if (args == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.args);
+
+            if (MinimumLevel <= LogLevel.<#= level #>)
+                Log(new LogEntry<string>(LogLevel.<#= level #>, string.Format(FormatProvider, format, args)));
+        }
+        #endregion
+
+<#
+    }
+#>
+    }
+}

--- a/Sweetener.Logging/Loggers/Logger.cs
+++ b/Sweetener.Logging/Loggers/Logger.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Globalization;
+
+namespace Sweetener.Logging 
+{
+    /// <summary>
+    /// A common implementation of the <see cref="ILogger{T}"/> interface that
+    /// logs optionally formattable string messages.
+    /// </summary>
+    public abstract partial class Logger : ILogger<string>
+    {
+        /// <summary>
+        /// Gets an object that controls formatting. 
+        /// </summary>
+        public IFormatProvider FormatProvider { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is synchronized (thread safe).
+        /// </summary>
+        /// <returns><c>true</c> if logging is synchronized (thread safe); otherwise, <c>false</c>.</returns>
+        public virtual bool IsSynchronized => false;
+
+        /// <summary>
+        /// Gets the minimum level of log requests that will be fulfilled.
+        /// </summary>
+        /// <returns>The minimum <see cref="LogLevel"/> that will be fulfilled.</returns>
+        public LogLevel MinimumLevel { get; }
+
+        /// <summary>
+        /// Gets an object that can be used to synchronize logging.
+        /// </summary>
+        /// <returns>An object that can be used to synchronize logging.</returns>
+        public object SyncRoot { get; } = new object();
+
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Logger"/> class for the current
+        /// culture that logs all levels.
+        /// </summary>
+        protected Logger()
+            : this(LogLevel.Trace, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Logger"/> class with a minimum
+        /// logging level for the current culture.
+        /// </summary>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        protected Logger(LogLevel minimumLevel)
+            : this(minimumLevel, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Logger"/> class with a minimum
+        /// logging level and an <see cref="IFormatProvider"/> object for a specific culture.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c>, the formatting of the current culture is used.
+        /// </remarks>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        protected Logger(LogLevel minimumLevel, IFormatProvider formatProvider)
+        {
+            if (minimumLevel < LogLevel.Trace || minimumLevel > LogLevel.Fatal)
+                throw new ArgumentOutOfRangeException(nameof(minimumLevel), $"Unknown {nameof(LogLevel)} value '{minimumLevel}'");
+
+            if (formatProvider == null)
+                formatProvider = CultureInfo.CurrentCulture;
+
+            FormatProvider = formatProvider;
+            MinimumLevel   = minimumLevel;
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="Logger"/> object.
+        /// </summary>
+        /// <remarks>
+        /// Call <see cref="Dispose()"/> when you are finished using the <see cref="Logger"/>.
+        /// The <see cref="Dispose()"/> method leaves the <see cref="Logger"/> in an unusable state.
+        /// After calling <see cref="Dispose()"/>, you must release all references to the
+        /// <see cref="Logger"/> so the garbage collector can reclaim the memory that the
+        /// <see cref="Logger"/> was occupying.
+        /// </remarks>
+        public void Dispose()
+        {
+            Dispose(true);
+
+            // Still suppress, in case any derived classes use a finalizer
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the <see cref="Logger"/> and
+        /// optionally releases the managed resources.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This method is called by <see cref="Dispose()"/> and possible Finalize in a
+        /// derived class. By default, this method specifies the <paramref name="disposing"/>
+        /// parameter as <c>true</c>. Any Finalize implementation specifies the
+        /// <paramref name="disposing"/> parameter as <c>false</c>.
+        /// </para>
+        /// <para>
+        /// When the <paramref name="disposing"/> parameter is <c>true</c>, this method
+        /// releases all resources held by any managed objects that this <see cref="Logger"/>
+        /// references. This method invokes the <see cref="IDisposable.Dispose"/> method
+        /// of each referenced object.
+        /// </para>
+        /// </remarks>
+        /// <param name="disposing">
+        /// <c>true</c> to release both managed and unmanaged resources; <c>false</c>
+        /// to release only unmanaged resources.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // In the base class, this flag is used to short circuit calls before Log(...)
+            // We don't want method calls on disabled loggers to not throw exceptions
+            // because the log request was below the minimum log level!
+            if (!_disposed)
+                _disposed = true;
+        }
+
+        /// <summary>
+        /// Logs the specified entry.
+        /// </summary>
+        /// <param name="logEntry">A log entry which consists of the message and its context.</param>
+        protected internal abstract void Log(LogEntry<string> logEntry);
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+                ThrowObjectDisposedException();
+
+            void ThrowObjectDisposedException() => throw new ObjectDisposedException(GetType().Name, "Cannot log to a disposed logger.");
+        }
+    }
+}

--- a/Sweetener.Logging/Loggers/TemplateLogger.cs
+++ b/Sweetener.Logging/Loggers/TemplateLogger.cs
@@ -1,0 +1,80 @@
+﻿using System;
+
+namespace Sweetener.Logging
+{
+    /// <summary>
+    /// A <see cref="Logger"/> implementation that writes log entries as templated strings.
+    /// </summary>
+    public abstract class TemplateLogger : Logger
+    {
+        internal const string DefaultTemplate = "[{ts:O}] [{level:F}] {msg}";
+
+        internal readonly ILogEntryTemplate<string> _template;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateLogger"/> class for the
+        /// current culture that logs all levels.
+        /// </summary>
+        protected TemplateLogger()
+            : this(LogLevel.Trace, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateLogger"/> class with a
+        /// minimum logging level for the current culture.
+        /// </summary>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        protected TemplateLogger(LogLevel minimumLevel)
+            : this(minimumLevel, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateLogger"/> class with a minimum
+        /// logging level and an <see cref="IFormatProvider"/> object for a specific culture.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c>, the formatting of the current culture is used.
+        /// </remarks>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        protected TemplateLogger(LogLevel minimumLevel, IFormatProvider formatProvider)
+            : this(minimumLevel, formatProvider, DefaultTemplate)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateLogger"/> class with a minimum
+        /// logging level and an <see cref="IFormatProvider"/> object for a specific culture.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <c>null</c>, the formatting of the current culture is used.
+        /// </remarks>
+        /// <param name="minimumLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="template"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minimumLevel"/> is unrecognized.</exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        protected TemplateLogger(LogLevel minimumLevel, IFormatProvider formatProvider, string template)
+            : base(minimumLevel, formatProvider)
+        {
+            TemplateBuilder templateBuilder = new TemplateBuilder(template);
+            _template = templateBuilder.Build<string>();
+        }
+
+        /// <summary>
+        /// Logs the specified entry.
+        /// </summary>
+        /// <param name="logEntry">A log entry which consists of the message and its context.</param>
+        protected internal override void Log(LogEntry<string> logEntry)
+            => WriteLine(_template.Format(FormatProvider, logEntry));
+
+        /// <summary>
+        /// Writes the message to the log.
+        /// </summary>
+        /// <param name="message">The value to be logged.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+        protected abstract void WriteLine(string message);
+    }
+}

--- a/Sweetener.Logging/Sweetener.Logging.csproj
+++ b/Sweetener.Logging/Sweetener.Logging.csproj
@@ -1,0 +1,44 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>$(MSBuildProjectName).Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Loggers\ILogger{T}.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ILogger{T}.cs</LastGenOutput>
+    </None>
+    <None Update="Loggers\Logger.Format.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Logger.Format.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Loggers\ILogger{T}.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ILogger{T}.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Loggers\Logger.Format.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Logger.Format.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/Sweetener.Logging/Templates/FormatItem.cs
+++ b/Sweetener.Logging/Templates/FormatItem.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Sweetener.Logging
+{
+    internal readonly struct FormatItem
+    {
+        public readonly int Index;
+
+        public readonly int? Alignment;
+
+        public readonly string Format;
+
+        public FormatItem(int index, int? alignment, string format)
+        {
+            if (index < 0)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            Index     = index;
+            Alignment = alignment;
+            Format    = format;
+        }
+
+        public override string ToString()
+            => ToString(Index);
+
+        public string ToString(int index)
+        {
+            string formatString = "{" + index;
+            if (Alignment != null)
+                formatString += "," + Alignment;
+
+            if (Format != null)
+                formatString += ":" + Format;
+
+            return formatString + "}";
+        }
+    }
+}

--- a/Sweetener.Logging/Templates/ILogEntryTemplate{T}.cs
+++ b/Sweetener.Logging/Templates/ILogEntryTemplate{T}.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Sweetener.Logging
+{
+    internal interface ILogEntryTemplate<T>
+    {
+        string Format(IFormatProvider provider, LogEntry<T> logEntry);
+    }
+}

--- a/Sweetener.Logging/Templates/TemplateBuilder.cs
+++ b/Sweetener.Logging/Templates/TemplateBuilder.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Sweetener.Logging
+{
+    internal class TemplateBuilder
+    {
+        protected internal readonly string _template;
+        protected internal readonly string _format;
+        protected readonly Dictionary<TemplateParameter, int> _indices = new Dictionary<TemplateParameter, int>();
+
+        public TemplateBuilder(string template)
+        {
+            _format   = ParseTemplate(template);
+            _template = template;
+        }
+
+        public virtual ILogEntryTemplate<T> Build<T>()
+        {
+            if (!_indices.ContainsKey(TemplateParameter.Message))
+                throw new InvalidOperationException("Template is missing required 'msg' or 'message' parameter");
+
+            // The use of an interface will force the template (a struct) to box, but
+            // it will provide a hook for polymorphism and further cement the relationship
+            // between the builder and the template itself
+            return new LogEntryTemplate<T>(_template, _format);
+        }
+
+        protected virtual int GetIndex(TemplateParameter parameter)
+            => (int)parameter;
+
+        private string ParseTemplate(string template)
+        {
+            if (template == null)
+                throw new ArgumentNullException(nameof(template));
+
+            StringBuilder builder = new StringBuilder();
+            using (StringReader reader = new StringReader(template))
+            {
+                while (reader.Peek() != -1)
+                {
+                    char c = (char)reader.Read();
+                    if (c == '{')
+                    {
+                        if (reader.Peek() == '{')
+                        {
+                            // Escaped opened curly brace
+                            builder.Append(c);
+                            builder.Append((char)reader.Read());
+                        }
+                        else
+                        {
+                            builder.Append(ReadFormatItem(reader).ToString());
+
+                            // Check but don't append -- we already appended it!
+                            if (reader.Read() != '}')
+                                throw new FormatException("Input string was not in a correct format");
+                        }
+                    }
+                    else if (c == '}')
+                    {
+                        if (reader.Peek() != '}')
+                            throw new FormatException("Input string was not in a correct format");
+
+                        // Escaped closed curly brace
+                        builder.Append(c);
+                        builder.Append((char)reader.Read());
+                    }
+                    else
+                    {
+                        builder.Append(c);
+                    }
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private FormatItem ReadFormatItem(TextReader reader)
+        {
+            TemplateParameter parameter = ReadTemplateParameter(reader);
+            if (!_indices.TryGetValue(parameter, out int index))
+            {
+                index = GetIndex(parameter);
+                _indices[parameter] = index;
+            }
+
+            // Create the FormatItem for the parameter
+            FormatItem formatItem = new FormatItem(
+                index,
+                ReadAlignment(reader),
+                ReadFormat   (reader));
+
+            // Perform some validation on the template parameter's format if possible
+            string compositeFormat = formatItem.ToString(0);
+            switch (parameter)
+            {
+                // DateTime
+                case TemplateParameter.Timestamp:
+                    string.Format(compositeFormat, DateTime.UtcNow);
+                    break;
+                // Enum
+                case TemplateParameter.Level:
+                    string.Format(compositeFormat, LogLevel.Error);
+                    break;
+                // Integer
+                case TemplateParameter.ProcessId:
+                case TemplateParameter.ThreadId:
+                    string.Format(compositeFormat, 42);
+                    break;
+                default:
+                    break;
+            }
+
+            return formatItem;
+        }
+
+        private TemplateParameter ReadTemplateParameter(TextReader reader)
+        {
+            string name = null;
+            StringBuilder nameBuilder = new StringBuilder();
+
+            int next;
+            while ((next = reader.Peek()) != -1)
+            {
+                char c = (char)next;
+
+                // Format Item indices allow leading and trailing white space, so the
+                // template names also allow white space inside the format item
+                if (char.IsLetter(c) && name == null)
+                {
+                    // Currently all parameter names consist of letters
+                    nameBuilder.Append(c);
+                }
+                else if (c == ' ')
+                {
+                    if (name == null)
+                        name = nameBuilder.ToString();
+                }
+                else if (c == ',' || c == ':' || c == '}')
+                {
+                    name = nameBuilder.ToString();
+                    break;
+                }
+                else
+                {
+                    // Unexpected character!
+                    name = null;
+                    break;
+                }
+
+                // Move onto the next character
+                reader.Read();
+            }
+
+            // Did we reach the end without breaking or was there an unexpected character?
+            if (name == null)
+                throw new FormatException("Input string was not in a correct format");
+
+            return TemplateParameterName.Parse(name);
+        }
+
+        private int? ReadAlignment(TextReader reader)
+        {
+            // Read the alignment between the comma ',' and either the colon ':' or closed curly brace '}'
+            if (reader.Peek() == ',')
+            {
+                StringBuilder alignmentBuilder = new StringBuilder();
+
+                int next;
+                reader.Read(); // Move past the comma
+                while ((next = reader.Peek()) != -1)
+                {
+                    // There are no recognized escape sequences in the alignment
+                    if (next == ':' || next == '}')
+                        break;
+
+                    alignmentBuilder.Append((char)reader.Read());
+                }
+
+                return int.Parse(alignmentBuilder.ToString());
+            }
+
+            return null;
+        }
+
+        private string ReadFormat(TextReader reader)
+        {
+            // Read the format between the comma ':' and the closed curly brace '}'
+            if (reader.Peek() == ':')
+            {
+                StringBuilder formatBuilder = new StringBuilder();
+
+                int next;
+                reader.Read(); // Move past the colon
+                while ((next = reader.Peek()) != -1)
+                {
+                    // '}' cannot be escaped, so there is no need to special-case escape sequences
+                    if (next == '}')
+                        break;
+
+                    formatBuilder.Append((char)reader.Read());
+                }
+
+                return formatBuilder.ToString();
+            }
+
+            return null;
+        }
+
+        private readonly struct LogEntryTemplate<T> : ILogEntryTemplate<T>
+        {
+            private readonly string _format;
+            private readonly string _template;
+
+            private static readonly Process s_currentProcess = Process.GetCurrentProcess();
+
+            public LogEntryTemplate(string template, string format)
+            {
+                // TODO: While the originalTemplate is really bloat in production, it is
+                //       very helpful to have when debugging and for unit testing.
+                //       That said, is there a better mechanism that doesn't involve
+                //       different code between debug/release configuration?
+                _format   = format;
+                _template = template;
+            }
+
+            public string Format(IFormatProvider provider, LogEntry<T> logEntry)
+            {
+                // TODO: It seems silly to use the object[] override here when we avoid the
+                //       object[] allocation in the ILogger interface. We should figure out
+                //       how to avoid this allocation too if possible.
+                // TODO: Can probably replace the process parameters with real values now
+                return string.Format(provider, _format,
+                    logEntry.Message,              // {0} - Message
+                    logEntry.Timestamp,            // {1} - Timestamp
+                    logEntry.Level,                // {2} - LogLevel
+                    s_currentProcess.Id,           // {3} - Process Id
+                    s_currentProcess.ProcessName,  // {4} - Process Name
+                    logEntry.ThreadId,             // {5} - Thread Id
+                    logEntry.ThreadName);          // {6} - Thread Name
+            }
+
+            public override string ToString()
+                => _template;
+        }
+    }
+}

--- a/Sweetener.Logging/Templates/TemplateParameter.cs
+++ b/Sweetener.Logging/Templates/TemplateParameter.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+
+namespace Sweetener.Logging
+{
+    internal enum TemplateParameter
+    {
+        Message     = 0,
+        Timestamp   = 1,
+        Level       = 2,
+        ProcessId   = 3,
+        ProcessName = 4,
+        ThreadId    = 5,
+        ThreadName  = 6,
+    }
+
+    internal static class TemplateParameterName
+    {
+        public static TemplateParameter Parse(string name)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+
+            // TODO: Case insensitive?
+            switch (name)
+            {
+                case "msg":
+                case "message":
+                    return TemplateParameter.Message;
+                case "ts":
+                case "timestamp":
+                    return TemplateParameter.Timestamp;
+                case "l":
+                case "level":
+                    return TemplateParameter.Level;
+                case "pid":
+                case "processId":
+                    return TemplateParameter.ProcessId;
+                case "pn":
+                case "processName":
+                    return TemplateParameter.ProcessName;
+                case "tid":
+                case "threadId":
+                    return TemplateParameter.ThreadId;
+                case "tn":
+                case "threadName":
+                    return TemplateParameter.ThreadName;
+                default:
+                    throw new FormatException($"Unrecognized template parameter '{name}'.");
+            }
+        }
+    }
+}

--- a/Sweetener.Logging/TextTemplating/Include.t4
+++ b/Sweetener.Logging/TextTemplating/Include.t4
@@ -1,0 +1,5 @@
+﻿<#@ assembly name="System" #>
+<#@ import namespace="System" #>
+<#
+    string[] logLevels = new string[] { "Trace", "Debug", "Info", "Warn", "Error", "Fatal" };
+#>

--- a/Sweetener.Logging/ThrowHelper.cs
+++ b/Sweetener.Logging/ThrowHelper.cs
@@ -1,0 +1,31 @@
+﻿// The purpose of ThrowHelper.cs is the same as those seen in the CoreFX repository
+// like https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/System/ThrowHelper.cs.
+//
+// As logging may be called through an application, it is imperative that we optimize and
+// do not adversely impact consumers. To that end, it would be best if we can inline
+// logging as much as possible. However, throwing exceptions can often be verbose in IL
+// and may prevent the inlining of our methods. So instead we wrap our throw expressions
+// in non-inlined methods to prevent them from bloating our log methods.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Sweetener.Logging
+{
+    internal static class ThrowHelper
+    {
+        // TODO: Also perform resource localization
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentNullException(ExceptionArgument argument)
+            => throw new ArgumentNullException(argument.ToString());
+    }
+
+    internal enum ExceptionArgument
+    {
+        args,
+        format,
+    }
+}

--- a/Sweetener.sln
+++ b/Sweetener.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sweetener.Logging", "Sweetener.Logging\Sweetener.Logging.csproj", "{8B4B7850-5753-462A-ACBE-777BB119BE87}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sweetener.Logging.Test", "Sweetener.Logging.Test\Sweetener.Logging.Test.csproj", "{A631A105-131F-4E9E-B285-B635C0A29621}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{436CED33-A321-497A-B14F-4230D80517F0}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8B4B7850-5753-462A-ACBE-777BB119BE87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B4B7850-5753-462A-ACBE-777BB119BE87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B4B7850-5753-462A-ACBE-777BB119BE87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B4B7850-5753-462A-ACBE-777BB119BE87}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A631A105-131F-4E9E-B285-B635C0A29621}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A631A105-131F-4E9E-B285-B635C0A29621}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A631A105-131F-4E9E-B285-B635C0A29621}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A631A105-131F-4E9E-B285-B635C0A29621}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F6F03838-0E0B-40B6-A87B-2A71309475AC}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- Define an `ILogger<T>` interface for logging arbitrary instances of type `T` at a given `LogLevel`
    - Implementations may either rely on applications to create new logger instances as needed, or they may support a single static instance to be used by applications (like many other logging libraries)
    - Implementations communicate thread-safety in the same manner as [`ICollection`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.icollection?view=netframework-4.8) using an `IsSynchronized` flag and a `SyncRoot` for locking if the logger is not natively thread-safe
- Create a `string`-specific abstract implementation called `Logger` which provides additional formatting overloads
    - Could optionally create an `ILogger` interface specifically for `string`, but it didn't seem immediately useful. However, there may be merit in creating that level of abstraction
    - `Logger` does not assume that the implementation ultimately writes a `string`. Instead its API logs instances of `LogEntry<string>` which encapsulates the context of the `string` message
- Create a derivation of the `Logger` class called `PatternLogger` which strictly writes `string` values based on a pre-defined pattern 
    - Supports a small variety of patterns, similar to [Log4J](https://logging.apache.org/log4j/2.x/), that are implemented in the `internal` `LogPattern` class
        - Patterns are declared like [composite format strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting), except that instead of index in the format item the logger expects the name of the parameter. These patterns use standard .NET [formatting](https://docs.microsoft.com/en-us/dotnet/standard/base-types/formatting-types)
        - The use of names instead of item indices is reminiscent of ASP.NET [routing](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-2.2#route-template-reference)