### PR TITLE
Always Sign Library with Strong Name

### DIFF
--- a/eng/Build.Template.yml
+++ b/eng/Build.Template.yml
@@ -2,45 +2,12 @@ parameters:
   project: ''
 
 jobs:
-- job: Validation
-
-  pool:
-    vmImage: 'ubuntu-latest'
-
-  variables:
-    buildConfiguration: 'Debug'
-
-  steps:
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core 3.x'
-    inputs:
-      packageType: 'sdk'
-      version: '3.x'
-
-  # Enable "-p:ContinuousIntegrationBuild=true" after tonerdo/coverlet#363 is fixed
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Tests and Collect Code Coverage'
-    inputs:
-      command: 'test'
-      projects: 'src/${{ parameters.Project }}.Test/${{ parameters.Project }}.Test.csproj'
-      arguments: '-c $(BuildConfiguration) --collect "XPlat Code Coverage" -s "$(Build.Repository.LocalPath)/src/CodeCoverage.runsettings" -v normal'
-
-  - task: PublishCodeCoverageResults@1
-    displayName: 'Publish Code Coverage Report'
-    inputs:
-      codeCoverageTool: 'Cobertura'
-      summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
-      failIfCoverageEmpty: true
-
 - job: Build
-
   pool:
     vmImage: 'windows-latest'
-
   variables:
     buildConfiguration: 'Release'
     netfxTools: 'C:/Program Files (x86)/Microsoft SDKs/Windows/v10.0A/bin/NETFX 4.8 Tools'
-
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3.x'
@@ -70,7 +37,7 @@ jobs:
         $assemblies = @(Get-ChildItem -Path "src/${{ parameters.Project }}/bin/$(BuildConfiguration)/" -Recurse -Include ${{ parameters.Project }}.dll)
         foreach ($assembly in $assemblies)
         {
-            Start-Process -FilePath "${{ parameters.netfxTools }}/sn.exe" -ArgumentList "-Ra","$assembly","$(SigningKey.SecureFilePath)" -NoNewWindow -Wait
+            Start-Process -FilePath "$(NetfxTools)/sn.exe" -ArgumentList "-Ra","$assembly","$(SigningKey.SecureFilePath)" -NoNewWindow -Wait
         }
       pwsh: true
 
@@ -88,3 +55,32 @@ jobs:
     displayName: 'Publish Build Artifacts'
     inputs:
       artifactName: 'pkg'
+
+- job: Validation
+  dependsOn: Build
+  condition: succeeded()
+  pool:
+    vmImage: 'ubuntu-latest'
+  variables:
+    buildConfiguration: 'Debug'
+  steps:
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 3.x'
+    inputs:
+      packageType: 'sdk'
+      version: '3.x'
+
+  # Enable "-p:ContinuousIntegrationBuild=true" after tonerdo/coverlet#363 is fixed
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Tests and Collect Code Coverage'
+    inputs:
+      command: 'test'
+      projects: 'src/${{ parameters.Project }}.Test/${{ parameters.Project }}.Test.csproj'
+      arguments: '-c $(BuildConfiguration) --collect "XPlat Code Coverage" -s "$(Build.Repository.LocalPath)/src/CodeCoverage.runsettings" -v normal'
+
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish Code Coverage Report'
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
+      failIfCoverageEmpty: true

--- a/eng/Build.Template.yml
+++ b/eng/Build.Template.yml
@@ -61,7 +61,6 @@ jobs:
     displayName: 'Download Signing Key'
     inputs:
       secureFile: 'Sweetener.snk'
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
   - task: PowerShell@2
     displayName: 'Sign Library with an Enhanced Strong Name'
@@ -74,7 +73,6 @@ jobs:
             Start-Process -FilePath "${{ parameters.netfxTools }}/sn.exe" -ArgumentList "-Ra","$assembly","$(SigningKey.SecureFilePath)" -NoNewWindow -Wait
         }
       pwsh: true
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
   - task: DotNetCoreCLI@2
     displayName: 'Pack Library'


### PR DESCRIPTION
- Remove condition on signing tasks to prevent build inconsistencies