### PR TITLE
Fix Logger Properties and Refactor Tests

### DIFF
--- a/src/Sweetener.Logging.Test/ContextualLoggers/Logger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/Logger{T}.Test.cs
@@ -38,34 +38,37 @@ namespace Sweetener.Logging.Test
         [TestMethod]
         public void Null()
         {
-            Logger<Guid> logger = Logger<Guid>.Null;
-
-            Assert.IsNotNull(logger);
-            Assert.AreEqual(typeof(NullLogger<Guid>), logger.GetType());
+            using (Logger<Guid> logger = Logger<Guid>.Null)
+            {
+                Assert.IsNotNull(logger);
+                Assert.AreEqual(typeof(NullLogger<Guid>), logger.GetType());
+            }
         }
 
         [TestMethod]
         public void IsSynchronized()
         {
-            Assert.IsFalse(new MemoryLogger<char>(                                           ).IsSynchronized);
-            Assert.IsFalse(new MemoryLogger<char>(LogLevel.Info                              ).IsSynchronized);
-            Assert.IsFalse(new MemoryLogger<char>(LogLevel.Warn, CultureInfo.InvariantCulture).IsSynchronized);
+            using (Logger<char> logger = new MemoryLogger<char>())
+                Assert.IsFalse(logger.IsSynchronized);
+
+            using (Logger<char> logger = new MemoryLogger<char>(LogLevel.Info))
+                Assert.IsFalse(logger.IsSynchronized);
+
+            using (Logger<char> logger = new MemoryLogger<char>(LogLevel.Warn, CultureInfo.GetCultureInfo("es-ES")))
+                Assert.IsFalse(logger.IsSynchronized);
         }
 
         [TestMethod]
         public void SyncRoot()
         {
-            Logger<ulong> logger0 = new MemoryLogger<ulong>();
-            Logger<ulong> logger1 = new MemoryLogger<ulong>(LogLevel.Info);
-            Logger<ulong> logger2 = new MemoryLogger<ulong>(LogLevel.Warn, CultureInfo.GetCultureInfo("es-ES"));
+            using (Logger<ulong> logger = new MemoryLogger<ulong>())
+                Assert.AreEqual(logger, logger.SyncRoot);
 
-            Assert.IsNotNull(logger0.SyncRoot);
-            Assert.IsNotNull(logger1.SyncRoot);
-            Assert.IsNotNull(logger2.SyncRoot);
+            using (Logger<ulong> logger = new MemoryLogger<ulong>(LogLevel.Info))
+                Assert.AreEqual(logger, logger.SyncRoot);
 
-            Assert.AreEqual(typeof(object), logger0.SyncRoot.GetType());
-            Assert.AreEqual(typeof(object), logger1.SyncRoot.GetType());
-            Assert.AreEqual(typeof(object), logger2.SyncRoot.GetType());
+            using (Logger<ulong> logger = new MemoryLogger<ulong>(LogLevel.Warn, CultureInfo.GetCultureInfo("es-ES")))
+                Assert.AreEqual(logger, logger.SyncRoot);
         }
 
         [TestMethod]

--- a/src/Sweetener.Logging.Test/ContextualLoggers/NullLogger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/NullLogger{T}.Test.cs
@@ -20,7 +20,15 @@ namespace Sweetener.Logging.Test
         [TestMethod]
         public void IsSynchronized()
         {
-            Assert.IsTrue(new NullLogger<DateTime>().IsSynchronized);
+            using (Logger<DateTime> logger = new NullLogger<DateTime>())
+                Assert.IsTrue(logger.IsSynchronized);
+        }
+
+        [TestMethod]
+        public void SyncRoot()
+        {
+            using (Logger<short> logger = new NullLogger<short>())
+                Assert.AreEqual(logger, logger.SyncRoot);
         }
 
         [TestMethod]

