### PR TITLE
Add Null fields to Logger and Logger<T>

### DIFF
--- a/src/Sweetener.Logging.Test/ContextualLoggers/Logger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/Logger{T}.Test.cs
@@ -36,6 +36,15 @@ namespace Sweetener.Logging.Test
         }
 
         [TestMethod]
+        public void Null()
+        {
+            Logger<Guid> logger = Logger<Guid>.Null;
+
+            Assert.IsNotNull(logger);
+            Assert.AreEqual(typeof(NullLogger<Guid>), logger.GetType());
+        }
+
+        [TestMethod]
         public void IsSynchronized()
         {
             Assert.IsFalse(new MemoryLogger<char>(                                           ).IsSynchronized);

--- a/src/Sweetener.Logging.Test/ContextualLoggers/NullLogger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/NullLogger{T}.Test.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class ContextualNullLoggerTest
+    {
+        [TestMethod]
+        public void Constructor()
+        {
+            using (Logger<int> logger = new NullLogger<int>())
+            {
+                Assert.AreEqual(LogLevel.Trace            , logger.MinLevel      );
+                Assert.AreEqual(CultureInfo.CurrentCulture, logger.FormatProvider);
+            }
+        }
+
+        [TestMethod]
+        public void IsSynchronized()
+        {
+            Assert.IsTrue(new NullLogger<DateTime>().IsSynchronized);
+        }
+
+        [TestMethod]
+        public void Dispose()
+        {
+            Logger<char> logger = new NullLogger<char>();
+
+            // Assert that we can call Dispose multiple times without issue
+            logger.Info('1', "Foo");
+            logger.Dispose();
+            logger.Warn('2', "Bar");
+            logger.Dispose();
+            logger.Fatal('3', "Baz");
+        }
+
+        [TestMethod]
+        public void Log()
+        {
+            using (Logger<long> logger = new NullLogger<long>())
+            {
+                // Log can be called without issue for each level
+                foreach (LogLevel level in Enum.GetValues(typeof(LogLevel)))
+                    logger.Log(new LogEntry<long>(DateTime.UtcNow, level, (long)level, level.ToString("F")));
+            }
+        }
+    }
+}

--- a/src/Sweetener.Logging.Test/Loggers/Logger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/Logger.Test.cs
@@ -36,6 +36,15 @@ namespace Sweetener.Logging.Test
         }
 
         [TestMethod]
+        public void Null()
+        {
+            Logger logger = Logger.Null;
+
+            Assert.IsNotNull(logger);
+            Assert.AreEqual(typeof(NullLogger), logger.GetType());
+        }
+
+        [TestMethod]
         public void IsSynchronized()
         {
             Assert.IsFalse(new MemoryLogger(                                           ).IsSynchronized);

--- a/src/Sweetener.Logging.Test/Loggers/NullLogger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/NullLogger.Test.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class NullLoggerTest
+    {
+        [TestMethod]
+        public void Constructor()
+        {
+            using (Logger logger = new NullLogger())
+            {
+                Assert.AreEqual(LogLevel.Trace            , logger.MinLevel      );
+                Assert.AreEqual(CultureInfo.CurrentCulture, logger.FormatProvider);
+            }
+        }
+
+        [TestMethod]
+        public void IsSynchronized()
+        {
+            Assert.IsTrue(new NullLogger().IsSynchronized);
+        }
+
+        [TestMethod]
+        public void Dispose()
+        {
+            Logger logger = new NullLogger();
+
+            // Assert that we can call Dispose multiple times without issue
+            logger.Info("Foo");
+            logger.Dispose();
+            logger.Warn("Bar");
+            logger.Dispose();
+            logger.Fatal("Baz");
+        }
+
+        [TestMethod]
+        public void Log()
+        {
+            using (Logger logger = new NullLogger())
+            {
+                // Log can be called without issue for each level
+                foreach (LogLevel level in Enum.GetValues(typeof(LogLevel)))
+                    logger.Log(new LogEntry(DateTime.UtcNow, level, level.ToString("F")));
+            }
+        }
+    }
+}

