### PR TITLE
Add NuGet Metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,5 @@ msbuild.binlog
 *.nuget.props
 *.nuget.targets
 *.nupkg
+*.snupkg
 **/packages/*

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Each Sweetener library follows the same set of principles:
 4. Ensure compatability across .NET implementations
 
 ## Table of Contents
-  1. [Libraries](#Libraries)
-     1. [Reliability](#Reliability)
-  2. [License](#License)
+1. [Libraries](#Libraries)
+    1. [Reliability](#Reliability)
+2. [License](#License)
 
 ## Libraries
 ### Reliability

--- a/docs/ReleaseNotes/Sweetener.Reliability.md
+++ b/docs/ReleaseNotes/Sweetener.Reliability.md
@@ -1,0 +1,8 @@
+# Release Notes
+
+## 1.0.0-alpha.1
+- Initial pre-release
+- Defines the following APIs:
+    - Reliable classes that wrap user-defined delegates
+    - Delegate extensions that provide the same reliable semantics for the most common scenarios
+    - Policies, and their corresponding handlers, that determine execution behavior

--- a/eng/pipelines/Build.Template.yml
+++ b/eng/pipelines/Build.Template.yml
@@ -60,6 +60,7 @@ jobs:
       command: 'pack'
       packagesToPack: 'src/${{ parameters.Project }}/${{ parameters.Project }}.csproj'
       nobuild: true
+      verbosityPack: 'normal'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Build Artifacts'

--- a/eng/pipelines/Build.Template.yml
+++ b/eng/pipelines/Build.Template.yml
@@ -13,22 +13,23 @@ jobs:
 
   steps:
   - task: DotNetCoreCLI@2
-    displayName: 'Build ${{ parameters.Project }}'
+    displayName: 'Build'
     inputs:
       command: 'build'
       projects: |
         src/${{ parameters.Project }}/${{ parameters.Project }}.csproj
         src/${{ parameters.Project }}.Test/${{ parameters.Project }}.Test.csproj
-      arguments: '-c $(BuildConfiguration)'
+      arguments: '-c $(BuildConfiguration) -p:ContinuousIntegrationBuild=true'
 
   - task: DownloadSecureFile@1
     name: SigningKey
     displayName: 'Download Signing Key'
     inputs:
       secureFile: 'Sweetener.snk'
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
   - task: PowerShell@2
-    displayName: 'Sign ${{ parameters.Project }}'
+    displayName: 'Enhanced Strong Name Signing'
     inputs:
       targetType: 'inline'
       script: |
@@ -38,11 +39,24 @@ jobs:
             Start-Process -FilePath "${{ parameters.netfxTools }}/sn.exe" -ArgumentList "-Ra","$assembly","$(SigningKey.SecureFilePath)" -NoNewWindow -Wait
         }
       pwsh: true
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
   # Note that "Debug" code coverage may result in inaccurate code coverage metrics
   - task: DotNetCoreCLI@2
-    displayName: 'Test ${{ parameters.Project }}'
+    displayName: 'Test'
     inputs:
       command: 'test'
       projects: 'src/${{ parameters.Project }}.Test/${{ parameters.Project }}.Test.csproj'
       arguments: '-c $(BuildConfiguration) --no-build --collect "Code Coverage" -s "$(Build.Repository.LocalPath)/src/CodeCoverage.runsettings" -v normal'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Pack'
+    inputs:
+      command: 'pack'
+      projects: 'src/${{ parameters.Project }}/${{ parameters.Project }}.csproj'
+      nobuild: true
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Build Artifacts'
+    inputs:
+      artifactName: 'pkg'

--- a/eng/pipelines/Build.Template.yml
+++ b/eng/pipelines/Build.Template.yml
@@ -58,7 +58,7 @@ jobs:
     displayName: 'Pack Library'
     inputs:
       command: 'pack'
-      projects: 'src/${{ parameters.Project }}/${{ parameters.Project }}.csproj'
+      packagesToPack: 'src/${{ parameters.Project }}/${{ parameters.Project }}.csproj'
       nobuild: true
 
   - task: PublishBuildArtifacts@1

--- a/eng/pipelines/Build.Template.yml
+++ b/eng/pipelines/Build.Template.yml
@@ -13,12 +13,10 @@ jobs:
 
   steps:
   - task: DotNetCoreCLI@2
-    displayName: 'Build'
+    displayName: 'Build Library'
     inputs:
       command: 'build'
-      projects: |
-        src/${{ parameters.Project }}/${{ parameters.Project }}.csproj
-        src/${{ parameters.Project }}.Test/${{ parameters.Project }}.Test.csproj
+      projects: 'src/${{ parameters.Project }}/${{ parameters.Project }}.csproj'
       arguments: '-c $(BuildConfiguration) -p:ContinuousIntegrationBuild=true'
 
   - task: DownloadSecureFile@1
@@ -29,7 +27,7 @@ jobs:
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
   - task: PowerShell@2
-    displayName: 'Enhanced Strong Name Signing'
+    displayName: 'Sign Library with an Enhanced Strong Name'
     inputs:
       targetType: 'inline'
       script: |
@@ -41,16 +39,23 @@ jobs:
       pwsh: true
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Test Project'
+    inputs:
+      command: 'build'
+      projects: 'src/${{ parameters.Project }}.Test/${{ parameters.Project }}.Test.csproj'
+      arguments: '-c $(BuildConfiguration)'
+
   # Note that "Debug" code coverage may result in inaccurate code coverage metrics
   - task: DotNetCoreCLI@2
-    displayName: 'Test'
+    displayName: 'Run Tests'
     inputs:
       command: 'test'
       projects: 'src/${{ parameters.Project }}.Test/${{ parameters.Project }}.Test.csproj'
       arguments: '-c $(BuildConfiguration) --no-build --collect "Code Coverage" -s "$(Build.Repository.LocalPath)/src/CodeCoverage.runsettings" -v normal'
 
   - task: DotNetCoreCLI@2
-    displayName: 'Pack'
+    displayName: 'Pack Library'
     inputs:
       command: 'pack'
       projects: 'src/${{ parameters.Project }}/${{ parameters.Project }}.csproj'

--- a/eng/pipelines/Build.Template.yml
+++ b/eng/pipelines/Build.Template.yml
@@ -26,19 +26,6 @@ jobs:
       secureFile: 'Sweetener.snk'
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
-  - task: PowerShell@2
-    displayName: 'Sign Library with an Enhanced Strong Name'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $assemblies = @(Get-ChildItem -Path "src/${{ parameters.Project }}/bin/$(BuildConfiguration)/" -Recurse -Include ${{ parameters.Project }}.dll)
-        foreach ($assembly in $assemblies)
-        {
-            Start-Process -FilePath "${{ parameters.netfxTools }}/sn.exe" -ArgumentList "-Ra","$assembly","$(SigningKey.SecureFilePath)" -NoNewWindow -Wait
-        }
-      pwsh: true
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-
   - task: DotNetCoreCLI@2
     displayName: 'Build Test Project'
     inputs:
@@ -53,6 +40,19 @@ jobs:
       command: 'test'
       projects: 'src/${{ parameters.Project }}.Test/${{ parameters.Project }}.Test.csproj'
       arguments: '-c $(BuildConfiguration) --no-build --collect "Code Coverage" -s "$(Build.Repository.LocalPath)/src/CodeCoverage.runsettings" -v normal'
+
+  - task: PowerShell@2
+    displayName: 'Sign Library with an Enhanced Strong Name'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $assemblies = @(Get-ChildItem -Path "src/${{ parameters.Project }}/bin/$(BuildConfiguration)/" -Recurse -Include ${{ parameters.Project }}.dll)
+        foreach ($assembly in $assemblies)
+        {
+            Start-Process -FilePath "${{ parameters.netfxTools }}/sn.exe" -ArgumentList "-Ra","$assembly","$(SigningKey.SecureFilePath)" -NoNewWindow -Wait
+        }
+      pwsh: true
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
   - task: DotNetCoreCLI@2
     displayName: 'Pack Library'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -44,6 +44,7 @@
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <IncludeSymbols>true</IncludeSymbols>
+        <NoWarn>NU5105</NoWarn> <!-- Ignore warnings about requiring SemVar 2.0. We want to use it! -->
         <Product>Sweetener</Product>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,25 +16,56 @@
   </PropertyGroup>
 
   <!-- Below are items and properties that vary between projects -->
+  <!-- Common framework and tooling PackageReference elements are also kept in sync here -->
   <Choose>
     <When Condition="$(MSBuildProjectName.EndsWith('Test'))">
-      <!-- Do not expect test classes to have XML doc -->
+
+      <!-- Unit Test Properties -->
       <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <NoWarn>CS1591</NoWarn>
+        <NoWarn>CS1591</NoWarn> <!-- XML comments are not required for tests -->
         <PublicSign>true</PublicSign>
       </PropertyGroup>
+
+      <!-- Test Framework Packages -->
+      <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+        <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+      </ItemGroup>
+
     </When>
     <Otherwise>
+
+      <!-- Assembly and Build Properties -->
       <PropertyGroup>
+        <Copyright>Copyright © William Sugarman 2020</Copyright>
         <DelaySign>true</DelaySign>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IncludeSymbols>true</IncludeSymbols>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
       </PropertyGroup>
+
+      <!-- NuGet metadata -->
+      <PropertyGroup>
+        <Authors>William Sugarman</Authors>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <MinClientVersion>4.3.0</MinClientVersion>
+      </PropertyGroup>
+
+      <!-- InternalsVisibleTo -->
       <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
           <_Parameter1>$(MSBuildProjectName).Test, PublicKey=002400000c8000001402000006020000002400005253413100100000010001007127af9e53dfa81f9909fa8c032ec685ce024339149defa44a2e2c93b831fafb8ee2edf2cd1181f4c45c4d2603819801275eb64ff834174fd5aa9d5f4527291ba1bee287cefac997b04a352264995c1752181d4e7ac914a5df0d5e15c068da2a3dd4f157c02ca0bf3ea43c23c35e879c733f84a64f5ef478192cbe514b2e09467626d2c44b878aa8d84ecc4129877f67384295689b108f48f99a3a063135ea4a3b257733bedc4fc3c7989b637414d7f0956be8813a9dbd3a20dd4c9477b191299a315cff14dec19dbe152f0ce28eaa4a1e812efa985b35e855540512e1feafe314f072e78df54711c5942b806f4138d9e3f5bc03285603517d964b714491310bd6a3010397bc5e71345f645a5218bc6eaccaa1cdc1dab857579ff8408ba40da69018f11d94d314331ff54c2a6bb2ca74c2da199358dc66a5c470f1dbf0c381b1d4591d911fa73c1ab2765340d4a0900a24bc541684aeba32975cf2039e6022f6712f00ae04438ff837738c1914c84d938a776a18e524d5b549dde76f8629c1c0c67669daf914d05f8835c8290d71d87379c7b654ebb08b0003aec77fbef706d3842654cfa7c4f1ee049a63efdcf1565e8027cbaebc6fec67925e1673d4ad2d152f03658d3f3a8a1d09a26796213b7bcd9a4ffbbc57b62f920f2e947a8e638cd89f03a03413a5994d0be643e28af44021062281dd80e9dff8343e33cc4d5539ab</_Parameter1>
         </AssemblyAttribute>
       </ItemGroup>
+
+      <!-- Tool Packages -->
+      <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+      </ItemGroup>
+
     </Otherwise>
   </Choose>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -41,8 +41,10 @@
       <PropertyGroup>
         <Copyright>Copyright © William Sugarman 2020</Copyright>
         <DelaySign>true</DelaySign>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <IncludeSymbols>true</IncludeSymbols>
+        <Product>Sweetener</Product>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
       </PropertyGroup>
@@ -54,7 +56,7 @@
         <MinClientVersion>4.3.0</MinClientVersion>
       </PropertyGroup>
 
-      <!-- InternalsVisibleTo -->
+      <!-- Explicit Assembly Attributes -->
       <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
           <_Parameter1>$(MSBuildProjectName).Test, PublicKey=002400000c8000001402000006020000002400005253413100100000010001007127af9e53dfa81f9909fa8c032ec685ce024339149defa44a2e2c93b831fafb8ee2edf2cd1181f4c45c4d2603819801275eb64ff834174fd5aa9d5f4527291ba1bee287cefac997b04a352264995c1752181d4e7ac914a5df0d5e15c068da2a3dd4f157c02ca0bf3ea43c23c35e879c733f84a64f5ef478192cbe514b2e09467626d2c44b878aa8d84ecc4129877f67384295689b108f48f99a3a063135ea4a3b257733bedc4fc3c7989b637414d7f0956be8813a9dbd3a20dd4c9477b191299a315cff14dec19dbe152f0ce28eaa4a1e812efa985b35e855540512e1feafe314f072e78df54711c5942b806f4138d9e3f5bc03285603517d964b714491310bd6a3010397bc5e71345f645a5218bc6eaccaa1cdc1dab857579ff8408ba40da69018f11d94d314331ff54c2a6bb2ca74c2da199358dc66a5c470f1dbf0c381b1d4591d911fa73c1ab2765340d4a0900a24bc541684aeba32975cf2039e6022f6712f00ae04438ff837738c1914c84d938a776a18e524d5b549dde76f8629c1c0c67669daf914d05f8835c8290d71d87379c7b654ebb08b0003aec77fbef706d3842654cfa7c4f1ee049a63efdcf1565e8027cbaebc6fec67925e1673d4ad2d152f03658d3f3a8a1d09a26796213b7bcd9a4ffbbc57b62f920f2e947a8e638cd89f03a03413a5994d0be643e28af44021062281dd80e9dff8343e33cc4d5539ab</_Parameter1>

--- a/src/Sweetener.Core.Test/Sweetener.Core.Test.csproj
+++ b/src/Sweetener.Core.Test/Sweetener.Core.Test.csproj
@@ -6,12 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Sweetener.Core\Sweetener.Core.csproj" />
   </ItemGroup>
 

--- a/src/Sweetener.Core/Sweetener.Core.csproj
+++ b/src/Sweetener.Core/Sweetener.Core.csproj
@@ -1,8 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Common APIs that sweeten the .NET foundational class libraries</Description>
+    <PackageTags>common</PackageTags>
     <RootNamespace>Sweetener</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>alpha.1</VersionSuffix>
   </PropertyGroup>
 
   <!-- Generated Files -->

--- a/src/Sweetener.Core/Sweetener.Core.csproj
+++ b/src/Sweetener.Core/Sweetener.Core.csproj
@@ -9,6 +9,12 @@
     <VersionSuffix>alpha.1</VersionSuffix>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.InteropServices.Guid">
+      <_Parameter1>3238523c-5921-4100-9eb9-17cfa9a03121</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <!-- Generated Files -->
   <ItemGroup>
     <Compile Update="Action\Action.cs">

--- a/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
+++ b/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
@@ -5,15 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <ProjectReference Include="..\Sweetener.Reliability\Sweetener.Reliability.csproj" />
   </ItemGroup>
 
-  <!-- TODO: Remove ProjectReference for Sweetener.Core.csproj after package has been published -->
+  <!-- TODO: Remove these inclusions after Sweetener.Core has been published -->
   <ItemGroup>
-    <ProjectReference Include="..\Sweetener.Reliability\Sweetener.Reliability.csproj" />
-    <ProjectReference Include="..\Sweetener.Core\Sweetener.Core.csproj" />
+    <Compile Include="..\Sweetener.Core\Func\TryFunc.cs">
+      <Link>Core\TryFunc.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <!-- Generated Files -->

--- a/src/Sweetener.Reliability/Sweetener.Reliability.csproj
+++ b/src/Sweetener.Reliability/Sweetener.Reliability.csproj
@@ -1,12 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>APIs for executing user-defined delegates despite transient failures</Description>
+    <PackageTags>action delegate failure func reliable retry</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>alpha.1</VersionSuffix>
   </PropertyGroup>
 
-  <!-- TODO: Remove ProjectReference after package has been published -->
+  <!-- TODO: Remove these inclusions after Sweetener.Core has been published -->
   <ItemGroup>
-    <ProjectReference Include="..\Sweetener.Core\Sweetener.Core.csproj" />
+    <Compile Include="..\Sweetener.Core\Action\Action.cs">
+      <Link>Core\Action.cs</Link>
+    </Compile>
+    <Compile Include="..\Sweetener.Core\Func\Func.cs">
+      <Link>Core\Func.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <!-- Generated Files -->

--- a/src/Sweetener.Reliability/Sweetener.Reliability.csproj
+++ b/src/Sweetener.Reliability/Sweetener.Reliability.csproj
@@ -1,12 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>APIs for executing user-defined delegates despite transient failures</Description>
+    <Description>API for executing user-defined delegates despite transient failures</Description>
     <PackageTags>action delegate failure func reliable retry</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix>alpha.1</VersionSuffix>
   </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.InteropServices.Guid">
+      <_Parameter1>eb226990-2782-431c-9ff1-e17f53718e82</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
   <!-- TODO: Remove these inclusions after Sweetener.Core has been published -->
   <ItemGroup>


### PR DESCRIPTION
- Update *Directory.build.props* to include:
    - NuGet metadata
    - Common tooling and framework `<PackageReference>` elements
- Add SourceLink support
- Output packages in build pipeline
- Restrict strong name signing to builds on master branch
- Create release notes