--- a/src/Sweetener.Logging.Test/ContextualLoggers/TemplateLogger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/TemplateLogger{T}.Test.cs
@@ -50,10 +50,33 @@ namespace Sweetener.Logging.Test
         [TestMethod]
         public void IsSynchronized()
         {
-            Assert.IsFalse(new MemoryTemplateLogger<int>(                                                           ).IsSynchronized);
-            Assert.IsFalse(new MemoryTemplateLogger<int>(LogLevel.Info                                              ).IsSynchronized);
-            Assert.IsFalse(new MemoryTemplateLogger<int>(LogLevel.Warn, "{cxt} {msg}"                               ).IsSynchronized);
-            Assert.IsFalse(new MemoryTemplateLogger<int>(LogLevel.Debug, CultureInfo.InvariantCulture, "{cxt} {msg}").IsSynchronized);
+            using (Logger<int> logger = new MemoryTemplateLogger<int>())
+                Assert.IsFalse(logger.IsSynchronized);
+
+            using (Logger<int> logger = new MemoryTemplateLogger<int>(LogLevel.Info))
+                Assert.IsFalse(logger.IsSynchronized);
+
+            using (Logger<int> logger = new MemoryTemplateLogger<int>(LogLevel.Warn, "{cxt} {msg}"))
+                Assert.IsFalse(logger.IsSynchronized);
+
+            using (Logger<int> logger = new MemoryTemplateLogger<int>(LogLevel.Debug, CultureInfo.GetCultureInfo("es-ES"), "{cxt} {msg}"))
+                Assert.IsFalse(logger.IsSynchronized);
+        }
+
+        [TestMethod]
+        public void SyncRoot()
+        {
+            using (Logger<int> logger = new MemoryTemplateLogger<int>())
+                Assert.AreEqual(logger, logger.SyncRoot);
+
+            using (Logger<int> logger = new MemoryTemplateLogger<int>(LogLevel.Info))
+                Assert.AreEqual(logger, logger.SyncRoot);
+
+            using (Logger<int> logger = new MemoryTemplateLogger<int>(LogLevel.Warn, "{cxt} {msg}"))
+                Assert.AreEqual(logger, logger.SyncRoot);
+
+            using (Logger<int> logger = new MemoryTemplateLogger<int>(LogLevel.Debug, CultureInfo.GetCultureInfo("es-ES"), "{cxt} {msg}"))
+                Assert.AreEqual(logger, logger.SyncRoot);
         }
 
         [TestMethod]

--- a/src/Sweetener.Logging.Test/Loggers/Logger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/Logger.Test.cs
@@ -38,34 +38,37 @@ namespace Sweetener.Logging.Test
         [TestMethod]
         public void Null()
         {
-            Logger logger = Logger.Null;
-
-            Assert.IsNotNull(logger);
-            Assert.AreEqual(typeof(NullLogger), logger.GetType());
+            using (Logger logger = Logger.Null)
+            {
+                Assert.IsNotNull(logger);
+                Assert.AreEqual(typeof(NullLogger), logger.GetType());
+            }
         }
 
         [TestMethod]
         public void IsSynchronized()
         {
-            Assert.IsFalse(new MemoryLogger(                                           ).IsSynchronized);
-            Assert.IsFalse(new MemoryLogger(LogLevel.Info                              ).IsSynchronized);
-            Assert.IsFalse(new MemoryLogger(LogLevel.Warn, CultureInfo.InvariantCulture).IsSynchronized);
+            using (Logger logger = new MemoryLogger())
+                Assert.IsFalse(logger.IsSynchronized);
+
+            using (Logger logger = new MemoryLogger(LogLevel.Info))
+                Assert.IsFalse(logger.IsSynchronized);
+
+            using (Logger logger = new MemoryLogger(LogLevel.Warn, CultureInfo.GetCultureInfo("es-ES")))
+                Assert.IsFalse(logger.IsSynchronized);
         }
 
         [TestMethod]
         public void SyncRoot()
         {
-            Logger logger0 = new MemoryLogger();
-            Logger logger1 = new MemoryLogger(LogLevel.Info);
-            Logger logger2 = new MemoryLogger(LogLevel.Warn, CultureInfo.GetCultureInfo("es-ES"));
+            using (Logger logger = new MemoryLogger())
+                Assert.AreEqual(logger, logger.SyncRoot);
 
-            Assert.IsNotNull(logger0.SyncRoot);
-            Assert.IsNotNull(logger1.SyncRoot);
-            Assert.IsNotNull(logger2.SyncRoot);
+            using (Logger logger = new MemoryLogger(LogLevel.Info))
+                Assert.AreEqual(logger, logger.SyncRoot);
 
-            Assert.AreEqual(typeof(object), logger0.SyncRoot.GetType());
-            Assert.AreEqual(typeof(object), logger1.SyncRoot.GetType());
-            Assert.AreEqual(typeof(object), logger2.SyncRoot.GetType());
+            using (Logger logger = new MemoryLogger(LogLevel.Warn, CultureInfo.GetCultureInfo("es-ES")))
+                Assert.AreEqual(logger, logger.SyncRoot);
         }
 
         [TestMethod]

