### PR TITLE
Add StreamLogger and StreamLogger<T>

### DIFF
--- a/src/Sweetener.Logging.Test/ContextualLoggers/ConsoleLogger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/ConsoleLogger{T}.Test.cs
@@ -21,31 +21,31 @@ namespace Sweetener.Logging.Test
             // Constructor Overloads
             using (ConsoleLogger<byte> logger = new ConsoleLogger<byte>())
             {
-                Assert.AreEqual(LogLevel.Trace                      , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture          , logger.FormatProvider      );
-                Assert.AreEqual(TemplateLogger<byte>.DefaultTemplate, logger._template.ToString());
+                Assert.AreEqual(LogLevel.Trace                      , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture          , logger.FormatProvider     );
+                Assert.AreEqual(TemplateLogger<byte>.DefaultTemplate, logger.Template.ToString());
             }
 
             using (ConsoleLogger<string> logger = new ConsoleLogger<string>(LogLevel.Warn))
             {
-                Assert.AreEqual(LogLevel.Warn                         , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture            , logger.FormatProvider      );
-                Assert.AreEqual(TemplateLogger<string>.DefaultTemplate, logger._template.ToString());
+                Assert.AreEqual(LogLevel.Warn                         , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture            , logger.FormatProvider     );
+                Assert.AreEqual(TemplateLogger<string>.DefaultTemplate, logger.Template.ToString());
             }
 
             using (ConsoleLogger<Guid> logger = new ConsoleLogger<Guid>(LogLevel.Info, "<{pn}|{pid}> - {msg} {cxt}"))
             {
-                Assert.AreEqual(LogLevel.Info               , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture  , logger.FormatProvider      );
-                Assert.AreEqual("<{pn}|{pid}> - {msg} {cxt}", logger._template.ToString());
+                Assert.AreEqual(LogLevel.Info               , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture  , logger.FormatProvider     );
+                Assert.AreEqual("<{pn}|{pid}> - {msg} {cxt}", logger.Template.ToString());
             }
 
             CultureInfo esES = CultureInfo.GetCultureInfo("es-ES");
             using (ConsoleLogger<TimeSpan> logger = new ConsoleLogger<TimeSpan>(LogLevel.Error, esES, "[{tid}] {cxt} {msg}"))
             {
-                Assert.AreEqual(LogLevel.Error       , logger.MinLevel            );
-                Assert.AreEqual(esES                 , logger.FormatProvider      );
-                Assert.AreEqual("[{tid}] {cxt} {msg}", logger._template.ToString());
+                Assert.AreEqual(LogLevel.Error       , logger.MinLevel           );
+                Assert.AreEqual(esES                 , logger.FormatProvider     );
+                Assert.AreEqual("[{tid}] {cxt} {msg}", logger.Template.ToString());
             }
         }
 

--- a/src/Sweetener.Logging.Test/ContextualLoggers/Logger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/Logger{T}.Test.cs
@@ -72,7 +72,7 @@ namespace Sweetener.Logging.Test
         }
 
         [TestMethod]
-        public void LogThrowIfDisposed()
+        public void ThrowObjectDisposedException()
         {
             Logger<int> logger = new MemoryLogger<int>();
             logger.Dispose();

--- a/src/Sweetener.Logging.Test/ContextualLoggers/StreamLogger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/StreamLogger{T}.Test.cs
@@ -136,10 +136,10 @@ namespace Sweetener.Logging.Test
                 LogLevel.Debug,
                 frFr,
                 ">> {cxt} {msg}",
-                Encoding.UTF8,
+                Encoding.UTF32,
                 2000,
                 true,
-                (stream) => new StreamLogger<int>(stream, LogLevel.Debug, frFr, ">> {cxt} {msg}", Encoding.UTF8, 2000, true));
+                (stream) => new StreamLogger<int>(stream, LogLevel.Debug, frFr, ">> {cxt} {msg}", Encoding.UTF32, 2000, true));
         }
 
         [TestMethod]

