### PR TITLE
Add LogLevel Validation in Logging Methods

### DIFF
--- a/src/Sweetener.Logging.Test/ContextualLoggers/Logger{T}.Test.cs
+++ b/src/Sweetener.Logging.Test/ContextualLoggers/Logger{T}.Test.cs
@@ -45,7 +45,14 @@ namespace Sweetener.Logging.Test
                 Assert.ThrowsException<ArgumentNullException>(() => logger.Log(LogLevel.Warn , 0, null, 1, 2, 3, 4));
                 Assert.ThrowsException<ArgumentNullException>(() => logger.Log(LogLevel.Fatal, 0, "{0}", args     ));
 
-                // Format Exception
+                // ArgumentOutOfRangeException
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => logger.Log((LogLevel)101, 0, "1"                             ));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => logger.Log((LogLevel)102, 0, "1 {0}"            , 2          ));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => logger.Log((LogLevel)103, 0, "1 {0} {1}"        , 2, 3       ));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => logger.Log((LogLevel)104, 0, "1 {0} {1} {2}"    , 2, 3, 4    ));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => logger.Log((LogLevel)105, 0, "1 {0} {1} {2} {3}", 2, 3, 4, 5 ));
+
+                // FormatException
                 Assert.ThrowsException<FormatException>(() => logger.Log(LogLevel.Fatal, 0, "{0:Y}", 1         ));
                 Assert.ThrowsException<FormatException>(() => logger.Log(LogLevel.Error, 0, "{0:Y}", 1, 2      ));
                 Assert.ThrowsException<FormatException>(() => logger.Log(LogLevel.Warn , 0, "{0:Y}", 1, 2, 3   ));

--- a/src/Sweetener.Logging.Test/Loggers/Logger.Test.cs
+++ b/src/Sweetener.Logging.Test/Loggers/Logger.Test.cs
@@ -45,7 +45,14 @@ namespace Sweetener.Logging.Test
                 Assert.ThrowsException<ArgumentNullException>(() => logger.Log(LogLevel.Warn , null, 1, 2, 3, 4));
                 Assert.ThrowsException<ArgumentNullException>(() => logger.Log(LogLevel.Fatal, "{0}", args     ));
 
-                // Format Exception
+                // ArgumentOutOfRangeException
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => logger.Log((LogLevel)101, "1"                             ));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => logger.Log((LogLevel)102, "1 {0}"            , 2          ));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => logger.Log((LogLevel)103, "1 {0} {1}"        , 2, 3       ));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => logger.Log((LogLevel)104, "1 {0} {1} {2}"    , 2, 3, 4    ));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => logger.Log((LogLevel)105, "1 {0} {1} {2} {3}", 2, 3, 4, 5 ));
+
+                // FormatException
                 Assert.ThrowsException<FormatException>(() => logger.Log(LogLevel.Fatal, "{0:Y}", 1         ));
                 Assert.ThrowsException<FormatException>(() => logger.Log(LogLevel.Error, "{0:Y}", 1, 2      ));
                 Assert.ThrowsException<FormatException>(() => logger.Log(LogLevel.Warn , "{0:Y}", 1, 2, 3   ));

--- a/src/Sweetener.Logging/ContextualLoggers/LogEntry{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/LogEntry{T}.cs
@@ -49,6 +49,19 @@ namespace Sweetener.Logging
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LogEntry"/> structure that
+        /// associates the specified message with additional contextual information
+        /// at the current UTC time.
+        /// </summary>
+        /// <param name="level">The <see cref="LogLevel"/> associated with the <paramref name="message"/>.</param>
+        /// <param name="context">The domain-specific information that provides additional context about the entry.</param>
+        /// <param name="message">The value to be logged.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
+        public LogEntry(LogLevel level, T context, string message)
+            : this(DateTime.UtcNow, level, context, message)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogEntry"/> structure that
         /// associates the specified message with additional contextual information.
         /// </summary>
         /// <param name="timestamp">The timestamp when the log request was made.</param>
@@ -71,19 +84,6 @@ namespace Sweetener.Logging
             ThreadId   = currentThread.ManagedThreadId;
             ThreadName = currentThread.Name;
             Timestamp  = timestamp;
-        }
-
-        // This ctor is called internally where we don't need additional checks
-        internal LogEntry(LogLevel level, T context, string message)
-        {
-            Thread currentThread = Thread.CurrentThread;
-
-            Context    = context;
-            Level      = level;
-            Message    = message;
-            ThreadId   = currentThread.ManagedThreadId;
-            ThreadName = currentThread.Name;
-            Timestamp  = DateTime.UtcNow;
         }
     }
 }