--- a/src/Sweetener.Logging.Test/Loggers/NullLogger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/NullLogger.Test.cs
@@ -20,7 +20,15 @@ namespace Sweetener.Logging.Test
         [TestMethod]
         public void IsSynchronized()
         {
-            Assert.IsTrue(new NullLogger().IsSynchronized);
+            using (Logger logger = new NullLogger())
+                Assert.IsTrue(logger.IsSynchronized);
+        }
+
+        [TestMethod]
+        public void SyncRoot()
+        {
+            using (Logger logger = new NullLogger())
+                Assert.AreEqual(logger, logger.SyncRoot);
         }
 
         [TestMethod]

--- a/src/Sweetener.Logging.Test/Loggers/TemplateLogger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/TemplateLogger.Test.cs
@@ -50,10 +50,33 @@ namespace Sweetener.Logging.Test
         [TestMethod]
         public void IsSynchronized()
         {
-            Assert.IsFalse(new MemoryTemplateLogger(                                                     ).IsSynchronized);
-            Assert.IsFalse(new MemoryTemplateLogger(LogLevel.Info                                        ).IsSynchronized);
-            Assert.IsFalse(new MemoryTemplateLogger(LogLevel.Warn, "{msg}"                               ).IsSynchronized);
-            Assert.IsFalse(new MemoryTemplateLogger(LogLevel.Debug, CultureInfo.InvariantCulture, "{msg}").IsSynchronized);
+            using (Logger logger = new MemoryTemplateLogger())
+                Assert.IsFalse(logger.IsSynchronized);
+
+            using (Logger logger = new MemoryTemplateLogger(LogLevel.Info))
+                Assert.IsFalse(logger.IsSynchronized);
+
+            using (Logger logger = new MemoryTemplateLogger(LogLevel.Warn, "{msg}"))
+                Assert.IsFalse(logger.IsSynchronized);
+
+            using (Logger logger = new MemoryTemplateLogger(LogLevel.Debug, CultureInfo.GetCultureInfo("es-ES"), "{msg}"))
+                Assert.IsFalse(logger.IsSynchronized);
+        }
+
+        [TestMethod]
+        public void SyncRoot()
+        {
+            using (Logger logger = new MemoryTemplateLogger())
+                Assert.AreEqual(logger, logger.SyncRoot);
+
+            using (Logger logger = new MemoryTemplateLogger(LogLevel.Info))
+                Assert.AreEqual(logger, logger.SyncRoot);
+
+            using (Logger logger = new MemoryTemplateLogger(LogLevel.Warn, "{msg}"))
+                Assert.AreEqual(logger, logger.SyncRoot);
+
+            using (Logger logger = new MemoryTemplateLogger(LogLevel.Debug, CultureInfo.GetCultureInfo("es-ES"), "{msg}"))
+                Assert.AreEqual(logger, logger.SyncRoot);
         }
 
         [TestMethod]