--- a/src/Sweetener.Logging.Test/ContextualLoggers/StreamLogger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/StreamLogger{T}.Test.cs
@@ -1,0 +1,338 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class ContextualStreamLoggerTest
+    {
+        [TestMethod]
+        public void ConstructorExceptions()
+        {
+            CultureInfo jaJP = CultureInfo.GetCultureInfo("ja-JP");
+            CultureInfo ptBR = CultureInfo.GetCultureInfo("pt-BR");
+            Stream readOnlyStream = new MemoryStream(Array.Empty<byte>(), writable: false);
+
+            // StreamLogger(Stream)
+            Assert.ThrowsException<ArgumentException    >(() => new StreamLogger<sbyte>(readOnlyStream));
+            Assert.ThrowsException<ArgumentNullException>(() => new StreamLogger<short>(null          ));
+
+            // StreamLogger(Stream, LogLevel)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger<sbyte>(readOnlyStream, LogLevel.Info));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(null          , LogLevel.Warn));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger<int  >(Stream.Null   , (LogLevel)42 ));
+
+            // StreamLogger(Stream, LogLevel, string)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger<sbyte>(readOnlyStream, LogLevel.Info , "{cxt} {msg}"));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(null          , LogLevel.Warn , "{cxt} {msg}"));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(Stream.Null   , LogLevel.Debug, null         ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger<int  >(Stream.Null   , (LogLevel)42  , "{cxt} {msg}"));
+            Assert.ThrowsException<FormatException            >(() => new StreamLogger<long >(Stream.Null   , LogLevel.Fatal, "Missing msg"));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger<sbyte>(readOnlyStream, LogLevel.Info , jaJP, "{cxt} {msg}"));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(null          , LogLevel.Warn , ptBR, "{cxt} {msg}"));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(Stream.Null   , LogLevel.Debug, ptBR, null         ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger<int  >(Stream.Null   , (LogLevel)42  , jaJP, "{cxt} {msg}"));
+            Assert.ThrowsException<FormatException            >(() => new StreamLogger<long >(Stream.Null   , LogLevel.Fatal, null, "Missing msg"));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger<sbyte>(readOnlyStream, LogLevel.Info , jaJP, "{cxt} {msg}", Encoding.ASCII  ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(null          , LogLevel.Warn , ptBR, "{cxt} {msg}", Encoding.UTF7   ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(Stream.Null   , LogLevel.Debug, ptBR, null         , Encoding.UTF8   ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(Stream.Null   , LogLevel.Warn , ptBR, "{cxt} {msg}", null            ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger<int  >(Stream.Null   , (LogLevel)42  , jaJP, "{cxt} {msg}", Encoding.UTF32  ));
+            Assert.ThrowsException<FormatException            >(() => new StreamLogger<long >(Stream.Null   , LogLevel.Fatal, null, "Missing msg", Encoding.Unicode));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding, int)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger<sbyte>(readOnlyStream, LogLevel.Info , jaJP, "{cxt} {msg}", Encoding.ASCII  ,  1234));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(null          , LogLevel.Warn , ptBR, "{cxt} {msg}", Encoding.UTF7   ,  5678));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(Stream.Null   , LogLevel.Debug, ptBR, null         , Encoding.UTF8   ,  0910));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(Stream.Null   , LogLevel.Warn , ptBR, "{cxt} {msg}", null            ,  1112));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger<int  >(Stream.Null   , (LogLevel)42  , jaJP, "{cxt} {msg}", Encoding.UTF32  ,  1314));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger<int  >(Stream.Null   , LogLevel.Trace, jaJP, "{cxt} {msg}", Encoding.Default, -1516));
+            Assert.ThrowsException<FormatException            >(() => new StreamLogger<long >(Stream.Null   , LogLevel.Fatal, null, "Missing msg", Encoding.Unicode,  1718));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding, int, bool)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger<sbyte>(readOnlyStream, LogLevel.Info , jaJP, "{cxt} {msg}", Encoding.ASCII  ,  1234, false));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(null          , LogLevel.Warn , ptBR, "{cxt} {msg}", Encoding.UTF7   ,  5678, true ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(Stream.Null   , LogLevel.Debug, ptBR, null         , Encoding.UTF8   ,  0910, false));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger<short>(Stream.Null   , LogLevel.Warn , ptBR, "{cxt} {msg}", null            ,  1112, true ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger<int  >(Stream.Null   , (LogLevel)42  , jaJP, "{cxt} {msg}", Encoding.UTF32  ,  1314, false));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger<int  >(Stream.Null   , LogLevel.Trace, jaJP, "{cxt} {msg}", Encoding.Default, -1516, true ));
+            Assert.ThrowsException<FormatException            >(() => new StreamLogger<long >(Stream.Null   , LogLevel.Fatal, null, "Missing msg", Encoding.Unicode,  1718, false));
+        }
+
+        [TestMethod]
+        public void Constructor()
+        {
+            CultureInfo frFr = CultureInfo.GetCultureInfo("fr-FR");
+
+            // StreamLogger(Stream)
+            AssertStreamLogger(
+                LogLevel.Trace,
+                CultureInfo.CurrentCulture,
+                StreamLogger<int>.DefaultTemplate,
+                EncodingCache.UTF8NoBOM,
+                1024,
+                false,
+                (stream) => new StreamLogger<int>(stream));
+
+            // StreamLogger(Stream, LogLevel)
+            AssertStreamLogger(
+                LogLevel.Warn,
+                CultureInfo.CurrentCulture,
+                StreamLogger<int>.DefaultTemplate,
+                EncodingCache.UTF8NoBOM,
+                1024,
+                false,
+                (stream) => new StreamLogger<int>(stream, LogLevel.Warn));
+
+            // StreamLogger(Stream, LogLevel, string)
+            AssertStreamLogger(
+                LogLevel.Error,
+                CultureInfo.CurrentCulture,
+                "{l} {cxt} {msg}",
+                EncodingCache.UTF8NoBOM,
+                1024,
+                false,
+                (stream) => new StreamLogger<int>(stream, LogLevel.Error, "{l} {cxt} {msg}"));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string)
+            AssertStreamLogger(
+                LogLevel.Debug,
+                frFr,
+                ">> {cxt} {msg}",
+                EncodingCache.UTF8NoBOM,
+                1024,
+                false,
+                (stream) => new StreamLogger<int>(stream, LogLevel.Debug, frFr, ">> {cxt} {msg}"));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding)
+            AssertStreamLogger(
+                LogLevel.Info,
+                frFr,
+                ">> {cxt} {msg}",
+                Encoding.Unicode,
+                1024,
+                false,
+                (stream) => new StreamLogger<int>(stream, LogLevel.Info, frFr, ">> {cxt} {msg}", Encoding.Unicode));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding, int)
+            AssertStreamLogger(
+                LogLevel.Fatal,
+                frFr,
+                ">> {cxt} {msg}",
+                Encoding.ASCII,
+                500,
+                false,
+                (stream) => new StreamLogger<int>(stream, LogLevel.Fatal, frFr, ">> {cxt} {msg}", Encoding.ASCII, 500));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding, int, bool)
+            AssertStreamLogger(
+                LogLevel.Debug,
+                frFr,
+                ">> {cxt} {msg}",
+                Encoding.UTF8,
+                2000,
+                true,
+                (stream) => new StreamLogger<int>(stream, LogLevel.Debug, frFr, ">> {cxt} {msg}", Encoding.UTF8, 2000, true));
+        }
+
+        [TestMethod]
+        public void ThrowObjectDisposedException()
+        {
+            StreamLogger<Guid> logger = new StreamLogger<Guid>(Stream.Null);
+            logger.Dispose();
+
+            // Methods
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Log(default));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Flush());
+        }
+
+        [TestMethod]
+        public void AutoFlush()
+        {
+            // AutoFlush = false
+            using (StreamLogger<char> logger = new StreamLogger<char>(new MemoryStream()))
+            {
+                Assert.IsFalse(logger.AutoFlush);
+
+                logger.Warn('A', "Warning!");
+                Assert.AreEqual(0, logger.BaseStream.Position);
+            }
+
+            // AutoFlush = true
+            using (StreamLogger<char> logger = new StreamLogger<char>(new MemoryStream()) { AutoFlush = true })
+            {
+                Assert.IsTrue(logger.AutoFlush);
+
+                logger.Warn('A', "Warning!");
+                Assert.AreNotEqual(0, logger.BaseStream.Position);
+            }
+        }
+
+        [TestMethod]
+        public void BaseStream()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            using (StreamLogger<TimeSpan> logger = new StreamLogger<TimeSpan>(stream))
+                Assert.AreEqual(stream, logger.BaseStream);
+        }
+
+        [TestMethod]
+        // Change name to not conflict with class
+        public void EncodingProperty()
+        {
+            // Default
+            using (StreamLogger<ulong> logger = new StreamLogger<ulong>(Stream.Null, LogLevel.Fatal, null, "{cxt} {msg}"))
+                Assert.AreEqual(EncodingCache.UTF8NoBOM, logger.Encoding);
+
+            // Non-null
+            using (StreamLogger<ulong> logger = new StreamLogger<ulong>(Stream.Null, LogLevel.Fatal, null, "{cxt} {msg}", Encoding.UTF32))
+                Assert.AreEqual(Encoding.UTF32, logger.Encoding);
+        }
+
+        [TestMethod]
+        public void IsSynchronized()
+        {
+            using (Logger<string> logger = new StreamLogger<string>(Stream.Null))
+                Assert.IsFalse(logger.IsSynchronized);
+        }
+
+        [TestMethod]
+        public void NewLine()
+        {
+            using (StreamLogger<Guid> logger = new StreamLogger<Guid>(Stream.Null))
+            {
+                // Default value
+                Assert.AreEqual(Environment.NewLine, logger.NewLine);
+
+                // Assign to a different value
+                logger.NewLine = "EOL";
+                Assert.AreEqual("EOL", logger.NewLine);
+
+                // Assign default using null
+                logger.NewLine = null;
+                Assert.AreEqual(Environment.NewLine, logger.NewLine);
+            }
+        }
+
+        [TestMethod]
+        public void SyncRoot()
+        {
+            using (Logger<double> logger = new StreamLogger<double>(Stream.Null))
+                Assert.AreEqual(logger, logger.SyncRoot);
+        }
+
+        [TestMethod]
+        public void Flush()
+        {
+            using (StreamLogger<int> logger = new StreamLogger<int>(new MemoryStream()))
+            {
+                Assert.IsFalse(logger.AutoFlush);
+
+                logger.Warn(2, "Warnings!");
+                Assert.AreEqual(0, logger.BaseStream.Position);
+
+                logger.Flush();
+                Assert.AreNotEqual(0, logger.BaseStream.Position);
+            }
+        }
+
+        [TestMethod]
+        public void Log()
+        {
+            using (StreamLogger<ulong> logger = new StreamLogger<ulong>(new MemoryStream(), LogLevel.Trace, CultureInfo.InvariantCulture, "[{ts:HH:mm:ss}] [{l,-5:F}] [User: {cxt,4}] - {msg}"))
+            {
+                DateTime timestamp = new DateTime(2999, 12, 31, 23, 59, 57);
+
+                logger.Log(new LogEntry<ulong>(timestamp              , LogLevel.Warn ,  246, "Hello" ));
+                logger.Log(new LogEntry<ulong>(timestamp.AddSeconds(1), LogLevel.Info ,  246, "Stream"));
+                logger.Log(new LogEntry<ulong>(timestamp.AddSeconds(2), LogLevel.Warn , 1357, "Hello" ));
+                logger.Log(new LogEntry<ulong>(timestamp.AddSeconds(2), LogLevel.Debug,  246, "World" ));
+
+                logger.Flush();
+
+                // Read back the log entries
+                logger.BaseStream.Seek(0, SeekOrigin.Begin);
+                using (StreamReader reader = new StreamReader(logger.BaseStream))
+                {
+                    Assert.AreEqual("[23:59:57] [Warn ] [User:  246] - Hello" , reader.ReadLine());
+                    Assert.AreEqual("[23:59:58] [Info ] [User:  246] - Stream", reader.ReadLine());
+                    Assert.AreEqual("[23:59:59] [Warn ] [User: 1357] - Hello" , reader.ReadLine());
+                    Assert.AreEqual("[23:59:59] [Debug] [User:  246] - World" , reader.ReadLine());
+                }
+            }
+        }
+
+        private static void AssertStreamLogger(
+            LogLevel                        expectedMinLevel,
+            IFormatProvider                 expectedFormatProvider,
+            string                          expectedTemplate,
+            Encoding                        expectedEncoding,
+            int                             expectedBufferSize,
+            bool                            leaveOpen,
+            Func<Stream, StreamLogger<int>> loggerFactory)
+        {
+            // Assert the various properties, except the buffer size
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (StreamLogger<int> actual = loggerFactory(stream))
+                {
+                    Assert.AreEqual(expectedMinLevel      , actual.MinLevel           );
+                    Assert.AreEqual(expectedFormatProvider, actual.FormatProvider     );
+                    Assert.AreEqual(expectedTemplate      , actual.Template.ToString());
+                    Assert.AreEqual(expectedEncoding      , actual.Encoding           );
+                }
+
+                if (leaveOpen)
+                    Assert.AreEqual(expectedEncoding.Preamble.Length, stream.Position); // Preamble flushed
+                else
+                    Assert.ThrowsException<ObjectDisposedException>(() => stream.Position);
+            }
+
+            // Assert that the buffer size is expected
+            AssertBufferSize(expectedBufferSize, loggerFactory);
+        }
+
+        private static void AssertBufferSize(int expectedBufferSize, Func<Stream, StreamLogger<int>> loggerFactory)
+        {
+            string msg;
+            DateTime timestamp = new DateTime(2019, 7, 2, 21, 37, 04);
+
+            // Write a message that is the same length as the internal buffer
+            using (StreamLogger<int> logger = loggerFactory(new MemoryStream()))
+            {
+                LogEntry<int> entry = new LogEntry<int>(timestamp, LogLevel.Warn, 7, string.Empty);
+                int lineLength = logger.Template.Format(logger.FormatProvider, entry).Length + logger.NewLine.Length;
+
+                // Note: The Preamble is not included in the buffer, and therefore its size
+                //       doesn't impact how many characters fit in the buffer for the first time 
+                msg = new string('a', expectedBufferSize - lineLength);
+
+                // Write the message and assert that the buffer was not filled (ie. flushed)
+                logger.Log(new LogEntry<int>(timestamp, LogLevel.Warn, 7, msg));
+                Assert.AreEqual(0, logger.BaseStream.Position);
+            }
+
+            // Write a message just 1 more character than the length of the buffer
+            using (StreamLogger<int> logger = loggerFactory(new MemoryStream()))
+            {
+                LogEntry<int> overflowMsg = new LogEntry<int>(timestamp, LogLevel.Warn, 7, msg + 'a');
+                string line = logger.Template.Format(logger.FormatProvider, overflowMsg) + logger.NewLine;
+
+                // Note: Without an explicit flush, only a buffer's length worth of characters
+                //       will be written at a time to the underlying stream
+                int expectedBytes = logger.Encoding.GetByteCount(line.Substring(0, expectedBufferSize));
+
+                // Write the message and assert that the buffer flushed when logging
+                logger.Log(overflowMsg);
+                Assert.AreEqual(logger.Encoding.Preamble.Length + expectedBytes, logger.BaseStream.Position);
+            }
+        }
+    }
+}