--- a/src/Sweetener.Logging/ContextualLoggers/Logger{T}.cs
+++ b/src/Sweetener.Logging/ContextualLoggers/Logger{T}.cs
@@ -113,6 +113,7 @@ namespace Sweetener.Logging
         /// The domain-specific information that provides additional context surrounding the message.
         /// </param>
         /// <param name="message">The message to be logged.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
         /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
         public virtual void Log(LogLevel level, T context, string message)
         {
@@ -136,6 +137,7 @@ namespace Sweetener.Logging
         /// <param name="format">A composite format string.</param>
         /// <param name="arg0">An object to format and log.</param>
         /// <exception cref="ArgumentNullException"><paramref name="format"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
         /// <exception cref="FormatException">
         /// <para><paramref name="format"/> is not a valid composite format string.</para>
         /// <para>-or-</para>
@@ -168,6 +170,7 @@ namespace Sweetener.Logging
         /// <param name="arg0">The first object to format and log.</param>
         /// <param name="arg1">The second object to format and log.</param>
         /// <exception cref="ArgumentNullException"><paramref name="format"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
         /// <exception cref="FormatException">
         /// <para><paramref name="format"/> is not a valid composite format string.</para>
         /// <para>-or-</para>
@@ -201,6 +204,7 @@ namespace Sweetener.Logging
         /// <param name="arg1">The second object to format and log.</param>
         /// <param name="arg2">The third object to format and log.</param>
         /// <exception cref="ArgumentNullException"><paramref name="format"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
         /// <exception cref="FormatException">
         /// <para><paramref name="format"/> is not a valid composite format string.</para>
         /// <para>-or-</para>
@@ -234,6 +238,7 @@ namespace Sweetener.Logging
         /// <exception cref="ArgumentNullException">
         /// <paramref name="format"/> or <paramref name="args"/> is <see langword="null"/>.
         /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
         /// <exception cref="FormatException">
         /// <para><paramref name="format"/> is not a valid composite format string.</para>
         /// <para>-or-</para>

--- a/src/Sweetener.Logging/Loggers/LogEntry.cs
+++ b/src/Sweetener.Logging/Loggers/LogEntry.cs
@@ -43,6 +43,18 @@ namespace Sweetener.Logging
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LogEntry"/> structure that
+        /// associates the specified message with additional contextual information
+        /// at the current UTC time.
+        /// </summary>
+        /// <param name="level">The <see cref="LogLevel"/> associated with the <see cref="Message"/>.</param>
+        /// <param name="message">The value to be logged.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
+        public LogEntry(LogLevel level, string message)
+            : this(DateTime.UtcNow, level, message)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogEntry"/> structure that
         /// associates the specified message with additional contextual information.
         /// </summary>
         /// <param name="timestamp">The timestamp when the log request was made.</param>
@@ -63,18 +75,6 @@ namespace Sweetener.Logging
             ThreadId   = currentThread.ManagedThreadId;
             ThreadName = currentThread.Name;
             Timestamp  = timestamp;
-        }
-
-        // This ctor is called internally where we don't need additional checks
-        internal LogEntry(LogLevel level, string message)
-        {
-            Thread currentThread = Thread.CurrentThread;
-
-            Level      = level;
-            Message    = message;
-            ThreadId   = currentThread.ManagedThreadId;
-            ThreadName = currentThread.Name;
-            Timestamp  = DateTime.UtcNow;
         }
     }
 }

--- a/src/Sweetener.Logging/Loggers/Logger.cs
+++ b/src/Sweetener.Logging/Loggers/Logger.cs
@@ -108,6 +108,7 @@ namespace Sweetener.Logging
         /// </remarks>
         /// <param name="level">The <see cref="LogLevel"/> associated with the message.</param>
         /// <param name="message">The message to be logged.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
         /// <exception cref="ObjectDisposedException">The logger is disposed.</exception>
         public virtual void Log(LogLevel level, string message)
         {
@@ -127,6 +128,7 @@ namespace Sweetener.Logging
         /// <param name="format">A composite format string.</param>
         /// <param name="arg0">An object to format and log.</param>
         /// <exception cref="ArgumentNullException"><paramref name="format"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
         /// <exception cref="FormatException">
         /// <para><paramref name="format"/> is not a valid composite format string.</para>
         /// <para>-or-</para>
@@ -155,6 +157,7 @@ namespace Sweetener.Logging
         /// <param name="arg0">The first object to format and log.</param>
         /// <param name="arg1">The second object to format and log.</param>
         /// <exception cref="ArgumentNullException"><paramref name="format"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
         /// <exception cref="FormatException">
         /// <para><paramref name="format"/> is not a valid composite format string.</para>
         /// <para>-or-</para>
@@ -184,6 +187,7 @@ namespace Sweetener.Logging
         /// <param name="arg1">The second object to format and log.</param>
         /// <param name="arg2">The third object to format and log.</param>
         /// <exception cref="ArgumentNullException"><paramref name="format"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
         /// <exception cref="FormatException">
         /// <para><paramref name="format"/> is not a valid composite format string.</para>
         /// <para>-or-</para>
@@ -213,6 +217,7 @@ namespace Sweetener.Logging
         /// <exception cref="ArgumentNullException">
         /// <paramref name="format"/> or <paramref name="args"/> is <see langword="null"/>.
         /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="level"/> is an unknown value.</exception>
         /// <exception cref="FormatException">
         /// <para><paramref name="format"/> is not a valid composite format string.</para>
         /// <para>-or-</para>


### PR DESCRIPTION
- Change `LogEntry` and `LogEntry<T>` ctor that uses`DateTime.UtcNow` to be `public`
    - Add check on `LogLevel`
- Leverage checks on `LogLevel` in `Log` methods
- Update tests accordingly