--- a/src/Sweetener.Logging/ContextualLoggers/Logger{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/Logger{T}.cs
@@ -11,6 +11,11 @@ namespace Sweetener.Logging
     public abstract partial class Logger<T> : IDisposable
     {
         /// <summary>
+        /// A <see cref="Logger{T}"/> with no backing store for its entries.
+        /// </summary>
+        public static readonly Logger<T> Null = new NullLogger<T>();
+
+        /// <summary>
         /// Gets an object that controls formatting. 
         /// </summary>
         public IFormatProvider FormatProvider { get; }

--- a/src/Sweetener.Logging/ContextualLoggers/NullLogger{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/NullLogger{T}.cs
@@ -4,16 +4,16 @@
     {
         public override bool IsSynchronized => true;
 
-        protected internal override void Log(LogEntry<T> logEntry)
-        { }
-
         protected override void Dispose(bool disposing)
         {
             // There is nothing to dispose and we don't want users to be able to
             // dispose of a logger used statically!
             //
             // Furthermore, repeated calls to GC.SuppressFinalize(this) are just fine
-            // in Logger.Dispose() since there is no finalizer
+            // in Logger<T>.Dispose() since there is no finalizer
         }
+
+        protected internal override void Log(LogEntry<T> logEntry)
+        { }
     }
 }

--- a/src/Sweetener.Logging/ContextualLoggers/NullLogger{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/NullLogger{T}.cs
@@ -1,0 +1,19 @@
+﻿namespace Sweetener.Logging
+{
+    internal sealed class NullLogger<T> : Logger<T>
+    {
+        public override bool IsSynchronized => true;
+
+        protected internal override void Log(LogEntry<T> logEntry)
+        { }
+
+        protected override void Dispose(bool disposing)
+        {
+            // There is nothing to dispose and we don't want users to be able to
+            // dispose of a logger used statically!
+            //
+            // Furthermore, repeated calls to GC.SuppressFinalize(this) are just fine
+            // in Logger.Dispose() since there is no finalizer
+        }
+    }
+}

--- a/src/Sweetener.Logging/Loggers/Logger.cs
+++ b/src/Sweetener.Logging/Loggers/Logger.cs
@@ -10,6 +10,11 @@ namespace Sweetener.Logging
     public abstract partial class Logger : IDisposable
     {
         /// <summary>
+        /// A <see cref="Logger"/> with no backing store for its entries.
+        /// </summary>
+        public static readonly Logger Null = new NullLogger();
+
+        /// <summary>
         /// Gets an object that controls formatting. 
         /// </summary>
         public IFormatProvider FormatProvider { get; }

--- a/src/Sweetener.Logging/Loggers/NullLogger.cs
+++ b/src/Sweetener.Logging/Loggers/NullLogger.cs
@@ -1,0 +1,19 @@
+﻿namespace Sweetener.Logging
+{
+    internal sealed class NullLogger : Logger
+    {
+        public override bool IsSynchronized => true;
+
+        protected override void Dispose(bool disposing)
+        {
+            // There is nothing to dispose and we don't want users to be able to
+            // dispose of a logger used statically!
+            //
+            // Furthermore, repeated calls to GC.SuppressFinalize(this) are just fine
+            // in Logger.Dispose() since there is no finalizer
+        }
+
+        protected internal override void Log(LogEntry logEntry)
+        { }
+    }
+}


### PR DESCRIPTION
- Add a field `Null` to both `Logger` and `Logger<T>` which returns a `NullLogger` and `NullLogger<T>` respectively
    - These "null" loggers do not write entries to any backing store and:
        - Are `static`
        - Are thread-safe
        - Cannot be disposed
        - Use the default `MinLevel` (`Trace`)
        - Use the current culture
    - Mirrors [`Stream.Null`](https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.null?view=netstandard-2.0) in .NET Standard 2.0
- Add new tests for the loggers and how they're exposed