--- a/src/Sweetener.Logging.Test/ContextualLoggers/TemplateLogger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/TemplateLogger{T}.Test.cs
@@ -19,31 +19,31 @@ namespace Sweetener.Logging.Test
             // Constructor Overloads
             using (TemplateLogger<byte> logger = new MemoryTemplateLogger<byte>())
             {
-                Assert.AreEqual(LogLevel.Trace                      , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture          , logger.FormatProvider      );
-                Assert.AreEqual(TemplateLogger<byte>.DefaultTemplate, logger._template.ToString());
+                Assert.AreEqual(LogLevel.Trace                      , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture          , logger.FormatProvider     );
+                Assert.AreEqual(TemplateLogger<byte>.DefaultTemplate, logger.Template.ToString());
             }
 
             using (TemplateLogger<string> logger = new MemoryTemplateLogger<string>(LogLevel.Warn))
             {
-                Assert.AreEqual(LogLevel.Warn                         , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture            , logger.FormatProvider      );
-                Assert.AreEqual(TemplateLogger<string>.DefaultTemplate, logger._template.ToString());
+                Assert.AreEqual(LogLevel.Warn                         , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture            , logger.FormatProvider     );
+                Assert.AreEqual(TemplateLogger<string>.DefaultTemplate, logger.Template.ToString());
             }
 
             using (TemplateLogger<Guid> logger = new MemoryTemplateLogger<Guid>(LogLevel.Info, "<{pn}|{pid}> - {msg} {cxt}"))
             {
-                Assert.AreEqual(LogLevel.Info               , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture  , logger.FormatProvider      );
-                Assert.AreEqual("<{pn}|{pid}> - {msg} {cxt}", logger._template.ToString());
+                Assert.AreEqual(LogLevel.Info               , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture  , logger.FormatProvider     );
+                Assert.AreEqual("<{pn}|{pid}> - {msg} {cxt}", logger.Template.ToString());
             }
 
             CultureInfo esES = CultureInfo.GetCultureInfo("es-ES");
             using (TemplateLogger<TimeSpan> logger = new MemoryTemplateLogger<TimeSpan>(LogLevel.Error, esES, "[{tid}] {cxt} {msg}"))
             {
-                Assert.AreEqual(LogLevel.Error       , logger.MinLevel            );
-                Assert.AreEqual(esES                 , logger.FormatProvider      );
-                Assert.AreEqual("[{tid}] {cxt} {msg}", logger._template.ToString());
+                Assert.AreEqual(LogLevel.Error       , logger.MinLevel           );
+                Assert.AreEqual(esES                 , logger.FormatProvider     );
+                Assert.AreEqual("[{tid}] {cxt} {msg}", logger.Template.ToString());
             }
         }
 

--- a/src/Sweetener.Logging.Test/Loggers/ConsoleLogger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/ConsoleLogger.Test.cs
@@ -21,31 +21,31 @@ namespace Sweetener.Logging.Test
             // Constructor Overloads
             using (ConsoleLogger logger = new ConsoleLogger())
             {
-                Assert.AreEqual(LogLevel.Trace                , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture    , logger.FormatProvider      );
-                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger._template.ToString());
+                Assert.AreEqual(LogLevel.Trace                , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture    , logger.FormatProvider     );
+                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger.Template.ToString());
             }
 
             using (ConsoleLogger logger = new ConsoleLogger(LogLevel.Warn))
             {
-                Assert.AreEqual(LogLevel.Warn                 , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture    , logger.FormatProvider      );
-                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger._template.ToString());
+                Assert.AreEqual(LogLevel.Warn                 , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture    , logger.FormatProvider     );
+                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger.Template.ToString());
             }
 
             using (ConsoleLogger logger = new ConsoleLogger(LogLevel.Info, "<{pn}|{pid}> - {msg}"))
             {
-                Assert.AreEqual(LogLevel.Info             , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture, logger.FormatProvider      );
-                Assert.AreEqual("<{pn}|{pid}> - {msg}"    , logger._template.ToString());
+                Assert.AreEqual(LogLevel.Info             , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture, logger.FormatProvider     );
+                Assert.AreEqual("<{pn}|{pid}> - {msg}"    , logger.Template.ToString());
             }
 
             CultureInfo esES = CultureInfo.GetCultureInfo("es-ES");
             using (ConsoleLogger logger = new ConsoleLogger(LogLevel.Error, esES, "[{tid}] {msg}"))
             {
-                Assert.AreEqual(LogLevel.Error , logger.MinLevel            );
-                Assert.AreEqual(esES           , logger.FormatProvider      );
-                Assert.AreEqual("[{tid}] {msg}", logger._template.ToString());
+                Assert.AreEqual(LogLevel.Error , logger.MinLevel           );
+                Assert.AreEqual(esES           , logger.FormatProvider     );
+                Assert.AreEqual("[{tid}] {msg}", logger.Template.ToString());
             }
         }
 

--- a/src/Sweetener.Logging.Test/Loggers/Logger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/Logger.Test.cs
@@ -72,7 +72,7 @@ namespace Sweetener.Logging.Test
         }
 
         [TestMethod]
-        public void LogThrowIfDisposed()
+        public void ThrowObjectDisposedException()
         {
             Logger logger = new MemoryLogger();
             logger.Dispose();

--- a/src/Sweetener.Logging.Test/Loggers/StreamLogger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/StreamLogger.Test.cs
@@ -136,10 +136,10 @@ namespace Sweetener.Logging.Test
                 LogLevel.Debug,
                 frFr,
                 ">> {msg}",
-                Encoding.UTF8,
+                Encoding.UTF32,
                 2000,
                 true,
-                (stream) => new StreamLogger(stream, LogLevel.Debug, frFr, ">> {msg}", Encoding.UTF8, 2000, true));
+                (stream) => new StreamLogger(stream, LogLevel.Debug, frFr, ">> {msg}", Encoding.UTF32, 2000, true));
         }
 
         [TestMethod]