--- a/src/Sweetener.Logging/ContextualLoggers/Logger{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/Logger{T}.cs
@@ -18,25 +18,39 @@ namespace Sweetener.Logging
         /// <summary>
         /// Gets an object that controls formatting. 
         /// </summary>
+        /// <value>
+        /// An <see cref="IFormatProvider"/> object for a specific culture, or the
+        /// formatting of the current culture if no other culture is specified.
+        /// </value>
         public IFormatProvider FormatProvider { get; }
 
         /// <summary>
         /// Gets a value indicating whether logging is synchronized (thread safe).
         /// </summary>
-        /// <returns><see langword="true"/> if logging is synchronized (thread safe); otherwise, <see langword="false"/>.</returns>
+        /// <value>
+        /// <see langword="true"/> if logging is synchronized (thread safe);
+        /// otherwise, <see langword="false"/>.
+        /// </value>
         public virtual bool IsSynchronized => false;
 
         /// <summary>
         /// Gets the minimum level of log requests that will be fulfilled.
         /// </summary>
-        /// <returns>The minimum <see cref="LogLevel"/> that will be fulfilled.</returns>
+        /// <value>
+        /// The minimum <see cref="LogLevel"/> that will be fulfilled by the <see cref="Logger{T}"/>;
+        /// any log request with a <see cref="LogLevel"/> below the minimum will be ignored.
+        /// </value>
         public LogLevel MinLevel { get; }
 
         /// <summary>
-        /// Gets an object that can be used to synchronize logging.
+        /// Gets an object that can be used to synchronize access to the <see cref="Logger{T}"/>.
         /// </summary>
-        /// <returns>An object that can be used to synchronize logging.</returns>
-        public object SyncRoot { get; } = new object();
+        /// <value>
+        /// An object that can be used to synchronize access to the <see cref="Logger{T}"/>.
+        /// In the default implementation of <see cref="Logger{T}"/>, this property always
+        /// returns the current instance.
+        /// </value>
+        public virtual object SyncRoot => this;
 
         private bool _disposed = false;
 
@@ -122,8 +136,8 @@ namespace Sweetener.Logging
         /// </param>
         protected virtual void Dispose(bool disposing)
         {
-            // In the base class, this flag is used to short circuit calls before Log(...)
-            // We don't want method calls on disabled loggers to not throw exceptions
+            // In the base class, this flag is used to short-circuit calls before Log(...)
+            // We don't want method calls on disabled loggers to skip throwing exceptions
             // because the log request was below the minimum log level!
             if (!_disposed)
                 _disposed = true;

--- a/src/Sweetener.Logging/Loggers/Logger.cs
+++ b/src/Sweetener.Logging/Loggers/Logger.cs
@@ -17,25 +17,39 @@ namespace Sweetener.Logging
         /// <summary>
         /// Gets an object that controls formatting. 
         /// </summary>
+        /// <value>
+        /// An <see cref="IFormatProvider"/> object for a specific culture, or the
+        /// formatting of the current culture if no other culture is specified.
+        /// </value>
         public IFormatProvider FormatProvider { get; }
 
         /// <summary>
         /// Gets a value indicating whether logging is synchronized (thread safe).
         /// </summary>
-        /// <returns><see langword="true"/> if logging is synchronized (thread safe); otherwise, <see langword="false"/>.</returns>
+        /// <value>
+        /// <see langword="true"/> if logging is synchronized (thread safe);
+        /// otherwise, <see langword="false"/>.
+        /// </value>
         public virtual bool IsSynchronized => false;
 
         /// <summary>
         /// Gets the minimum level of log requests that will be fulfilled.
         /// </summary>
-        /// <returns>The minimum <see cref="LogLevel"/> that will be fulfilled.</returns>
+        /// <value>
+        /// The minimum <see cref="LogLevel"/> that will be fulfilled by the <see cref="Logger"/>;
+        /// any log request with a <see cref="LogLevel"/> below the minimum will be ignored.
+        /// </value>
         public LogLevel MinLevel { get; }
 
         /// <summary>
-        /// Gets an object that can be used to synchronize logging.
+        /// Gets an object that can be used to synchronize access to the <see cref="Logger"/>.
         /// </summary>
-        /// <returns>An object that can be used to synchronize logging.</returns>
-        public object SyncRoot { get; } = new object();
+        /// <value>
+        /// An object that can be used to synchronize access to the <see cref="Logger"/>.
+        /// In the default implementation of <see cref="Logger"/>, this property always
+        /// returns the current instance.
+        /// </value>
+        public virtual object SyncRoot => this;
 
         private bool _disposed = false;
 
@@ -121,8 +135,8 @@ namespace Sweetener.Logging
         /// </param>
         protected virtual void Dispose(bool disposing)
         {
-            // In the base class, this flag is used to short circuit calls before Log(...)
-            // We don't want method calls on disabled loggers to not throw exceptions
+            // In the base class, this flag is used to short-circuit calls before Log(...)
+            // We don't want method calls on disabled loggers to skip throwing exceptions
             // because the log request was below the minimum log level!
             if (!_disposed)
                 _disposed = true;


### PR DESCRIPTION
- Change `Logger` and `Logger<T>` property `SyncRoot` to return the instance instead of an arbitrary object
- Update XML doc for properties to use `<value/>` instead of `<returns/>`
- Update tests to use more `using` statements