--- a/src/Sweetener.Logging.Test/Loggers/StreamLogger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/StreamLogger.Test.cs
@@ -1,0 +1,336 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Logging.Test
+{
+    [TestClass]
+    public class StreamLoggerTest
+    {
+        [TestMethod]
+        public void ConstructorExceptions()
+        {
+            CultureInfo jaJP = CultureInfo.GetCultureInfo("ja-JP");
+            CultureInfo ptBR = CultureInfo.GetCultureInfo("pt-BR");
+            Stream readOnlyStream = new MemoryStream(Array.Empty<byte>(), writable: false);
+
+            // StreamLogger(Stream)
+            Assert.ThrowsException<ArgumentException    >(() => new StreamLogger(readOnlyStream));
+            Assert.ThrowsException<ArgumentNullException>(() => new StreamLogger(null          ));
+
+            // StreamLogger(Stream, LogLevel)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger(readOnlyStream, LogLevel.Info));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(null          , LogLevel.Warn));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger(Stream.Null   , (LogLevel)42 ));
+
+            // StreamLogger(Stream, LogLevel, string)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger(readOnlyStream, LogLevel.Info , "{msg}"      ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(null          , LogLevel.Warn , "{msg}"      ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(Stream.Null   , LogLevel.Debug, null         ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger(Stream.Null   , (LogLevel)42  , "{msg}"      ));
+            Assert.ThrowsException<FormatException            >(() => new StreamLogger(Stream.Null   , LogLevel.Fatal, "Missing msg"));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger(readOnlyStream, LogLevel.Info , jaJP, "{msg}"      ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(null          , LogLevel.Warn , ptBR, "{msg}"      ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(Stream.Null   , LogLevel.Debug, ptBR, null         ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger(Stream.Null   , (LogLevel)42  , jaJP, "{msg}"      ));
+            Assert.ThrowsException<FormatException            >(() => new StreamLogger(Stream.Null   , LogLevel.Fatal, null, "Missing msg"));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger(readOnlyStream, LogLevel.Info , jaJP, "{msg}"      , Encoding.ASCII  ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(null          , LogLevel.Warn , ptBR, "{msg}"      , Encoding.UTF7   ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(Stream.Null   , LogLevel.Debug, ptBR, null         , Encoding.UTF8   ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(Stream.Null   , LogLevel.Warn , ptBR, "{msg}"      , null            ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger(Stream.Null   , (LogLevel)42  , jaJP, "{msg}"      , Encoding.UTF32  ));
+            Assert.ThrowsException<FormatException            >(() => new StreamLogger(Stream.Null   , LogLevel.Fatal, null, "Missing msg", Encoding.Unicode));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding, int)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger(readOnlyStream, LogLevel.Info , jaJP, "{msg}"      , Encoding.ASCII  ,  1234));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(null          , LogLevel.Warn , ptBR, "{msg}"      , Encoding.UTF7   ,  5678));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(Stream.Null   , LogLevel.Debug, ptBR, null         , Encoding.UTF8   ,  0910));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(Stream.Null   , LogLevel.Warn , ptBR, "{msg}"      , null            ,  1112));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger(Stream.Null   , (LogLevel)42  , jaJP, "{msg}"      , Encoding.UTF32  ,  1314));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger(Stream.Null   , LogLevel.Trace, jaJP, "{msg}"      , Encoding.Default, -1516));
+            Assert.ThrowsException<FormatException            >(() => new StreamLogger(Stream.Null   , LogLevel.Fatal, null, "Missing msg", Encoding.Unicode,  1718));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding, int, bool)
+            Assert.ThrowsException<ArgumentException          >(() => new StreamLogger(readOnlyStream, LogLevel.Info , jaJP, "{msg}"      , Encoding.ASCII  ,  1234, false));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(null          , LogLevel.Warn , ptBR, "{msg}"      , Encoding.UTF7   ,  5678, true ));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(Stream.Null   , LogLevel.Debug, ptBR, null         , Encoding.UTF8   ,  0910, false));
+            Assert.ThrowsException<ArgumentNullException      >(() => new StreamLogger(Stream.Null   , LogLevel.Warn , ptBR, "{msg}"      , null            ,  1112, true ));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger(Stream.Null   , (LogLevel)42  , jaJP, "{msg}"      , Encoding.UTF32  ,  1314, false));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new StreamLogger(Stream.Null   , LogLevel.Trace, jaJP, "{msg}"      , Encoding.Default, -1516, true ));
+            Assert.ThrowsException<FormatException            >(() => new StreamLogger(Stream.Null   , LogLevel.Fatal, null, "Missing msg", Encoding.Unicode,  1718, false));
+        }
+
+        [TestMethod]
+        public void Constructor()
+        {
+            CultureInfo frFr = CultureInfo.GetCultureInfo("fr-FR");
+
+            // StreamLogger(Stream)
+            AssertStreamLogger(
+                LogLevel.Trace,
+                CultureInfo.CurrentCulture,
+                StreamLogger.DefaultTemplate,
+                EncodingCache.UTF8NoBOM,
+                1024,
+                false,
+                (stream) => new StreamLogger(stream));
+
+            // StreamLogger(Stream, LogLevel)
+            AssertStreamLogger(
+                LogLevel.Warn,
+                CultureInfo.CurrentCulture,
+                StreamLogger.DefaultTemplate,
+                EncodingCache.UTF8NoBOM,
+                1024,
+                false,
+                (stream) => new StreamLogger(stream, LogLevel.Warn));
+
+            // StreamLogger(Stream, LogLevel, string)
+            AssertStreamLogger(
+                LogLevel.Error,
+                CultureInfo.CurrentCulture,
+                "{l} {msg}",
+                EncodingCache.UTF8NoBOM,
+                1024,
+                false,
+                (stream) => new StreamLogger(stream, LogLevel.Error, "{l} {msg}"));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string)
+            AssertStreamLogger(
+                LogLevel.Debug,
+                frFr,
+                ">> {msg}",
+                EncodingCache.UTF8NoBOM,
+                1024,
+                false,
+                (stream) => new StreamLogger(stream, LogLevel.Debug, frFr, ">> {msg}"));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding)
+            AssertStreamLogger(
+                LogLevel.Info,
+                frFr,
+                ">> {msg}",
+                Encoding.Unicode,
+                1024,
+                false,
+                (stream) => new StreamLogger(stream, LogLevel.Info, frFr, ">> {msg}", Encoding.Unicode));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding, int)
+            AssertStreamLogger(
+                LogLevel.Fatal,
+                frFr,
+                ">> {msg}",
+                Encoding.ASCII,
+                500,
+                false,
+                (stream) => new StreamLogger(stream, LogLevel.Fatal, frFr, ">> {msg}", Encoding.ASCII, 500));
+
+            // StreamLogger(Stream, LogLevel, FormatProvider, string, Encoding, int, bool)
+            AssertStreamLogger(
+                LogLevel.Debug,
+                frFr,
+                ">> {msg}",
+                Encoding.UTF8,
+                2000,
+                true,
+                (stream) => new StreamLogger(stream, LogLevel.Debug, frFr, ">> {msg}", Encoding.UTF8, 2000, true));
+        }
+
+        [TestMethod]
+        public void ThrowObjectDisposedException()
+        {
+            StreamLogger logger = new StreamLogger(Stream.Null);
+            logger.Dispose();
+
+            // Methods
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Log(default));
+            Assert.ThrowsException<ObjectDisposedException>(() => logger.Flush());
+        }
+
+        [TestMethod]
+        public void AutoFlush()
+        {
+            // AutoFlush = false
+            using (StreamLogger logger = new StreamLogger(new MemoryStream()))
+            {
+                Assert.IsFalse(logger.AutoFlush);
+
+                logger.Warn("Warning!");
+                Assert.AreEqual(0, logger.BaseStream.Position);
+            }
+
+            // AutoFlush = true
+            using (StreamLogger logger = new StreamLogger(new MemoryStream()) { AutoFlush = true })
+            {
+                Assert.IsTrue(logger.AutoFlush);
+
+                logger.Warn("Warning!");
+                Assert.AreNotEqual(0, logger.BaseStream.Position);
+            }
+        }
+
+        [TestMethod]
+        public void BaseStream()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            using (StreamLogger logger = new StreamLogger(stream))
+                Assert.AreEqual(stream, logger.BaseStream);
+        }
+
+        [TestMethod]
+        // Change name to not conflict with class
+        public void EncodingProperty()
+        {
+            // Default
+            using (StreamLogger logger = new StreamLogger(Stream.Null, LogLevel.Fatal, null, "{msg}"))
+                Assert.AreEqual(EncodingCache.UTF8NoBOM, logger.Encoding);
+
+            // Non-null
+            using (StreamLogger logger = new StreamLogger(Stream.Null, LogLevel.Fatal, null, "{msg}", Encoding.UTF32))
+                Assert.AreEqual(Encoding.UTF32, logger.Encoding);
+        }
+
+        [TestMethod]
+        public void IsSynchronized()
+        {
+            using (Logger logger = new StreamLogger(Stream.Null))
+                Assert.IsFalse(logger.IsSynchronized);
+        }
+
+        [TestMethod]
+        public void NewLine()
+        {
+            using (StreamLogger logger = new StreamLogger(Stream.Null))
+            {
+                // Default value
+                Assert.AreEqual(Environment.NewLine, logger.NewLine);
+
+                // Assign to a different value
+                logger.NewLine = "EOL";
+                Assert.AreEqual("EOL", logger.NewLine);
+
+                // Assign default using null
+                logger.NewLine = null;
+                Assert.AreEqual(Environment.NewLine, logger.NewLine);
+            }
+        }
+
+        [TestMethod]
+        public void SyncRoot()
+        {
+            using (Logger logger = new StreamLogger(Stream.Null))
+                Assert.AreEqual(logger, logger.SyncRoot);
+        }
+
+        [TestMethod]
+        public void Flush()
+        {
+            using (StreamLogger logger = new StreamLogger(new MemoryStream()))
+            {
+                Assert.IsFalse(logger.AutoFlush);
+
+                logger.Warn("Warning!");
+                Assert.AreEqual(0, logger.BaseStream.Position);
+
+                logger.Flush();
+                Assert.AreNotEqual(0, logger.BaseStream.Position);
+            }
+        }
+
+        [TestMethod]
+        public void Log()
+        {
+            using (StreamLogger logger = new StreamLogger(new MemoryStream(), LogLevel.Trace, CultureInfo.InvariantCulture, "[{ts:HH:mm:ss}] [{l,-5:F}] - {msg}"))
+            {
+                DateTime timestamp = new DateTime(2999, 12, 31, 23, 59, 57);
+
+                logger.Log(new LogEntry(timestamp              , LogLevel.Warn , "Hello" ));
+                logger.Log(new LogEntry(timestamp.AddSeconds(1), LogLevel.Info , "Stream"));
+                logger.Log(new LogEntry(timestamp.AddSeconds(2), LogLevel.Debug, "World" ));
+
+                logger.Flush();
+
+                // Read back the log entries
+                logger.BaseStream.Seek(0, SeekOrigin.Begin);
+                using (StreamReader reader = new StreamReader(logger.BaseStream))
+                {
+                    Assert.AreEqual("[23:59:57] [Warn ] - Hello" , reader.ReadLine());
+                    Assert.AreEqual("[23:59:58] [Info ] - Stream", reader.ReadLine());
+                    Assert.AreEqual("[23:59:59] [Debug] - World" , reader.ReadLine());
+                }
+            }
+        }
+
+        private static void AssertStreamLogger(
+            LogLevel                   expectedMinLevel,
+            IFormatProvider            expectedFormatProvider,
+            string                     expectedTemplate,
+            Encoding                   expectedEncoding,
+            int                        expectedBufferSize,
+            bool                       leaveOpen,
+            Func<Stream, StreamLogger> loggerFactory)
+        {
+            // Assert the various properties, except the buffer size
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (StreamLogger actual = loggerFactory(stream))
+                {
+                    Assert.AreEqual(expectedMinLevel      , actual.MinLevel           );
+                    Assert.AreEqual(expectedFormatProvider, actual.FormatProvider     );
+                    Assert.AreEqual(expectedTemplate      , actual.Template.ToString());
+                    Assert.AreEqual(expectedEncoding      , actual.Encoding           );
+                }
+
+                if (leaveOpen)
+                    Assert.AreEqual(expectedEncoding.Preamble.Length, stream.Position); // Preamble flushed
+                else
+                    Assert.ThrowsException<ObjectDisposedException>(() => stream.Position);
+            }
+
+            // Assert that the buffer size is expected
+            AssertBufferSize(expectedBufferSize, loggerFactory);
+        }
+
+        private static void AssertBufferSize(int expectedBufferSize, Func<Stream, StreamLogger> loggerFactory)
+        {
+            string msg;
+            DateTime timestamp = new DateTime(2019, 7, 2, 21, 37, 04);
+
+            // Write a message that is the same length as the internal buffer
+            using (StreamLogger logger = loggerFactory(new MemoryStream()))
+            {
+                LogEntry entry = new LogEntry(timestamp, LogLevel.Warn, string.Empty);
+                int lineLength = logger.Template.Format(logger.FormatProvider, entry).Length + logger.NewLine.Length;
+
+                // Note: The Preamble is not included in the buffer, and therefore its size
+                //       doesn't impact how many characters fit in the buffer for the first time 
+                msg = new string('a', expectedBufferSize - lineLength);
+
+                // Write the message and assert that the buffer was not filled (ie. flushed)
+                logger.Log(new LogEntry(timestamp, LogLevel.Warn, msg));
+                Assert.AreEqual(0, logger.BaseStream.Position);
+            }
+
+            // Write a message just 1 more character than the length of the buffer
+            using (StreamLogger logger = loggerFactory(new MemoryStream()))
+            {
+                LogEntry overflowMsg = new LogEntry(timestamp, LogLevel.Warn, msg + 'a');
+                string line = logger.Template.Format(logger.FormatProvider, overflowMsg) + logger.NewLine;
+
+                // Note: Without an explicit flush, only a buffer's length worth of characters
+                //       will be written at a time to the underlying stream
+                int expectedBytes = logger.Encoding.GetByteCount(line.Substring(0, expectedBufferSize));
+
+                // Write the message and assert that the buffer flushed when logging
+                logger.Log(overflowMsg);
+                Assert.AreEqual(logger.Encoding.Preamble.Length + expectedBytes, logger.BaseStream.Position);
+            }
+        }
+    }
+}

--- a/src/Sweetener.Logging.Test/Loggers/TemplateLogger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/TemplateLogger.Test.cs
@@ -19,31 +19,31 @@ namespace Sweetener.Logging.Test
             // Constructor Overloads
             using (TemplateLogger logger = new MemoryTemplateLogger())
             {
-                Assert.AreEqual(LogLevel.Trace                , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture    , logger.FormatProvider      );
-                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger._template.ToString());
+                Assert.AreEqual(LogLevel.Trace                , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture    , logger.FormatProvider     );
+                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger.Template.ToString());
             }
 
             using (TemplateLogger logger = new MemoryTemplateLogger(LogLevel.Warn))
             {
-                Assert.AreEqual(LogLevel.Warn                 , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture    , logger.FormatProvider      );
-                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger._template.ToString());
+                Assert.AreEqual(LogLevel.Warn                 , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture    , logger.FormatProvider     );
+                Assert.AreEqual(TemplateLogger.DefaultTemplate, logger.Template.ToString());
             }
 
             using (TemplateLogger logger = new MemoryTemplateLogger(LogLevel.Info, "<{pn}|{pid}> - {msg}"))
             {
-                Assert.AreEqual(LogLevel.Info             , logger.MinLevel            );
-                Assert.AreEqual(CultureInfo.CurrentCulture, logger.FormatProvider      );
-                Assert.AreEqual("<{pn}|{pid}> - {msg}"    , logger._template.ToString());
+                Assert.AreEqual(LogLevel.Info             , logger.MinLevel           );
+                Assert.AreEqual(CultureInfo.CurrentCulture, logger.FormatProvider     );
+                Assert.AreEqual("<{pn}|{pid}> - {msg}"    , logger.Template.ToString());
             }
 
             CultureInfo esES = CultureInfo.GetCultureInfo("es-ES");
             using (TemplateLogger logger = new MemoryTemplateLogger(LogLevel.Error, esES, "[{tid}] {msg}"))
             {
-                Assert.AreEqual(LogLevel.Error , logger.MinLevel            );
-                Assert.AreEqual(esES           , logger.FormatProvider      );
-                Assert.AreEqual("[{tid}] {msg}", logger._template.ToString());
+                Assert.AreEqual(LogLevel.Error , logger.MinLevel           );
+                Assert.AreEqual(esES           , logger.FormatProvider     );
+                Assert.AreEqual("[{tid}] {msg}", logger.Template.ToString());
             }
         }
 

--- a/src/Sweetener.Logging.Test/Templates/TemplateBuilder.Test.cs
+++ b/src/Sweetener.Logging.Test/Templates/TemplateBuilder.Test.cs
@@ -77,21 +77,21 @@ namespace Sweetener.Logging.Test
             #region Build()
 
             // Missing "msg" or "message"
-            Assert.ThrowsException<InvalidOperationException>(() => new TemplateBuilder("{ts}" ).Build());
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{ts}" ).Build());
 
             // Unexpected "cxt" or "context"
-            Assert.ThrowsException<InvalidOperationException>(() => new TemplateBuilder("{cxt}"    ).Build());
-            Assert.ThrowsException<InvalidOperationException>(() => new TemplateBuilder("{context}").Build());
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{cxt}"    ).Build());
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{context}").Build());
 
             #endregion
 
             #region Build<T>()
 
             // Missing "cxt" or "context"
-            Assert.ThrowsException<InvalidOperationException>(() => new TemplateBuilder("{msg}").Build<Guid>());
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{msg}").Build<Guid>());
 
             // Missing "msg" or "message"
-            Assert.ThrowsException<InvalidOperationException>(() => new TemplateBuilder("{cxt}").Build<Guid>());
+            Assert.ThrowsException<FormatException>(() => new TemplateBuilder("{cxt}").Build<Guid>());
 
             #endregion
         }

--- a/src/Sweetener.Logging/ContextualLoggers/ConsoleLogger{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/ConsoleLogger{T}.cs
@@ -71,9 +71,17 @@ namespace Sweetener.Logging
         protected override void Dispose(bool disposing)
         {
             if (!IsDisposed)
-                Console.Out.Flush();
-
-            base.Dispose(disposing);
+            {
+                try
+                {
+                    if (disposing)
+                        Console.Out.Flush();
+                }
+                finally
+                {
+                    base.Dispose(disposing);
+                }
+            }
         }
 
         // TODO: Should ConsoleLogger<T> override the logging methods to update the possible exceptions?

--- a/src/Sweetener.Logging/ContextualLoggers/Logger{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/Logger{T}.cs
@@ -135,8 +135,8 @@ namespace Sweetener.Logging
         /// </para>
         /// </remarks>
         /// <param name="disposing">
-        /// <see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/>
-        /// to release only unmanaged resources.
+        /// <see langword="true"/> to release both managed and unmanaged resources;
+        /// <see langword="false"/> to release only unmanaged resources.
         /// </param>
         protected virtual void Dispose(bool disposing)
         {

--- a/src/Sweetener.Logging/ContextualLoggers/StreamLogger{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/StreamLogger{T}.cs
@@ -1,0 +1,293 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace Sweetener.Logging
+{
+    /// <summary>
+    /// A <see cref="Logger{T}"/> that writes its entries to a <see cref="Stream"/> using
+    /// a particular <see cref="System.Text.Encoding"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the domain-specific context.</typeparam>
+    public class StreamLogger<T> : TemplateLogger<T>
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="StreamLogger{T}"/> will
+        /// flush its buffer to the underlying stream after fulfilling every logging request.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> to force <see cref="StreamLogger{T}"/> to flush its buffer;
+        /// otherwise, <see langword="false"/>.
+        /// </value>
+        public bool AutoFlush
+        {
+            get => _writer.AutoFlush;
+            set => _writer.AutoFlush = value;
+        }
+
+        /// <summary>
+        /// Gets the underlying stream that interfaces with a backing store.
+        /// </summary>
+        /// <value>The stream this <see cref="StreamLogger{T}"/> is writing to.</value>
+        public Stream BaseStream => _writer.BaseStream;
+
+        /// <summary>
+        /// Gets the <see cref="System.Text.Encoding"/> in which the logs are written.
+        /// </summary>
+        /// <value>
+        /// The <see cref="System.Text.Encoding"/> specified in the constructor for the
+        /// current instance, or <see cref="UTF8Encoding"/> if an encoding was not specified.
+        /// </value>
+        public Encoding Encoding => _writer.Encoding;
+
+        /// <summary>
+        /// Gets or sets the line terminator string used by the current <see cref="StreamLogger{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// The default value is <see cref="Environment.NewLine"/>, and if the <see cref="NewLine"/>
+        /// is set to <see langword="null"/> then the default value will be used.
+        /// </remarks>
+        /// <value>The line terminator string for the current <see cref="StreamLogger{T}"/>.</value>
+        public string NewLine
+        {
+            get => _writer.NewLine;
+            set => _writer.NewLine = value;
+        }
+
+        private readonly StreamWriter _writer;
+
+        private const int DefaultBufferSize = 1024;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger{T}"/> class for the
+        /// current culture that fulfills all logging requests and writes to the given
+        /// <see cref="Stream"/> using the default UTF-8 encoded template.
+        /// </summary>
+        /// <param name="stream">The stream to log to.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+        public StreamLogger(Stream stream)
+            : this(stream, LogLevel.Trace)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger{T}"/> class for the
+        /// current culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> the
+        /// default UTF-8 encoded template.
+        /// </summary>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minLevel"/> is an unknown value.</exception>
+        public StreamLogger(Stream stream, LogLevel minLevel)
+            : this(stream, minLevel, DefaultTemplate)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger{T}"/> class for the
+        /// current culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> using
+        /// a custom UTF-8 encoded template.
+        /// </summary>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> or <paramref name="template"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minLevel"/> is an unknown value.</exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public StreamLogger(Stream stream, LogLevel minLevel, string template)
+            : this(stream, minLevel, null, template)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger{T}"/> class for a
+        /// particular culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> using
+        /// a custom UTF-8 encoded template.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, the formatting
+        /// of the current culture is used.
+        /// </remarks>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> or <paramref name="template"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minLevel"/> is an unknown value.</exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public StreamLogger(Stream stream, LogLevel minLevel, IFormatProvider formatProvider, string template)
+            : this(stream, minLevel, formatProvider, template, EncodingCache.UTF8NoBOM)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger{T}"/> class for a
+        /// particular culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> using
+        /// a specified <see cref="System.Text.Encoding"/> and custom template.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, the formatting
+        /// of the current culture is used.
+        /// </remarks>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="stream"/>, <paramref name="template"/>, or
+        /// <paramref name="encoding"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minLevel"/> is an unknown value.</exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public StreamLogger(Stream stream, LogLevel minLevel, IFormatProvider formatProvider, string template, Encoding encoding)
+            : this(stream, minLevel, formatProvider, template, encoding, DefaultBufferSize)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger{T}"/> class for a
+        /// particular culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> using
+        /// a specified <see cref="System.Text.Encoding"/> and custom template.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, the formatting
+        /// of the current culture is used.
+        /// </remarks>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="bufferSize">The buffer size, in 16-bit characters.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="stream"/>, <paramref name="template"/>, or
+        /// <paramref name="encoding"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para><paramref name="minLevel"/> is an unknown value.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="bufferSize"/> is negative.</para>
+        /// </exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public StreamLogger(
+            Stream          stream,
+            LogLevel        minLevel,
+            IFormatProvider formatProvider,
+            string          template,
+            Encoding        encoding,
+            int             bufferSize)
+            : this(stream, minLevel, formatProvider, template, encoding, bufferSize, false)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger{T}"/> class for a
+        /// particular culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> using
+        /// a specified <see cref="System.Text.Encoding"/> and custom template.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, the formatting
+        /// of the current culture is used.
+        /// </remarks>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="bufferSize">The buffer size, in 16-bit characters.</param>
+        /// <param name="leaveOpen">
+        /// <see langword="true"/> to leave the stream open after the <see cref="StreamLogger{T}"/>
+        /// object is disposed; otherwise, <see langword="false"/>.
+        /// </param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="stream"/>, <paramref name="template"/>, or
+        /// <paramref name="encoding"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para><paramref name="minLevel"/> is an unknown value.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="bufferSize"/> is negative.</para>
+        /// </exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public StreamLogger(
+            Stream          stream,
+            LogLevel        minLevel,
+            IFormatProvider formatProvider,
+            string          template,
+            Encoding        encoding,
+            int             bufferSize,
+            bool            leaveOpen)
+            : base(minLevel, formatProvider, template)
+        {
+            _writer = new StreamWriter(stream, encoding, bufferSize, leaveOpen);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the <see cref="StreamLogger{T}"/> and
+        /// optionally releases the managed resources.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This method is called by <see cref="Logger{T}.Dispose()"/> and possible Finalize in a
+        /// derived class. By default, this method specifies the <paramref name="disposing"/>
+        /// parameter as <see langword="true"/>. Any Finalize implementation specifies the
+        /// <paramref name="disposing"/> parameter as <see langword="false"/>.
+        /// </para>
+        /// <para>
+        /// When the <paramref name="disposing"/> parameter is <see langword="true"/>, this method
+        /// releases all resources held by any managed objects that this <see cref="Logger{T}"/>
+        /// references. This method invokes the <see cref="IDisposable.Dispose"/> method
+        /// of each referenced object.
+        /// </para>
+        /// </remarks>
+        /// <param name="disposing">
+        /// <see langword="true"/> to release both managed and unmanaged resources;
+        /// <see langword="false"/> to release only unmanaged resources.
+        /// </param>
+        protected override void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+            {
+                try
+                {
+                    if (disposing)
+                        _writer.Dispose();
+                }
+                finally
+                {
+                    base.Dispose(disposing);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears all buffers for the current logger and causes any buffered data to
+        /// be written to the underlying stream.
+        /// </summary>
+        /// <exception cref="EncoderFallbackException">
+        /// The <see cref="Encoding"/> does not support displaying half of a Unicode surrogate pair.
+        /// </exception>
+        /// <exception cref="IOException">An I/O error has occurred.</exception>
+        /// <exception cref="ObjectDisposedException">The current logger is disposed.</exception>
+        public void Flush()
+            => _writer.Flush();
+
+        /// <summary>
+        /// Writes the <paramref name="message"/> to the stream.
+        /// </summary>
+        /// <param name="message">The value to be written.</param>
+        /// <exception cref="IOException">An I/O error has occurred.</exception>
+        /// <exception cref="ObjectDisposedException">The current logger is disposed.</exception>
+        protected override void WriteLine(string message)
+            => _writer.WriteLine(message);
+    }
+}

--- a/src/Sweetener.Logging/ContextualLoggers/TemplateLogger{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/TemplateLogger{T}.cs
@@ -9,9 +9,9 @@ namespace Sweetener.Logging
     /// <typeparam name="T">The type of the domain-specific context.</typeparam>
     public abstract class TemplateLogger<T> : Logger<T>
     {
-        internal const string DefaultTemplate = "[{ts:O}] [{level:F}] {cxt} {msg}";
+        internal ILogEntryTemplate<T> Template { get; }
 
-        internal readonly ILogEntryTemplate<T> _template;
+        internal const string DefaultTemplate = "[{ts:O}] [{level:F}] {cxt} {msg}";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TemplateLogger{T}"/> class for the
@@ -64,7 +64,7 @@ namespace Sweetener.Logging
             : base(minLevel, formatProvider)
         {
             TemplateBuilder templateBuilder = new TemplateBuilder(template);
-            _template = templateBuilder.Build<T>();
+            Template = templateBuilder.Build<T>();
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Sweetener.Logging
         /// </summary>
         /// <param name="logEntry">A log entry which consists of the message and its context.</param>
         protected internal override void Log(LogEntry<T> logEntry)
-            => WriteLine(_template.Format(FormatProvider, logEntry));
+            => WriteLine(Template.Format(FormatProvider, logEntry));
 
         /// <summary>
         /// Writes the <paramref name="message"/> to the log.

--- a/src/Sweetener.Logging/ContextualLoggers/Templates/TemplateBuilder.Build{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/Templates/TemplateBuilder.Build{T}.cs
@@ -8,10 +8,10 @@ namespace Sweetener.Logging
         public virtual ILogEntryTemplate<T> Build<T>()
         {
             if (!_indices.ContainsKey(TemplateParameter.Context))
-                throw new InvalidOperationException("Template is missing required 'cxt' or 'context' parameter");
+                throw new FormatException("Template is missing required 'cxt' or 'context' parameter");
 
             if (!_indices.ContainsKey(TemplateParameter.Message))
-                throw new InvalidOperationException("Template is missing required 'msg' or 'message' parameter");
+                throw new FormatException("Template is missing required 'msg' or 'message' parameter");
 
             return new LogEntryTemplate<T>(_template, _format);
         }

--- a/src/Sweetener.Logging/EncodingCache.cs
+++ b/src/Sweetener.Logging/EncodingCache.cs
@@ -1,0 +1,11 @@
+﻿// A familiar class from CoreFX that defines commonly used encodings
+
+using System.Text;
+
+namespace Sweetener.Logging
+{
+    internal static class EncodingCache
+    {
+        public static readonly Encoding UTF8NoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    }
+}

--- a/src/Sweetener.Logging/Loggers/ConsoleLogger.cs
+++ b/src/Sweetener.Logging/Loggers/ConsoleLogger.cs
@@ -70,9 +70,17 @@ namespace Sweetener.Logging
         protected override void Dispose(bool disposing)
         {
             if (!IsDisposed)
-                Console.Out.Flush();
-
-            base.Dispose(disposing);
+            {
+                try
+                {
+                    if (disposing)
+                        Console.Out.Flush();
+                }
+                finally
+                {
+                    base.Dispose(disposing);
+                }
+            }
         }
 
         // TODO: Should ConsoleLogger override the logging methods to update the possible exceptions?

--- a/src/Sweetener.Logging/Loggers/Logger.cs
+++ b/src/Sweetener.Logging/Loggers/Logger.cs
@@ -134,8 +134,8 @@ namespace Sweetener.Logging
         /// </para>
         /// </remarks>
         /// <param name="disposing">
-        /// <see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/>
-        /// to release only unmanaged resources.
+        /// <see langword="true"/> to release both managed and unmanaged resources;
+        /// <see langword="false"/> to release only unmanaged resources.
         /// </param>
         protected virtual void Dispose(bool disposing)
         {

--- a/src/Sweetener.Logging/Loggers/StreamLogger.cs
+++ b/src/Sweetener.Logging/Loggers/StreamLogger.cs
@@ -1,0 +1,292 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace Sweetener.Logging
+{
+    /// <summary>
+    /// A <see cref="Logger"/> that writes its entries to a <see cref="Stream"/> using
+    /// a particular <see cref="System.Text.Encoding"/>.
+    /// </summary>
+    public class StreamLogger : TemplateLogger
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="StreamLogger"/> will
+        /// flush its buffer to the underlying stream after fulfilling every logging request.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> to force <see cref="StreamLogger"/> to flush its buffer;
+        /// otherwise, <see langword="false"/>.
+        /// </value>
+        public bool AutoFlush
+        {
+            get => _writer.AutoFlush;
+            set => _writer.AutoFlush = value;
+        }
+
+        /// <summary>
+        /// Gets the underlying stream that interfaces with a backing store.
+        /// </summary>
+        /// <value>The stream this <see cref="StreamLogger"/> is writing to.</value>
+        public Stream BaseStream => _writer.BaseStream;
+
+        /// <summary>
+        /// Gets the <see cref="System.Text.Encoding"/> in which the logs are written.
+        /// </summary>
+        /// <value>
+        /// The <see cref="System.Text.Encoding"/> specified in the constructor for the
+        /// current instance, or <see cref="UTF8Encoding"/> if an encoding was not specified.
+        /// </value>
+        public Encoding Encoding => _writer.Encoding;
+
+        /// <summary>
+        /// Gets or sets the line terminator string used by the current <see cref="StreamLogger"/>.
+        /// </summary>
+        /// <remarks>
+        /// The default value is <see cref="Environment.NewLine"/>, and if the <see cref="NewLine"/>
+        /// is set to <see langword="null"/> then the default value will be used.
+        /// </remarks>
+        /// <value>The line terminator string for the current <see cref="StreamLogger"/>.</value>
+        public string NewLine
+        {
+            get => _writer.NewLine;
+            set => _writer.NewLine = value;
+        }
+
+        private readonly StreamWriter _writer;
+
+        private const int DefaultBufferSize = 1024;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger"/> class for the
+        /// current culture that fulfills all logging requests and writes to the given
+        /// <see cref="Stream"/> using the default UTF-8 encoded template.
+        /// </summary>
+        /// <param name="stream">The stream to log to.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+        public StreamLogger(Stream stream)
+            : this(stream, LogLevel.Trace)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger"/> class for the
+        /// current culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> the
+        /// default UTF-8 encoded template.
+        /// </summary>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minLevel"/> is an unknown value.</exception>
+        public StreamLogger(Stream stream, LogLevel minLevel)
+            : this(stream, minLevel, DefaultTemplate)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger"/> class for the
+        /// current culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> using
+        /// a custom UTF-8 encoded template.
+        /// </summary>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> or <paramref name="template"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minLevel"/> is an unknown value.</exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public StreamLogger(Stream stream, LogLevel minLevel, string template)
+            : this(stream, minLevel, null, template)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger"/> class for a
+        /// particular culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> using
+        /// a custom UTF-8 encoded template.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, the formatting
+        /// of the current culture is used.
+        /// </remarks>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> or <paramref name="template"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minLevel"/> is an unknown value.</exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public StreamLogger(Stream stream, LogLevel minLevel, IFormatProvider formatProvider, string template)
+            : this(stream, minLevel, formatProvider, template, EncodingCache.UTF8NoBOM)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger"/> class for a
+        /// particular culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> using
+        /// a specified <see cref="System.Text.Encoding"/> and custom template.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, the formatting
+        /// of the current culture is used.
+        /// </remarks>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="stream"/>, <paramref name="template"/>, or
+        /// <paramref name="encoding"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minLevel"/> is an unknown value.</exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public StreamLogger(Stream stream, LogLevel minLevel, IFormatProvider formatProvider, string template, Encoding encoding)
+            : this(stream, minLevel, formatProvider, template, encoding, DefaultBufferSize)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger"/> class for a
+        /// particular culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> using
+        /// a specified <see cref="System.Text.Encoding"/> and custom template.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, the formatting
+        /// of the current culture is used.
+        /// </remarks>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="bufferSize">The buffer size, in 16-bit characters.</param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="stream"/>, <paramref name="template"/>, or
+        /// <paramref name="encoding"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para><paramref name="minLevel"/> is an unknown value.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="bufferSize"/> is negative.</para>
+        /// </exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public StreamLogger(
+            Stream          stream,
+            LogLevel        minLevel,
+            IFormatProvider formatProvider,
+            string          template,
+            Encoding        encoding,
+            int             bufferSize)
+            : this(stream, minLevel, formatProvider, template, encoding, bufferSize, false)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamLogger"/> class for a
+        /// particular culture that fulfills all logging requests above a specified minimum
+        /// <see cref="LogLevel"/> and writes them to the given <see cref="Stream"/> using
+        /// a specified <see cref="System.Text.Encoding"/> and custom template.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, the formatting
+        /// of the current culture is used.
+        /// </remarks>
+        /// <param name="stream">The stream to log to.</param>
+        /// <param name="minLevel">The minimum level of log requests that will be fulfilled.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> object for a specific culture.</param>
+        /// <param name="template">A format string that describes the layout of each log entry.</param>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="bufferSize">The buffer size, in 16-bit characters.</param>
+        /// <param name="leaveOpen">
+        /// <see langword="true"/> to leave the stream open after the <see cref="StreamLogger"/>
+        /// object is disposed; otherwise, <see langword="false"/>.
+        /// </param>
+        /// <exception cref="ArgumentException"><paramref name="stream"/> is not writable.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="stream"/>, <paramref name="template"/>, or
+        /// <paramref name="encoding"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para><paramref name="minLevel"/> is an unknown value.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="bufferSize"/> is negative.</para>
+        /// </exception>
+        /// <exception cref="FormatException">The <paramref name="template"/> is not formatted correctly.</exception>
+        public StreamLogger(
+            Stream          stream,
+            LogLevel        minLevel,
+            IFormatProvider formatProvider,
+            string          template,
+            Encoding        encoding,
+            int             bufferSize,
+            bool            leaveOpen)
+            : base(minLevel, formatProvider, template)
+        {
+            _writer = new StreamWriter(stream, encoding, bufferSize, leaveOpen);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the <see cref="StreamLogger"/> and
+        /// optionally releases the managed resources.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This method is called by <see cref="Logger.Dispose()"/> and possible Finalize in a
+        /// derived class. By default, this method specifies the <paramref name="disposing"/>
+        /// parameter as <see langword="true"/>. Any Finalize implementation specifies the
+        /// <paramref name="disposing"/> parameter as <see langword="false"/>.
+        /// </para>
+        /// <para>
+        /// When the <paramref name="disposing"/> parameter is <see langword="true"/>, this method
+        /// releases all resources held by any managed objects that this <see cref="Logger"/>
+        /// references. This method invokes the <see cref="IDisposable.Dispose"/> method
+        /// of each referenced object.
+        /// </para>
+        /// </remarks>
+        /// <param name="disposing">
+        /// <see langword="true"/> to release both managed and unmanaged resources;
+        /// <see langword="false"/> to release only unmanaged resources.
+        /// </param>
+        protected override void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+            {
+                try
+                {
+                    if (disposing)
+                        _writer.Dispose();
+                }
+                finally
+                {
+                    base.Dispose(disposing);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears all buffers for the current logger and causes any buffered data to
+        /// be written to the underlying stream.
+        /// </summary>
+        /// <exception cref="EncoderFallbackException">
+        /// The <see cref="Encoding"/> does not support displaying half of a Unicode surrogate pair.
+        /// </exception>
+        /// <exception cref="IOException">An I/O error has occurred.</exception>
+        /// <exception cref="ObjectDisposedException">The current logger is disposed.</exception>
+        public void Flush()
+            => _writer.Flush();
+
+        /// <summary>
+        /// Writes the <paramref name="message"/> to the stream.
+        /// </summary>
+        /// <param name="message">The value to be written.</param>
+        /// <exception cref="IOException">An I/O error has occurred.</exception>
+        /// <exception cref="ObjectDisposedException">The current logger is disposed.</exception>
+        protected override void WriteLine(string message)
+            => _writer.WriteLine(message);
+    }
+}

--- a/src/Sweetener.Logging/Loggers/TemplateLogger.cs
+++ b/src/Sweetener.Logging/Loggers/TemplateLogger.cs
@@ -8,9 +8,9 @@ namespace Sweetener.Logging
     /// </summary>
     public abstract class TemplateLogger : Logger
     {
-        internal const string DefaultTemplate = "[{ts:O}] [{level:F}] {msg}";
+        internal ILogEntryTemplate Template { get; }
 
-        internal readonly ILogEntryTemplate _template;
+        internal const string DefaultTemplate = "[{ts:O}] [{level:F}] {msg}";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TemplateLogger"/> class for the
@@ -63,7 +63,7 @@ namespace Sweetener.Logging
             : base(minLevel, formatProvider)
         {
             TemplateBuilder templateBuilder = new TemplateBuilder(template);
-            _template = templateBuilder.Build();
+            Template = templateBuilder.Build();
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Sweetener.Logging
         /// </summary>
         /// <param name="logEntry">A log entry which consists of the message and its context.</param>
         protected internal override void Log(LogEntry logEntry)
-            => WriteLine(_template.Format(FormatProvider, logEntry));
+            => WriteLine(Template.Format(FormatProvider, logEntry));
 
         /// <summary>
         /// Writes the <paramref name="message"/> to the log.

--- a/src/Sweetener.Logging/Loggers/Templates/TemplateBuilder.Build.cs
+++ b/src/Sweetener.Logging/Loggers/Templates/TemplateBuilder.Build.cs
@@ -8,10 +8,10 @@ namespace Sweetener.Logging
         public virtual ILogEntryTemplate Build()
         {
             if (_indices.ContainsKey(TemplateParameter.Context))
-                throw new InvalidOperationException("Template cannot contain 'cxt' or 'context' parameter");
+                throw new FormatException("Template cannot contain 'cxt' or 'context' parameter");
 
             if (!_indices.ContainsKey(TemplateParameter.Message))
-                throw new InvalidOperationException("Template is missing required 'msg' or 'message' parameter");
+                throw new FormatException("Template is missing required 'msg' or 'message' parameter");
 
             // The use of an interface will force the template (a struct) to box, but
             // it will provide a hook for polymorphism and further cement the relationship

--- a/src/Sweetener.Logging/Loggers/Templates/TemplateBuilder.Build.cs
+++ b/src/Sweetener.Logging/Loggers/Templates/TemplateBuilder.Build.cs
@@ -7,6 +7,9 @@ namespace Sweetener.Logging
     {
         public virtual ILogEntryTemplate Build()
         {
+            // While InvalidOperationException may be more semantically appropriate,
+            // FormatException makes more sense to callers of the ctor for TemplateLogger 
+            // and its various derived classes.
             if (_indices.ContainsKey(TemplateParameter.Context))
                 throw new FormatException("Template cannot contain 'cxt' or 'context' parameter");
 


### PR DESCRIPTION
- Create new loggers for writing log entries to a [`Stream`](https://docs.microsoft.com/en-us/dotnet/api/system.io.stream?view=netstandard-2.0)
- Model APIs on [`StreamWriter`](https://docs.microsoft.com/en-us/dotnet/api/system.io.streamwriter?view=netstandard-2.0)
    - While the API could have wrapped a `StreamWriter` or [`TextWriter`](https://docs.microsoft.com/en-us/dotnet/api/system.io.textwriter?view=netstandard-2.0) instead of a `Stream`, a few points suggested the wrapping of `Stream`:
        - Semantically, the logger is writing to a `Stream` and not necessarily writing using an arbitrary `TextWriter`. The emphasis should be on the different `Streams` and not the different `TextWriters`, like [`HtmlTextWriter`](https://docs.microsoft.com/en-us/dotnet/api/system.web.ui.htmltextwriter?view=netframework-4.8)
        - The API similarities should help developers more easily understand how to use `StreamLogger` and `StreamLogger<T>` if they have experience with `StreamWriter`
        - While the constructors could be more succinct by passing a `TextWriter`, the code written by a user would not necessarily be any shorter
- Refactor the `Dipose` implementations in `ConsoleLogger` and `ConsoleLogger<T>`