### PR TITLE
Gracefully Handle Synchronous Delegates that Return Task

### DIFF
--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T1.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, CancellationToken> invoke = (action, arg, token) => action(arg).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, CancellationToken> invoke = (action, arg, token) => action(arg).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, CancellationToken> invoke = (action, arg, token) => action(arg, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT2_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT2_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT2_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT2_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, CancellationToken> invoke = (action, arg, token) => action(arg, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT2_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT2_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT2_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T1.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T1.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, CancellationToken> invoke = (action, arg, token) => action(arg).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, CancellationToken> invoke = (action, arg, token) => action(arg).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, CancellationToken> invoke = (action, arg, token) => action(arg, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, CancellationToken> invoke = (action, arg, token) => action(arg, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T10.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T10.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T10.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT11_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT11_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT11_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT11_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT11_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT11_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT11_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT11_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT11_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T11.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT12_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT12_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT12_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT12_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT12_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT12_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT12_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT12_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT12_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T11.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T11.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T12.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T12.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT13_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT13_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT13_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT13_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT13_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT13_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT13_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT13_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT13_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T12.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T13.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T13.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT14_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT14_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT14_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT14_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT14_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT14_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT14_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT14_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT14_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T13.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T14.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T14.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T14.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT15_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT15_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT15_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT15_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT15_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT15_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT15_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT15_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT15_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T15.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T15.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T15.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT16_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT16_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT16_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT16_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT16_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT16_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT16_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT16_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT16_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T16.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT17_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT17_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT17_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT17_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT17_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT17_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT17_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT17_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT17_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T16.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T16.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T2.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, CancellationToken> invoke = (action, arg1, arg2, token) => action(arg1, arg2).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, CancellationToken> invoke = (action, arg1, arg2, token) => action(arg1, arg2).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, CancellationToken> invoke = (action, arg1, arg2, token) => action(arg1, arg2, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT3_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT3_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT3_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT3_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, CancellationToken> invoke = (action, arg1, arg2, token) => action(arg1, arg2, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT3_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT3_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT3_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T2.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, CancellationToken> invoke = (action, arg1, arg2, token) => action(arg1, arg2).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, CancellationToken> invoke = (action, arg1, arg2, token) => action(arg1, arg2).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, CancellationToken> invoke = (action, arg1, arg2, token) => action(arg1, arg2, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, CancellationToken> invoke = (action, arg1, arg2, token) => action(arg1, arg2, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T2.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T3.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T3.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, CancellationToken> invoke = (action, arg1, arg2, arg3, token) => action(arg1, arg2, arg3).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, CancellationToken> invoke = (action, arg1, arg2, arg3, token) => action(arg1, arg2, arg3).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, CancellationToken> invoke = (action, arg1, arg2, arg3, token) => action(arg1, arg2, arg3, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT4_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT4_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT4_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT4_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, CancellationToken> invoke = (action, arg1, arg2, arg3, token) => action(arg1, arg2, arg3, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT4_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT4_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT4_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T3.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, CancellationToken> invoke = (action, arg1, arg2, arg3, token) => action(arg1, arg2, arg3).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, CancellationToken> invoke = (action, arg1, arg2, arg3, token) => action(arg1, arg2, arg3).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, CancellationToken> invoke = (action, arg1, arg2, arg3, token) => action(arg1, arg2, arg3, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, CancellationToken> invoke = (action, arg1, arg2, arg3, token) => action(arg1, arg2, arg3, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T4.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T4.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, token) => action(arg1, arg2, arg3, arg4).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, token) => action(arg1, arg2, arg3, arg4).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, token) => action(arg1, arg2, arg3, arg4, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT5_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT5_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT5_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT5_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, token) => action(arg1, arg2, arg3, arg4, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT5_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT5_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT5_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T4.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, token) => action(arg1, arg2, arg3, arg4).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, token) => action(arg1, arg2, arg3, arg4).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, token) => action(arg1, arg2, arg3, arg4, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, token) => action(arg1, arg2, arg3, arg4, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T5.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T5.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, token) => action(arg1, arg2, arg3, arg4, arg5).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, token) => action(arg1, arg2, arg3, arg4, arg5).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, token) => action(arg1, arg2, arg3, arg4, arg5, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, token) => action(arg1, arg2, arg3, arg4, arg5, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T5.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, token) => action(arg1, arg2, arg3, arg4, arg5).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, token) => action(arg1, arg2, arg3, arg4, arg5).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, token) => action(arg1, arg2, arg3, arg4, arg5, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT6_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT6_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT6_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT6_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, token) => action(arg1, arg2, arg3, arg4, arg5, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT6_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT6_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT6_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T6.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, token) => action(arg1, arg2, arg3, arg4, arg5, arg6).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, token) => action(arg1, arg2, arg3, arg4, arg5, arg6).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T6.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, token) => action(arg1, arg2, arg3, arg4, arg5, arg6).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, token) => action(arg1, arg2, arg3, arg4, arg5, arg6).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT7_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT7_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT7_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT7_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT7_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT7_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT7_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T6.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T7.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T7.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT8_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT8_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT8_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT8_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT8_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT8_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT8_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T7.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T8.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T8.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T8.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT9_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT9_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT9_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT9_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT9_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT9_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT9_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T9.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -48,7 +48,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -75,7 +75,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T9.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token).Wait();
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T9.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).Wait();
@@ -55,7 +55,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).Wait();
@@ -82,7 +82,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token).Wait();
@@ -98,6 +98,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT10_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT10_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT10_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT10_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT10_Async_WithToken_ComplexDelayHandler()
@@ -110,7 +114,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke = (action, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token).Wait();
@@ -126,6 +130,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT10_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT10_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT10_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { a(token); return Task.CompletedTask; });
+            WithRetryT10_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.Test.cs
@@ -29,7 +29,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async () => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async () => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, CancellationToken> invoke = (action, token) => action().Wait();
@@ -56,7 +56,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async () => { await Task.CompletedTask.ConfigureAwait(false); a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async () => { await Task.CompletedTask; a(CancellationToken.None); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, CancellationToken> invoke = (action, token) => action().Wait();
@@ -83,7 +83,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, CancellationToken> invoke = (action, token) => action(token).Wait();
@@ -99,6 +99,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT1_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT1_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((token) => { a(token); return Task.CompletedTask; });
+            WithRetryT1_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
         [TestMethod]
         public void WithAsyncRetryT1_Async_WithToken_ComplexDelayHandler()
@@ -111,7 +115,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (token) => { await Task.CompletedTask.ConfigureAwait(false); a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (token) => { await Task.CompletedTask; a(token); });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, CancellationToken> invoke = (action, token) => action(token).Wait();
@@ -127,6 +131,10 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT1_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT1_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new InterruptableTestActionProxy((token) => { a(token); return Task.CompletedTask; });
+            WithRetryT1_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.Test.cs
@@ -22,7 +22,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_DelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async () => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async () => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -49,7 +49,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_ComplexDelayHandler()
         {
             TestAction nullAction = null;
-            TestAction action     = async () => await Operation.NullAsync().ConfigureAwait(false);
+            TestAction action     = async () => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));
@@ -76,7 +76,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_WithToken_DelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -108,7 +108,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestAction nullAction = null;
-            InterruptableTestAction action     = async (token) => await Operation.NullAsync().ConfigureAwait(false);
+            InterruptableTestAction action     = async (token) => await Task.CompletedTask;
             Assert.ThrowsException<ArgumentNullException      >(() => nullAction.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => action    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, null                     , (i, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.Test.cs
@@ -29,7 +29,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async () => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async () => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, CancellationToken> invoke = (action, token) => action().Wait();
@@ -56,7 +56,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async () => { await Task.CompletedTask; a(CancellationToken.None); });
+            Func<Action<CancellationToken>, TestActionProxy> actionFactory = a => new TestActionProxy(async () => { a(CancellationToken.None); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<TestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, TestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<TestAction, CancellationToken> invoke = (action, token) => action().Wait();
@@ -83,7 +83,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, CancellationToken> invoke = (action, token) => action(token).Wait();
@@ -115,7 +115,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (token) => { await Task.CompletedTask; a(token); });
+            Func<Action<CancellationToken>, InterruptableTestActionProxy> actionFactory = a => new InterruptableTestActionProxy(async (token) => { a(token); await Task.CompletedTask; });
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, e) => t);
             Func<InterruptableTestAction, int, ExceptionHandler, Func<int, Exception, TimeSpan>, InterruptableTestAction> withAsyncRetry = (a, r, e, d) => a.WithAsyncRetry(r, e, d.Invoke);
             Action<InterruptableTestAction, CancellationToken> invoke = (action, token) => action(token).Wait();

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T1.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, CancellationToken> action = new ActionProxy<int, CancellationToken>((arg, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, CancellationToken> action = new ActionProxy<int, CancellationToken>(
+                (arg, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T10.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T11.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T12.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T13.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T14.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T15.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T16.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T2.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, CancellationToken> action = new ActionProxy<int, string, CancellationToken>((arg1, arg2, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, CancellationToken> action = new ActionProxy<int, string, CancellationToken>(
+                (arg1, arg2, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T3.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, CancellationToken> action = new ActionProxy<int, string, double, CancellationToken>((arg1, arg2, arg3, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, CancellationToken> action = new ActionProxy<int, string, double, CancellationToken>(
+                (arg1, arg2, arg3, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T4.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, CancellationToken> action = new ActionProxy<int, string, double, long, CancellationToken>((arg1, arg2, arg3, arg4, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, CancellationToken> action = new ActionProxy<int, string, double, long, CancellationToken>(
+                (arg1, arg2, arg3, arg4, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T5.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, CancellationToken>((arg1, arg2, arg3, arg4, arg5, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T6.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T7.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T8.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T9.Test.cs
@@ -529,11 +529,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.Test.cs
@@ -525,11 +525,12 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            ActionProxy<CancellationToken> action = new ActionProxy<CancellationToken>((token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            ActionProxy<CancellationToken> action = new ActionProxy<CancellationToken>(
+                (token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T1.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, CancellationToken, Task>(
                     async (arg, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T1.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int>, int, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int>, int, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, CancellationToken, Task> action = new FuncProxy<int, CancellationToken, Task>(async (arg, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, CancellationToken, Task>((arg, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, CancellationToken, Task>(async (arg, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T1.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, CancellationToken, Task>((arg, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, CancellationToken, Task>(async (arg, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, CancellationToken, Task>(
+                    (arg, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, CancellationToken, Task>(
+                    async (arg, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T1.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int>> factory)
         {
-            Func<int, CancellationToken, Task> action = async (arg, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, CancellationToken, Task> action = async (arg, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int>> factory)
         {
-            Func<int, CancellationToken, Task> action = async (arg, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, CancellationToken, Task> action = async (arg, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int>, int, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int>, int, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int>, int, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, Task> action = new FuncProxy<int, Task>(async (arg) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T10.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T10.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T10.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T10.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T11.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T11.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T11.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T11.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T12.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T12.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T12.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T12.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T13.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T13.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T13.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T13.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T14.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T14.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T14.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T14.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T15.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T15.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T15.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T15.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T16.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T16.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T16.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T16.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T2.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, CancellationToken, Task>((arg1, arg2, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, CancellationToken, Task>(async (arg1, arg2, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, CancellationToken, Task>(
+                    (arg1, arg2, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, CancellationToken, Task>(
+                    async (arg1, arg2, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T2.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, CancellationToken, Task>(
                     async (arg1, arg2, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T2.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string>, int, string, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string>, int, string, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, CancellationToken, Task> action = new FuncProxy<int, string, CancellationToken, Task>(async (arg1, arg2, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, CancellationToken, Task>((arg1, arg2, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, CancellationToken, Task>(async (arg1, arg2, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T2.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string>> factory)
         {
-            Func<int, string, CancellationToken, Task> action = async (arg1, arg2, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, CancellationToken, Task> action = async (arg1, arg2, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string>> factory)
         {
-            Func<int, string, CancellationToken, Task> action = async (arg1, arg2, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, CancellationToken, Task> action = async (arg1, arg2, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string>, int, string, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string>, int, string, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string>, int, string, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, Task> action = new FuncProxy<int, string, Task>(async (arg1, arg2) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T3.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, CancellationToken, Task>(
                     async (arg1, arg2, arg3, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T3.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, CancellationToken, Task>((arg1, arg2, arg3, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, CancellationToken, Task>(async (arg1, arg2, arg3, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, CancellationToken, Task>(
+                    (arg1, arg2, arg3, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T3.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double>> factory)
         {
-            Func<int, string, double, CancellationToken, Task> action = async (arg1, arg2, arg3, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, CancellationToken, Task> action = async (arg1, arg2, arg3, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double>> factory)
         {
-            Func<int, string, double, CancellationToken, Task> action = async (arg1, arg2, arg3, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, CancellationToken, Task> action = async (arg1, arg2, arg3, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double>, int, string, double, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double>, int, string, double, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double>, int, string, double, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task> action = new FuncProxy<int, string, double, Task>(async (arg1, arg2, arg3) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T3.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double>, int, string, double, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double>, int, string, double, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, CancellationToken, Task> action = new FuncProxy<int, string, double, CancellationToken, Task>(async (arg1, arg2, arg3, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, CancellationToken, Task>((arg1, arg2, arg3, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, CancellationToken, Task>(async (arg1, arg2, arg3, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T4.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T4.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, CancellationToken, Task>((arg1, arg2, arg3, arg4, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T4.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long>> factory)
         {
-            Func<int, string, double, long, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long>> factory)
         {
-            Func<int, string, double, long, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long>, int, string, double, long, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long>, int, string, double, long, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long>, int, string, double, long, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task> action = new FuncProxy<int, string, double, long, Task>(async (arg1, arg2, arg3, arg4) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T4.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long>, int, string, double, long, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long>, int, string, double, long, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, CancellationToken, Task> action = new FuncProxy<int, string, double, long, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, CancellationToken, Task>((arg1, arg2, arg3, arg4, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T5.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T5.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort>> factory)
         {
-            Func<int, string, double, long, ushort, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort>> factory)
         {
-            Func<int, string, double, long, ushort, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort>, int, string, double, long, ushort, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort>, int, string, double, long, ushort, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort>, int, string, double, long, ushort, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task> action = new FuncProxy<int, string, double, long, ushort, Task>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T5.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T6.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T6.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T6.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte>, int, string, double, long, ushort, byte, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte>, int, string, double, long, ushort, byte, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T6.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte>> factory)
         {
-            Func<int, string, double, long, ushort, byte, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte>> factory)
         {
-            Func<int, string, double, long, ushort, byte, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte>, int, string, double, long, ushort, byte, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte>, int, string, double, long, ushort, byte, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte>, int, string, double, long, ushort, byte, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task> action = new FuncProxy<int, string, double, long, ushort, byte, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T7.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T7.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T7.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T7.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T8.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T8.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T8.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T8.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T9.Test.cs
@@ -162,7 +162,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Action(invoke, addEventHandlers);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -450,17 +451,24 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousAction)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task> action = useSynchronousAction
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T9.Test.cs
@@ -90,7 +90,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task>, int, ExceptionHandler, DelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler.Invoke));
@@ -107,7 +107,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task>, int, ExceptionHandler, ComplexDelayHandler, ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Operation.NullAsync().ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task> action = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.CompletedTask;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler delayHandler = (i, e) => TimeSpan.FromHours(1);
             Assert.ThrowsException<ArgumentNullException      >(() => factory(null, Retries.Infinite, exceptionHandler, delayHandler));
@@ -176,7 +176,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Operation.NullAsync().ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.CompletedTask);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>();
@@ -228,7 +228,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(() => throw new InvalidOperationException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromException(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -285,7 +285,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -342,7 +342,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(flakyAction).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { flakyAction(); await Task.CompletedTask; });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -398,7 +398,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -534,7 +534,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(() => throw new IOException()).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromException(new IOException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T9.Test.cs
@@ -458,17 +458,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T9.Test.cs
@@ -467,9 +467,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.Test.cs
@@ -454,17 +454,19 @@ namespace Sweetener.Reliability.Test
             // Create a user-defined action that will throw an exception depending on whether its canceled
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<CancellationToken, Task> action = useSynchronousAction
-                ? new FuncProxy<CancellationToken, Task>((token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new FuncProxy<CancellationToken, Task>(async (token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new FuncProxy<CancellationToken, Task>(
+                    (token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new FuncProxy<CancellationToken, Task>(
+                    async (token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.Test.cs
@@ -463,9 +463,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<CancellationToken, Task>(
                     async (token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/Action.Extensions.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/Action.Extensions.Test.t4
@@ -73,7 +73,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .With<#= optionalAsync #>Retry( 4, ExceptionPolicy.Transient, (<#= useComplexHandler ? "Complex" : string.Empty #>DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, <#= inputActionType #>Proxy> actionFactory = a => new <#= inputActionType #>Proxy(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalCommaToken #>) => <#= async ? $"{{ await Task.CompletedTask; a({optionalToken}); }}" : $"a({optionalToken})" #>);
+            Func<Action<CancellationToken>, <#= inputActionType #>Proxy> actionFactory = a => new <#= inputActionType #>Proxy(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalCommaToken #>) => <#= async ? $"{{ a({optionalToken}); await Task.CompletedTask; }}" : $"a({optionalToken})" #>);
             Func<TimeSpan, <#= delayHandlerTypeProxy #>> delayHandlerFactory = t => new <#= delayHandlerTypeProxy #>((i<#= useComplexHandler ? ", e" : string.Empty #>) => t);
             Func<<#= inputActionType #>, int, ExceptionHandler, <#= delayHandlerFunc #>, <#= inputActionType #>> with<#= optionalAsync #>Retry = (a, r, e, d) => a.With<#= optionalAsync #>Retry(r, e, d.Invoke);
             Action<<#= inputActionType #><#= optionalComma #><#= typeArguments #>, CancellationToken> invoke = (action<#= optionalComma #><#= arguments #>, token) => action(<#= arguments #><#= optionalCommaToken #>)<#= async ? ".Wait()" : string.Empty #>;

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/Action.Extensions.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/Action.Extensions.Test.t4
@@ -73,7 +73,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => action    .With<#= optionalAsync #>Retry( 4, ExceptionPolicy.Transient, (<#= useComplexHandler ? "Complex" : string.Empty #>DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Action<CancellationToken>, <#= inputActionType #>Proxy> actionFactory = a => new <#= inputActionType #>Proxy(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalCommaToken #>) => <#= async ? $"{{ await Task.CompletedTask.ConfigureAwait(false); a({optionalToken}); }}" : $"a({optionalToken})" #>);
+            Func<Action<CancellationToken>, <#= inputActionType #>Proxy> actionFactory = a => new <#= inputActionType #>Proxy(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalCommaToken #>) => <#= async ? $"{{ await Task.CompletedTask; a({optionalToken}); }}" : $"a({optionalToken})" #>);
             Func<TimeSpan, <#= delayHandlerTypeProxy #>> delayHandlerFactory = t => new <#= delayHandlerTypeProxy #>((i<#= useComplexHandler ? ", e" : string.Empty #>) => t);
             Func<<#= inputActionType #>, int, ExceptionHandler, <#= delayHandlerFunc #>, <#= inputActionType #>> with<#= optionalAsync #>Retry = (a, r, e, d) => a.With<#= optionalAsync #>Retry(r, e, d.Invoke);
             Action<<#= inputActionType #><#= optionalComma #><#= typeArguments #>, CancellationToken> invoke = (action<#= optionalComma #><#= arguments #>, token) => action(<#= arguments #><#= optionalCommaToken #>)<#= async ? ".Wait()" : string.Empty #>;
@@ -94,6 +94,15 @@ namespace Sweetener.Reliability.Test
             WithRetry<#= suffix #>_Canceled_Action (actionFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.<#= useComplexHandler ? "ExceptionAsc(e)" : "Asc()" #>);
             WithRetry<#= suffix #>_Canceled_Delay  (actionFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.<#= useComplexHandler ? "ExceptionAsc(e)" : "Asc()" #>);
 <#
+                        if (async)
+                        {
+#>
+
+            // We also want to test the scenario where a user passes a synchronous method that returns a Task
+            actionFactory = a => new <#= inputActionType #>Proxy((<#= arguments #><#= optionalCommaToken #>) => { a(<#= optionalToken #>); return Task.CompletedTask; });
+            WithRetry<#= suffix #>_Canceled_Action (actionFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.<#= useComplexHandler ? "ExceptionAsc(e)" : "Asc()" #>);
+<#
+                        }
                     }
 #>
         }

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/ReliableAction.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/ReliableAction.Test.t4
@@ -645,27 +645,30 @@ namespace Sweetener.Reliability.Test
 #>
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #> action = useSynchronousAction
-                ? new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>((<#= arguments #><#= optionalComma #>token) =>
-                {
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                })
-                : new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalComma #>token) =>
-                {
-                    await Task.CompletedTask;
-                    token.ThrowIfCancellationRequested();
-                    throw new IOException();
-                });
+                ? new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>(
+                    (<#= arguments #><#= optionalComma #>token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    })
+                : new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>(
+                    async (<#= arguments #><#= optionalComma #>token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        throw new IOException();
+                    });
 <#
         }
         else
         {
 #>
-            <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalComma #>token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                throw new IOException();
-            });
+            <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>(
+                (<#= arguments #><#= optionalComma #>token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 <#
         }
 #>

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/ReliableAction.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/ReliableAction.Test.t4
@@ -654,9 +654,8 @@ namespace Sweetener.Reliability.Test
                 : new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>(
                     async (<#= arguments #><#= optionalComma #>token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        throw new IOException();
+                        await Task.FromException(new IOException());
                     });
 <#
         }

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/ReliableAction.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/ReliableAction.Test.t4
@@ -243,7 +243,21 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+<#
+        if (async)
+        {
+#>
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: false);
+                    Invoke_Canceled_Action(invoke, addEventHandlers, useSynchronousAction: true );
+<#
+        }
+        else
+        {
+#>
                     Invoke_Canceled_Action(invoke, addEventHandlers);
+<#
+        }
+#>
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
             }
@@ -620,24 +634,41 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Action
 
-        private void Invoke_Canceled_Action(Action<Reliable<#= optionalAsync #>Action<#= typeArguments #><#= optionalComma #><#= typeArgumentsNoBrackets #>, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Action(Action<Reliable<#= optionalAsync #>Action<#= typeArguments #><#= optionalComma #><#= typeArgumentsNoBrackets #>, CancellationToken> invoke, bool addEventHandlers<#= async ? ", bool useSynchronousAction" : string.Empty #>)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
-            <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalComma #>token) =>
-            {
 <#
         if (async)
         {
 #>
-                await Task.CompletedTask;
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #> action = useSynchronousAction
+                ? new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>((<#= arguments #><#= optionalComma #>token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                })
+                : new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalComma #>token) =>
+                {
+                    await Task.CompletedTask;
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
 <#
         }
+        else
+        {
 #>
+            <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalComma #>token) =>
+            {
                 token.ThrowIfCancellationRequested();
                 throw new IOException();
             });
+<#
+        }
+#>
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/ReliableAction.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/ReliableAction.Test.t4
@@ -365,7 +365,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure(Action<Reliable<#= optionalAsync #>Action<#= typeArguments #><#= optionalComma #><#= typeArgumentsNoBrackets #>, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action
-            <#= inputActionKind #>Proxy<#= inputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= inputActionTypeArguments #>(<#= GetThrowException<InvalidOperationException>(parameterCount, async) #>);
+            <#= inputActionKind #>Proxy<#= inputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= inputActionTypeArguments #>(<#= GetThrowDelegate<InvalidOperationException>(parameterCount, async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<InvalidOperationException>().Invoke);
@@ -429,7 +429,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a "successful" user-defined action that completes after 1 IOException
             Action flakyAction = FlakyAction.Create<IOException>(1);
-            <#= inputActionKind #>Proxy<#= inputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= inputActionTypeArguments #>(<#= GetDelegate(parameterCount, "flakyAction", async) #>);
+            <#= inputActionKind #>Proxy<#= inputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= inputActionTypeArguments #>(<#= GetActionInvokeDelegate(parameterCount, "flakyAction", async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -499,7 +499,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
             Action flakyAction = FlakyAction.Create<IOException, InvalidOperationException>(2);
-            <#= inputActionKind #>Proxy<#= inputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= inputActionTypeArguments #>(<#= GetDelegate(parameterCount, "flakyAction", async) #>);
+            <#= inputActionKind #>Proxy<#= inputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= inputActionTypeArguments #>(<#= GetActionInvokeDelegate(parameterCount, "flakyAction", async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -568,7 +568,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_RetriesExhausted(Action<Reliable<#= optionalAsync #>Action<#= typeArguments #><#= optionalComma #><#= typeArgumentsNoBrackets #>, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
-            <#= inputActionKind #>Proxy<#= inputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= inputActionTypeArguments #>(<#= GetThrowException<IOException>(parameterCount, async) #>);
+            <#= inputActionKind #>Proxy<#= inputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= inputActionTypeArguments #>(<#= GetThrowDelegate<IOException>(parameterCount, async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
@@ -735,7 +735,7 @@ namespace Sweetener.Reliability.Test
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
-            <#= inputActionKind #>Proxy<#= inputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= inputActionTypeArguments #>(<#= GetThrowException<IOException>(parameterCount, async) #>);
+            <#= inputActionKind #>Proxy<#= inputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= inputActionTypeArguments #>(<#= GetThrowDelegate<IOException>(parameterCount, async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T1.Test.cs
@@ -22,7 +22,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async () => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async () => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -51,7 +51,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async () => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async () => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -80,7 +80,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async () => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async () => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -115,7 +115,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async () => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async () => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -150,7 +150,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -186,7 +186,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -222,7 +222,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -264,7 +264,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT1_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T1.Test.cs
@@ -177,6 +177,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((token) => Task.FromResult(f(token)));
+            WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT1_Async_WithToken_ComplexDelayHandler()
@@ -209,6 +213,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((token) => Task.FromResult(f(token)));
+            WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT1_Async_WithToken_ResultPolicy_DelayHandler()
@@ -247,6 +255,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((token) => Task.FromResult(f(token)));
+            WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT1_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -285,6 +297,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((token) => Task.FromResult(f(token)));
+            WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T1.Test.cs
@@ -29,7 +29,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async () => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async () => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, CancellationToken, int> invoke = (f, token) => f().Result;
@@ -58,7 +58,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async () => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async () => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, CancellationToken, int> invoke = (f, token) => f().Result;
@@ -88,7 +88,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async () => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async () => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, CancellationToken, int> invoke = (f, token) => f().Result;
@@ -123,7 +123,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async () => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async () => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, CancellationToken, int> invoke = (f, token) => f().Result;
@@ -157,7 +157,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, CancellationToken, int> invoke = (f, token) => f(token).Result;
@@ -193,7 +193,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, CancellationToken, int> invoke = (f, token) => f(token).Result;
@@ -230,7 +230,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, CancellationToken, int> invoke = (f, token) => f(token).Result;
@@ -272,7 +272,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, CancellationToken, int> invoke = (f, token) => f(token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T10.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT10_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T10.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT10_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT10_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => Task.FromResult(f(token)));
+            WithRetryT10_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT10_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT10_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT10_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => Task.FromResult(f(token)));
+            WithRetryT10_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT10_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT10_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT10_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => Task.FromResult(f(token)));
+            WithRetryT10_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT10_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT10_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT10_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => Task.FromResult(f(token)));
+            WithRetryT10_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T10.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T11.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT11_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT11_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => Task.FromResult(f(token)));
+            WithRetryT11_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT11_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT11_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT11_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => Task.FromResult(f(token)));
+            WithRetryT11_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT11_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT11_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT11_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => Task.FromResult(f(token)));
+            WithRetryT11_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT11_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT11_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT11_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => Task.FromResult(f(token)));
+            WithRetryT11_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T11.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT11_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T11.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T12.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT12_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T12.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T12.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT12_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT12_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => Task.FromResult(f(token)));
+            WithRetryT12_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT12_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT12_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT12_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => Task.FromResult(f(token)));
+            WithRetryT12_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT12_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT12_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT12_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => Task.FromResult(f(token)));
+            WithRetryT12_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT12_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT12_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT12_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => Task.FromResult(f(token)));
+            WithRetryT12_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T13.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T13.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT13_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT13_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => Task.FromResult(f(token)));
+            WithRetryT13_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT13_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT13_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT13_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => Task.FromResult(f(token)));
+            WithRetryT13_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT13_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT13_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT13_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => Task.FromResult(f(token)));
+            WithRetryT13_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT13_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT13_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT13_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => Task.FromResult(f(token)));
+            WithRetryT13_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T13.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT13_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T14.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T14.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT14_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T14.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT14_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT14_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => Task.FromResult(f(token)));
+            WithRetryT14_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT14_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT14_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT14_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => Task.FromResult(f(token)));
+            WithRetryT14_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT14_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT14_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT14_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => Task.FromResult(f(token)));
+            WithRetryT14_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT14_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT14_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT14_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => Task.FromResult(f(token)));
+            WithRetryT14_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T15.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT15_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T15.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT15_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT15_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => Task.FromResult(f(token)));
+            WithRetryT15_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT15_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT15_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT15_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => Task.FromResult(f(token)));
+            WithRetryT15_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT15_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT15_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT15_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => Task.FromResult(f(token)));
+            WithRetryT15_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT15_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT15_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT15_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => Task.FromResult(f(token)));
+            WithRetryT15_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T15.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T16.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT16_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT16_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => Task.FromResult(f(token)));
+            WithRetryT16_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT16_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT16_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT16_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => Task.FromResult(f(token)));
+            WithRetryT16_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT16_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT16_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT16_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => Task.FromResult(f(token)));
+            WithRetryT16_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT16_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT16_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT16_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => Task.FromResult(f(token)));
+            WithRetryT16_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T16.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT16_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T16.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T17.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T17.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T17.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T17.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT17_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T17.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T17.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT17_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT17_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => Task.FromResult(f(token)));
+            WithRetryT17_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT17_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT17_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT17_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => Task.FromResult(f(token)));
+            WithRetryT17_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT17_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT17_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT17_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => Task.FromResult(f(token)));
+            WithRetryT17_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT17_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT17_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT17_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => Task.FromResult(f(token)));
+            WithRetryT17_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T2.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT2_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T2.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, CancellationToken, int> invoke = (f, arg, token) => f(arg).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, CancellationToken, int> invoke = (f, arg, token) => f(arg).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, CancellationToken, int> invoke = (f, arg, token) => f(arg).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, CancellationToken, int> invoke = (f, arg, token) => f(arg).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, CancellationToken, int> invoke = (f, arg, token) => f(arg, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, CancellationToken, int> invoke = (f, arg, token) => f(arg, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, CancellationToken, int> invoke = (f, arg, token) => f(arg, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, CancellationToken, int> invoke = (f, arg, token) => f(arg, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T2.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg, token) => Task.FromResult(f(token)));
+            WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT2_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg, token) => Task.FromResult(f(token)));
+            WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT2_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg, token) => Task.FromResult(f(token)));
+            WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT2_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg, token) => Task.FromResult(f(token)));
+            WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T3.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT3_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T3.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, CancellationToken, int> invoke = (f, arg1, arg2, token) => f(arg1, arg2).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, CancellationToken, int> invoke = (f, arg1, arg2, token) => f(arg1, arg2).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, CancellationToken, int> invoke = (f, arg1, arg2, token) => f(arg1, arg2).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, CancellationToken, int> invoke = (f, arg1, arg2, token) => f(arg1, arg2).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, CancellationToken, int> invoke = (f, arg1, arg2, token) => f(arg1, arg2, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, CancellationToken, int> invoke = (f, arg1, arg2, token) => f(arg1, arg2, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, CancellationToken, int> invoke = (f, arg1, arg2, token) => f(arg1, arg2, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, CancellationToken, int> invoke = (f, arg1, arg2, token) => f(arg1, arg2, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T3.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, token) => Task.FromResult(f(token)));
+            WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT3_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, token) => Task.FromResult(f(token)));
+            WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT3_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, token) => Task.FromResult(f(token)));
+            WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT3_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, token) => Task.FromResult(f(token)));
+            WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T4.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, CancellationToken, int> invoke = (f, arg1, arg2, arg3, token) => f(arg1, arg2, arg3).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, CancellationToken, int> invoke = (f, arg1, arg2, arg3, token) => f(arg1, arg2, arg3).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, CancellationToken, int> invoke = (f, arg1, arg2, arg3, token) => f(arg1, arg2, arg3).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, CancellationToken, int> invoke = (f, arg1, arg2, arg3, token) => f(arg1, arg2, arg3).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, CancellationToken, int> invoke = (f, arg1, arg2, arg3, token) => f(arg1, arg2, arg3, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, CancellationToken, int> invoke = (f, arg1, arg2, arg3, token) => f(arg1, arg2, arg3, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, CancellationToken, int> invoke = (f, arg1, arg2, arg3, token) => f(arg1, arg2, arg3, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, CancellationToken, int> invoke = (f, arg1, arg2, arg3, token) => f(arg1, arg2, arg3, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T4.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT4_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T4.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, token) => Task.FromResult(f(token)));
+            WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT4_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, token) => Task.FromResult(f(token)));
+            WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT4_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, token) => Task.FromResult(f(token)));
+            WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT4_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, token) => Task.FromResult(f(token)));
+            WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T5.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, token) => f(arg1, arg2, arg3, arg4).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, token) => f(arg1, arg2, arg3, arg4).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, token) => f(arg1, arg2, arg3, arg4).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, token) => f(arg1, arg2, arg3, arg4).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, token) => f(arg1, arg2, arg3, arg4, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, token) => f(arg1, arg2, arg3, arg4, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, token) => f(arg1, arg2, arg3, arg4, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, token) => f(arg1, arg2, arg3, arg4, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T5.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, token) => Task.FromResult(f(token)));
+            WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT5_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, token) => Task.FromResult(f(token)));
+            WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT5_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, token) => Task.FromResult(f(token)));
+            WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT5_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, token) => Task.FromResult(f(token)));
+            WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T5.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT5_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T6.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, token) => f(arg1, arg2, arg3, arg4, arg5).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, token) => f(arg1, arg2, arg3, arg4, arg5).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, token) => f(arg1, arg2, arg3, arg4, arg5).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, token) => f(arg1, arg2, arg3, arg4, arg5).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, token) => f(arg1, arg2, arg3, arg4, arg5, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, token) => f(arg1, arg2, arg3, arg4, arg5, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, token) => f(arg1, arg2, arg3, arg4, arg5, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, token) => f(arg1, arg2, arg3, arg4, arg5, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T6.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, token) => Task.FromResult(f(token)));
+            WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT6_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, token) => Task.FromResult(f(token)));
+            WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT6_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, token) => Task.FromResult(f(token)));
+            WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT6_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, token) => Task.FromResult(f(token)));
+            WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T6.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT6_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T7.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, token) => f(arg1, arg2, arg3, arg4, arg5, arg6).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, token) => f(arg1, arg2, arg3, arg4, arg5, arg6).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, token) => f(arg1, arg2, arg3, arg4, arg5, arg6).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, token) => f(arg1, arg2, arg3, arg4, arg5, arg6).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T7.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT7_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T7.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, token) => Task.FromResult(f(token)));
+            WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT7_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, token) => Task.FromResult(f(token)));
+            WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT7_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, token) => Task.FromResult(f(token)));
+            WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT7_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, token) => Task.FromResult(f(token)));
+            WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T8.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => Task.FromResult(f(token)));
+            WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT8_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => Task.FromResult(f(token)));
+            WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT8_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => Task.FromResult(f(token)));
+            WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT8_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => Task.FromResult(f(token)));
+            WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T8.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T8.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT8_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T9.Test.cs
@@ -21,7 +21,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -50,7 +50,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -79,7 +79,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_ResultPolicy_DelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -114,7 +114,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_ResultPolicy_ComplexDelayHandler()
         {
             TestFunc nullFunc = null;
-            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(() => 12345).ConfigureAwait(false);
+            TestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
@@ -149,7 +149,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_WithToken_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , DelayPolicy.None));
@@ -185,7 +185,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_WithToken_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                     , (i, r, e) => TimeSpan.Zero));
@@ -221,7 +221,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_WithToken_ResultPolicy_DelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, DelayPolicy.None));
@@ -263,7 +263,7 @@ namespace Sweetener.Reliability.Test
         public void WithAsyncRetryT9_Async_WithToken_ResultPolicy_ComplexDelayHandler()
         {
             InterruptableTestFunc nullFunc = null;
-            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.Run(() => 12345).ConfigureAwait(false);
+            InterruptableTestFunc func     = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult(12345);
             Assert.ThrowsException<ArgumentNullException      >(() => nullFunc.WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => func    .WithAsyncRetry(-2, r => ResultKind.Successful, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, null                      , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T9.Test.cs
@@ -176,6 +176,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => Task.FromResult(f(token)));
+            WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT9_Async_WithToken_ComplexDelayHandler()
@@ -208,6 +212,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => Task.FromResult(f(token)));
+            WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
         [TestMethod]
         public void WithAsyncRetryT9_Async_WithToken_ResultPolicy_DelayHandler()
@@ -246,6 +254,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => Task.FromResult(f(token)));
+            WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
         [TestMethod]
         public void WithAsyncRetryT9_Async_WithToken_ResultPolicy_ComplexDelayHandler()
@@ -284,6 +296,10 @@ namespace Sweetener.Reliability.Test
             // Cancel
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
+
+            // Cancel (Synchronous)
+            funcFactory = f => new InterruptableTestFuncProxy((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => Task.FromResult(f(token)));
+            WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }
     }
 }

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T9.Test.cs
@@ -28,7 +28,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).Result;
@@ -57,7 +57,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).Result;
@@ -87,7 +87,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).Result;
@@ -122,7 +122,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => { await Task.CompletedTask.ConfigureAwait(false); return f(CancellationToken.None); });
+            Func<Func<CancellationToken, int>, TestFuncProxy> funcFactory = f => new TestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(f(CancellationToken.None)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<TestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, TestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<TestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).Result;
@@ -156,7 +156,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token).Result;
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token).Result;
@@ -229,7 +229,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (DelayHandler)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, DelayHandlerProxy> delayHandlerFactory = t => new DelayHandlerProxy((i) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token).Result;
@@ -271,7 +271,7 @@ namespace Sweetener.Reliability.Test
             Assert.ThrowsException<ArgumentNullException      >(() => func    .WithAsyncRetry( 4, r => ResultKind.Successful, ExceptionPolicy.Transient, (ComplexDelayHandler<int>)null));
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => { await Task.CompletedTask.ConfigureAwait(false); return f(token); });
+            Func<Func<CancellationToken, int>, InterruptableTestFuncProxy> funcFactory = f => new InterruptableTestFuncProxy(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult(f(token)));
             Func<TimeSpan, ComplexDelayHandlerProxy> delayHandlerFactory = t => new ComplexDelayHandlerProxy((i, r, e) => t);
             Func<InterruptableTestFunc, int, ResultHandler<int>, ExceptionHandler, Func<int, int, Exception, TimeSpan>, InterruptableTestFunc> withAsyncRetry = (f, m, r, e, d) => f.WithAsyncRetry(m, r, e, d.Invoke);
             Func<InterruptableTestFunc, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, int> invoke = (f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token).Result;

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T1.Test.cs
@@ -801,9 +801,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<CancellationToken, Task<string>>(
                     async (token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T1.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<string>> factory)
         {
-            Func<CancellationToken, Task<string>> func = async (token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<CancellationToken, Task<string>> func = async (token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<string>> factory)
         {
-            Func<CancellationToken, Task<string>> func = async (token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<CancellationToken, Task<string>> func = async (token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<string>> factory)
         {
-            Func<CancellationToken, Task<string>> func = async (token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<CancellationToken, Task<string>> func = async (token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<string>> factory)
         {
-            Func<CancellationToken, Task<string>> func = async (token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<CancellationToken, Task<string>> func = async (token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -297,7 +297,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<string>, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -352,7 +352,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<string>, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -411,7 +411,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<string>, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -471,7 +471,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -538,7 +538,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -605,7 +605,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -666,7 +666,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -727,7 +727,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -873,7 +873,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T10.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T10.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T10.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T11.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T11.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T11.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T12.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T12.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T12.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T13.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T13.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T13.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T14.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T14.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T14.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T15.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T15.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T15.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T16.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T16.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T16.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T17.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T17.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T17.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T17.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T17.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T17.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, string>, int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T2.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, CancellationToken, Task<string>>(
                     async (arg, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T2.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string>> factory)
         {
-            Func<int, CancellationToken, Task<string>> func = async (arg, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, CancellationToken, Task<string>> func = async (arg, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string>> factory)
         {
-            Func<int, CancellationToken, Task<string>> func = async (arg, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, CancellationToken, Task<string>> func = async (arg, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string>> factory)
         {
-            Func<int, CancellationToken, Task<string>> func = async (arg, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, CancellationToken, Task<string>> func = async (arg, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string>> factory)
         {
-            Func<int, CancellationToken, Task<string>> func = async (arg, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, CancellationToken, Task<string>> func = async (arg, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string>, int, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string>, int, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string>, int, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T2.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg, t) => f.InvokeAsync(arg, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg, t) => f.InvokeAsync(arg, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg, t) => f.InvokeAsync(arg, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg, t) => f.InvokeAsync(arg, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string>, int, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string>, int, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, CancellationToken, Task<string>> func = new FuncProxy<int, CancellationToken, Task<string>>(async (arg, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, CancellationToken, Task<string>>(
+                    (arg, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, CancellationToken, Task<string>>(
+                    async (arg, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T3.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, string>> factory)
         {
-            Func<int, string, CancellationToken, Task<string>> func = async (arg1, arg2, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, CancellationToken, Task<string>> func = async (arg1, arg2, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, string>> factory)
         {
-            Func<int, string, CancellationToken, Task<string>> func = async (arg1, arg2, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, CancellationToken, Task<string>> func = async (arg1, arg2, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, string>> factory)
         {
-            Func<int, string, CancellationToken, Task<string>> func = async (arg1, arg2, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, CancellationToken, Task<string>> func = async (arg1, arg2, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, string>> factory)
         {
-            Func<int, string, CancellationToken, Task<string>> func = async (arg1, arg2, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, CancellationToken, Task<string>> func = async (arg1, arg2, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, string>, int, string, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, string>, int, string, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, string>, int, string, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, Task<string>> func = new FuncProxy<int, string, Task<string>>(async (arg1, arg2) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T3.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, CancellationToken, Task<string>>(
                     async (arg1, arg2, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T3.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, t) => f.InvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, t) => f.InvokeAsync(arg1, arg2, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, t) => f.InvokeAsync(arg1, arg2, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, t) => f.InvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, string>, int, string, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, string>, int, string, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, CancellationToken, Task<string>> func = new FuncProxy<int, string, CancellationToken, Task<string>>(async (arg1, arg2, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, CancellationToken, Task<string>>(
+                    (arg1, arg2, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, CancellationToken, Task<string>>(
+                    async (arg1, arg2, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T4.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, string>, int, string, double, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, string>, int, string, double, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, CancellationToken, Task<string>>(async (arg1, arg2, arg3, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T4.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, string>> factory)
         {
-            Func<int, string, double, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, string>> factory)
         {
-            Func<int, string, double, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, string>> factory)
         {
-            Func<int, string, double, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, string>> factory)
         {
-            Func<int, string, double, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, string>, int, string, double, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, string>, int, string, double, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, string>, int, string, double, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T4.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T5.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T5.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, string>, int, string, double, long, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, string>, int, string, double, long, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T5.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, string>> factory)
         {
-            Func<int, string, double, long, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, string>> factory)
         {
-            Func<int, string, double, long, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, string>> factory)
         {
-            Func<int, string, double, long, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, string>> factory)
         {
-            Func<int, string, double, long, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, string>, int, string, double, long, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, string>, int, string, double, long, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, string>, int, string, double, long, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T6.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, string>> factory)
         {
-            Func<int, string, double, long, ushort, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, string>> factory)
         {
-            Func<int, string, double, long, ushort, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, string>> factory)
         {
-            Func<int, string, double, long, ushort, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, string>> factory)
         {
-            Func<int, string, double, long, ushort, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, string>, int, string, double, long, ushort, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, string>, int, string, double, long, ushort, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, string>, int, string, double, long, ushort, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T6.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T6.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, string>, int, string, double, long, ushort, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, string>, int, string, double, long, ushort, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T7.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T7.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, string>, int, string, double, long, ushort, byte, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, string>, int, string, double, long, ushort, byte, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, string>, int, string, double, long, ushort, byte, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T7.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, string>, int, string, double, long, ushort, byte, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, string>, int, string, double, long, ushort, byte, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T8.Test.cs
@@ -285,7 +285,8 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
-                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                 }
             }
@@ -788,18 +789,27 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
-            {
-                await Task.CompletedTask;
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = useSynchronousFunc
+                ? new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>>(
+                    (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>>(
+                    async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T8.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T8.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T9.Test.cs
@@ -806,9 +806,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>>(
                     async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 
             // Declare the various proxies for the input delegates and event handlers

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T9.Test.cs
@@ -164,7 +164,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>>, int, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
 
@@ -182,7 +182,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>>, int, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult("Hello World");
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
 
@@ -200,7 +200,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_DelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, DelayHandler, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             FuncProxy<int, TimeSpan> delayHandler = new FuncProxy<int, TimeSpan>(i => Constants.Delay);
@@ -220,7 +220,7 @@ namespace Sweetener.Reliability.Test
 
         private void Ctor_Interruptable_ResultHandler_ComplexDelayHandler(Func<Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>>, int, ResultHandler<string>, ExceptionHandler, ComplexDelayHandler<string>, ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>> factory)
         {
-            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.Run(() => "Hello World").ConfigureAwait(false);
+            Func<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>> func = async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => await Task.FromResult("Hello World");
             ResultHandler<string> resultHandler = r => r == "Successful Value" ? ResultKind.Successful : ResultKind.Fatal;
             ExceptionHandler exceptionHandler = ExceptionPolicy.Fatal;
             ComplexDelayHandler<string> delayHandler = (i, r, e) => TimeSpan.FromHours(1);
@@ -299,7 +299,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Success(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create a "successful" user-defined function
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(() => "Success").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult("Success"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Result(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, string> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that returns a fatal result
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(() => "Failure").ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult("Failure"));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
@@ -415,7 +415,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run((Func<string>)(() => throw new InvalidOperationException())).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromException<string>(new InvalidOperationException()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -476,7 +476,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -543,7 +543,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -610,7 +610,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -671,7 +671,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -732,7 +732,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -878,7 +878,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.Run(flakyFunc).ConfigureAwait(false));
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(flakyFunc()));
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T1.Test.cs
@@ -906,11 +906,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<CancellationToken, string> func = new FuncProxy<CancellationToken, string>((token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<CancellationToken, string> func = new FuncProxy<CancellationToken, string>(
+                (token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T10.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T10.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T11.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T11.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T12.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T12.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T13.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T13.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T14.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T14.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T15.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T15.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T16.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T16.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T17.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T17.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Tuple<bool, ulong>, DateTime, ulong, sbyte, decimal, char, float, Guid, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T2.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, CancellationToken, string> func = new FuncProxy<int, CancellationToken, string>((arg, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, CancellationToken, string> func = new FuncProxy<int, CancellationToken, string>(
+                (arg, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T3.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, CancellationToken, string> func = new FuncProxy<int, string, CancellationToken, string>((arg1, arg2, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, CancellationToken, string> func = new FuncProxy<int, string, CancellationToken, string>(
+                (arg1, arg2, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T4.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, CancellationToken, string> func = new FuncProxy<int, string, double, CancellationToken, string>((arg1, arg2, arg3, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, CancellationToken, string> func = new FuncProxy<int, string, double, CancellationToken, string>(
+                (arg1, arg2, arg3, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T5.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, CancellationToken, string> func = new FuncProxy<int, string, double, long, CancellationToken, string>((arg1, arg2, arg3, arg4, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, CancellationToken, string> func = new FuncProxy<int, string, double, long, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T6.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T7.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T8.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T9.Test.cs
@@ -911,11 +911,12 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
-            {
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/Func.Extensions.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/Func.Extensions.Test.t4
@@ -133,6 +133,15 @@ namespace Sweetener.Reliability.Test
             WithRetry<#= suffix #>_Canceled_Func (funcFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.<#= delayHandlerExpectation #>, passResultHandler: <#= passResultHandler.ToString().ToLowerInvariant() #>);
             WithRetry<#= suffix #>_Canceled_Delay(funcFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.<#= delayHandlerExpectation #>, passResultHandler: <#= passResultHandler.ToString().ToLowerInvariant() #>);
 <#
+                            if (async)
+                            {
+#>
+
+            // Cancel (Synchronous)
+            funcFactory = f => new <#= inputFuncType #>Proxy((<#= arguments #><#= optionalCommaToken #>) => Task.FromResult(f(<#= optionalToken #>)));
+            WithRetry<#= suffix #>_Canceled_Func (funcFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.<#= delayHandlerExpectation #>, passResultHandler: <#= passResultHandler.ToString().ToLowerInvariant() #>);
+<#
+                            }
                         }
 #>
         }

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/Func.Extensions.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/Func.Extensions.Test.t4
@@ -96,7 +96,7 @@ namespace Sweetener.Reliability.Test
 #>
 
             // Create the delegates necessary to test the WithRetry overload
-            Func<Func<CancellationToken, int>, <#= inputFuncType #>Proxy> funcFactory = f => new <#= inputFuncType #>Proxy(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalCommaToken #>) => <#= async ? $"{{ await Task.CompletedTask.ConfigureAwait(false); return f({optionalToken}); }}" : $"f({optionalToken})" #>);
+            Func<Func<CancellationToken, int>, <#= inputFuncType #>Proxy> funcFactory = f => new <#= inputFuncType #>Proxy(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalCommaToken #>) => <#= async ? $"await Task.FromResult(f({optionalToken}))" : $"f({optionalToken})" #>);
             Func<TimeSpan, <#= delayHandlerTypeProxy #>> delayHandlerFactory = t => new <#= delayHandlerTypeProxy #>((i<#= useComplexHandler ? ", r, e" : string.Empty #>) => t);
             Func<<#= inputFuncType #>, int, ResultHandler<int>, ExceptionHandler, <#= delayHandlerFunc #>, <#= inputFuncType #>> with<#= optionalAsync #>Retry = (f, m, r, e, d) => f.With<#= optionalAsync #>Retry(m<#= passResultHandler ? ", r" : string.Empty #>, e, d.Invoke);
             Func<<#= inputFuncType #><#= optionalComma #><#= typeArguments #>, CancellationToken, int> invoke = (f<#= optionalComma #><#= arguments #>, token) => f(<#= arguments #><#= optionalCommaToken #>)<#= async ? ".Result" : string.Empty #>;

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/ReliableFunc.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/ReliableFunc.Test.t4
@@ -548,7 +548,7 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Failure_Exception(Action<Reliable<#= optionalAsync #>Func<<#= typeArguments #>><#= optionalComma #><#= inputTypeArguments #>, CancellationToken, Type> assertInvoke, bool addEventHandlers)
         {
             // Create an "unsuccessful" user-defined function that throws a fatal exception
-            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetThrowException<InvalidOperationException>(parameterCount, async, outputType: "string") #>);
+            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetThrowDelegate<InvalidOperationException>(parameterCount, async, outputType: "string") #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>();
@@ -616,7 +616,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually succeeds after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Success", 2);
-            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetDelegate(parameterCount, "flakyFunc", async) #>);
+            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetExpressionDelegate(parameterCount, "flakyFunc()", async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -696,7 +696,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry", "Failure", 2);
-            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetDelegate(parameterCount, "flakyFunc", async) #>);
+            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetExpressionDelegate(parameterCount, "flakyFunc()", async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r =>
@@ -776,7 +776,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually fails after a transient result and exception
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException, InvalidOperationException>("Retry", 2);
-            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetDelegate(parameterCount, "flakyFunc", async) #>);
+            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetExpressionDelegate(parameterCount, "flakyFunc()", async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -850,7 +850,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetDelegate(parameterCount, "flakyFunc", async) #>);
+            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetExpressionDelegate(parameterCount, "flakyFunc()", async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -924,7 +924,7 @@ namespace Sweetener.Reliability.Test
         {
             // Create a user-defined function that eventually exhausts the maximum number of retries after transient results and exceptions
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetDelegate(parameterCount, "flakyFunc", async) #>);
+            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetExpressionDelegate(parameterCount, "flakyFunc()", async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Retry" ? ResultKind.Transient : ResultKind.Successful);
@@ -1101,7 +1101,7 @@ namespace Sweetener.Reliability.Test
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetDelegate(parameterCount, "flakyFunc", async) #>);
+            FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetExpressionDelegate(parameterCount, "flakyFunc()", async) #>);
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/ReliableFunc.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/ReliableFunc.Test.t4
@@ -319,7 +319,21 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+<#
+        if (async)
+        {
+#>
+                    Invoke_Canceled_Func ((f<#= optionalComma #><#= arguments #>, t) => f.InvokeAsync(<#= arguments #><#= optionalComma #>t).Wait(), addEventHandlers, useSynchronousFunc: false);
+                    Invoke_Canceled_Func ((f<#= optionalComma #><#= arguments #>, t) => f.InvokeAsync(<#= arguments #><#= optionalComma #>t).Wait(), addEventHandlers, useSynchronousFunc: true );
+<#
+        }
+        else
+        {
+#>
                     Invoke_Canceled_Func ((f<#= optionalComma #><#= arguments #>, t) => f.InvokeAsync(<#= arguments #><#= optionalComma #>t).Wait(), addEventHandlers);
+<#
+        }
+#>
                     Invoke_Canceled_Delay((f<#= optionalComma #><#= arguments #>, t) => f.InvokeAsync(<#= arguments #><#= optionalComma #>t).Wait(), addEventHandlers);
                 }
             }
@@ -980,25 +994,45 @@ namespace Sweetener.Reliability.Test
 
         #region Invoke_Canceled_Func
 
-        private void Invoke_Canceled_Func(Action<Reliable<#= optionalAsync #>Func<<#= typeArguments #>><#= optionalComma #><#= inputTypeArguments #>, CancellationToken> invoke, bool addEventHandlers)
+        private void Invoke_Canceled_Func(Action<Reliable<#= optionalAsync #>Func<<#= typeArguments #>><#= optionalComma #><#= inputTypeArguments #>, CancellationToken> invoke, bool addEventHandlers<#= async ? ", bool useSynchronousFunc" : string.Empty #>)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             // Create a user-defined action that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
-            FuncProxy<#= tokenInputFuncTypeArguments #> func = new FuncProxy<#= tokenInputFuncTypeArguments #>(<#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalComma #>token) =>
-            {
 <#
         if (async)
         {
 #>
-                await Task.CompletedTask;
+            // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
+            FuncProxy<#= tokenInputFuncTypeArguments #> func = useSynchronousFunc
+                ? new FuncProxy<#= tokenInputFuncTypeArguments #>(
+                    (<#= arguments #><#= optionalComma #>token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return Task.FromResult(flakyFunc());
+                    })
+                : new FuncProxy<#= tokenInputFuncTypeArguments #>(
+                    async (<#= arguments #><#= optionalComma #>token) =>
+                    {
+                        await Task.CompletedTask;
+                        token.ThrowIfCancellationRequested();
+                        return flakyFunc();
+                    });
+<#
+        }
+        else
+        {
+#>
+            FuncProxy<#= tokenInputFuncTypeArguments #> func = new FuncProxy<#= tokenInputFuncTypeArguments #>(
+                (<#= arguments #><#= optionalComma #>token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    return flakyFunc();
+                });
 <#
         }
 #>
-                token.ThrowIfCancellationRequested();
-                return flakyFunc();
-            });
 
             // Declare the various proxies for the input delegates and event handlers
             FuncProxy<string, ResultKind>               resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Transient);

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/ReliableFunc.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/ReliableFunc.Test.t4
@@ -1015,9 +1015,8 @@ namespace Sweetener.Reliability.Test
                 : new FuncProxy<#= tokenInputFuncTypeArguments #>(
                     async (<#= arguments #><#= optionalComma #>token) =>
                     {
-                        await Task.CompletedTask;
                         token.ThrowIfCancellationRequested();
-                        return flakyFunc();
+                        return await Task.FromResult(flakyFunc());
                     });
 <#
         }

--- a/src/Sweetener.Reliability.Test/Operation.cs
+++ b/src/Sweetener.Reliability.Test/Operation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 
 namespace Sweetener.Reliability.Test
 {
@@ -7,12 +6,7 @@ namespace Sweetener.Reliability.Test
     {
         public static readonly Action Null = NoOp;
 
-        public static readonly Func<Task> NullAsync = NoOpAsync;
-
         private static void NoOp()
         { }
-
-        private static async Task NoOpAsync()
-            => await Task.CompletedTask;
     }
 }

--- a/src/Sweetener.Reliability.Test/TextTemplating/Include.t4
+++ b/src/Sweetener.Reliability.Test/TextTemplating/Include.t4
@@ -60,7 +60,7 @@
         return string.Join(", ", typeArgs.Take(count).Concat(additionalElements));
     }
 
-    public string GetDelegate(int argCount, string delegateName, bool async, bool interruptable = false)
+    public string GetActionInvokeDelegate(int argCount, string delegateName, bool async, bool interruptable = false)
     {
         string args          = GetArguments(argCount);
         string optionalComma = argCount > 0 ? ", " : string.Empty;
@@ -69,7 +69,7 @@
         if (!async)
             return $"({args}{optionalToken}) => {delegateName}()";
 
-        return $"async ({args}{optionalToken}) => await Task.Run({delegateName}).ConfigureAwait(false)";
+        return $"async ({args}{optionalToken}) => {{ {delegateName}(); await Task.CompletedTask; }}";
     }
 
     public string GetExpressionDelegate(int argCount, string expression, bool async, bool interruptable = false)
@@ -81,10 +81,10 @@
         if (!async)
             return $"({args}{optionalToken}) => {expression}";
 
-        return $"async ({args}{optionalToken}) => await Task.Run(() => {expression}).ConfigureAwait(false)";
+        return $"async ({args}{optionalToken}) => await Task.FromResult({expression})";
     }
 
-    public string GetThrowException<T>(int argCount, bool async, bool interruptable = false, string outputType = null)
+    public string GetThrowDelegate<T>(int argCount, bool async, bool interruptable = false, string outputType = null)
         where T : Exception
     {
         string args          = GetArguments(argCount);
@@ -95,9 +95,9 @@
             return $"({args}{optionalToken}) => throw new {typeof(T).Name}()";
 
         if (outputType == null)
-            return $"async ({args}{optionalToken}) => await Task.Run(() => throw new {typeof(T).Name}()).ConfigureAwait(false)";
+            return $"async ({args}{optionalToken}) => await Task.FromException(new {typeof(T).Name}())";
         else
-            return $"async ({args}{optionalToken}) => await Task.Run((Func<{outputType}>)(() => throw new {typeof(T).Name}())).ConfigureAwait(false)";
+            return $"async ({args}{optionalToken}) => await Task.FromException<{outputType}>(new {typeof(T).Name}())";
     }
 
     public string GetNoOpDelegate(int argCount, bool async, bool interruptable = false)
@@ -109,6 +109,6 @@
         if (!async)
             return $"({args}{optionalToken}) => Operation.Null()";
 
-        return $"async ({args}{optionalToken}) => await Operation.NullAsync().ConfigureAwait(false)";
+        return $"async ({args}{optionalToken}) => await Task.CompletedTask";
     }
 #>

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T1.cs
@@ -152,7 +152,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T1.cs
@@ -60,10 +60,11 @@ namespace Sweetener.Reliability
 
             return async (arg) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -138,10 +139,11 @@ namespace Sweetener.Reliability
 
             return async (arg, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T10.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T10.cs
@@ -78,10 +78,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -174,10 +175,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T10.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T10.cs
@@ -188,7 +188,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T11.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T11.cs
@@ -80,10 +80,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -178,10 +179,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T11.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T11.cs
@@ -192,7 +192,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T12.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T12.cs
@@ -196,7 +196,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T12.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T12.cs
@@ -82,10 +82,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -182,10 +183,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T13.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T13.cs
@@ -84,10 +84,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -186,10 +187,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T13.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T13.cs
@@ -200,7 +200,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T14.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T14.cs
@@ -204,7 +204,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T14.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T14.cs
@@ -86,10 +86,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -190,10 +191,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T15.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T15.cs
@@ -88,10 +88,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -194,10 +195,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T15.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T15.cs
@@ -208,7 +208,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T16.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T16.cs
@@ -212,7 +212,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T16.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T16.cs
@@ -90,10 +90,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -198,10 +199,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T2.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T2.cs
@@ -156,7 +156,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T2.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T2.cs
@@ -62,10 +62,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -142,10 +143,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T3.cs
@@ -64,10 +64,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -146,10 +147,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T3.cs
@@ -160,7 +160,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T4.cs
@@ -66,10 +66,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -150,10 +151,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T4.cs
@@ -164,7 +164,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T5.cs
@@ -168,7 +168,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T5.cs
@@ -68,10 +68,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -154,10 +155,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T6.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T6.cs
@@ -172,7 +172,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T6.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T6.cs
@@ -70,10 +70,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -158,10 +159,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T7.cs
@@ -176,7 +176,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T7.cs
@@ -72,10 +72,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -162,10 +163,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T8.cs
@@ -74,10 +74,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -166,10 +167,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T8.cs
@@ -180,7 +180,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T9.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T9.cs
@@ -76,10 +76,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -170,10 +171,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T9.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T9.cs
@@ -184,7 +184,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.cs
@@ -151,7 +151,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.cs
@@ -61,10 +61,11 @@ namespace Sweetener.Reliability
 
             return async () =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -137,10 +138,11 @@ namespace Sweetener.Reliability
 
             return async (cancellationToken) =>
             {
-                Task t = null;
+                Task t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T1.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T1.cs
@@ -128,7 +128,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T10.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T10.cs
@@ -155,7 +155,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T11.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T11.cs
@@ -158,7 +158,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T12.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T12.cs
@@ -161,7 +161,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T13.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T13.cs
@@ -164,7 +164,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T14.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T14.cs
@@ -167,7 +167,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T15.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T15.cs
@@ -170,7 +170,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T16.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T16.cs
@@ -173,7 +173,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T2.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T2.cs
@@ -131,7 +131,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T3.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T3.cs
@@ -134,7 +134,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T4.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T4.cs
@@ -137,7 +137,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T5.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T5.cs
@@ -140,7 +140,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T6.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T6.cs
@@ -143,7 +143,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T7.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T7.cs
@@ -146,7 +146,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T8.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T8.cs
@@ -149,7 +149,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T9.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T9.cs
@@ -152,7 +152,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.cs
@@ -125,7 +125,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Action/TextTemplating/Action.Extensions.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/Action.Extensions.t4
@@ -41,7 +41,7 @@ namespace Sweetener.Reliability
         foreach (bool interruptable in new bool[] { false, true })
         {
             string inputActionType           = (async ? "Func" : "Action") + Enclose(GetActionTypeParameters(parameterCount, async, interruptable), BracketType.AngleBrackets);
-            string optionalCancellationCheck = interruptable ? (async ? "t.IsCanceled" : "e.IsCancellation(cancellationToken)") + " || " : string.Empty;
+            string optionalCancellationCheck = interruptable ? (async ? "isCanceled" : "e.IsCancellation(cancellationToken)") + " || " : string.Empty;
             string asyncOperationSuffx       = async ? ".ConfigureAwait(false)" : ".Wait(" + (interruptable ? "cancellationToken" : string.Empty) + ")";
 #>
         #region <#= inputActionType #>
@@ -113,6 +113,14 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
+<#
+        if (async && interruptable)
+        {
+#>
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+<#
+        }
+#>
                     if (<#= optionalCancellationCheck #>!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 

--- a/src/Sweetener.Reliability/Action/TextTemplating/Action.Extensions.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/Action.Extensions.t4
@@ -83,13 +83,21 @@ namespace Sweetener.Reliability
             if (async)
             {
 #>
-                Task t = null;
+                Task t;
 <#
             }
 #>
                 int attempt = 0;
 
             Attempt:
+<#
+        if (async)
+        {
+#>
+                t = null;
+<#
+        }
+#>
                 attempt++;
 
                 try

--- a/src/Sweetener.Reliability/Action/TextTemplating/ReliableAction.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/ReliableAction.t4
@@ -216,7 +216,15 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (<#= async ? "t.IsCanceled" : "e.IsCancellation(cancellationToken)" #> || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+<#
+        if (async)
+        {
+#>
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+<#
+        }
+#>
+                    if (<#= async ? "isCanceled" : "e.IsCancellation(cancellationToken)" #> || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                         throw;
                 }
             } while (true);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T1.cs
@@ -116,10 +116,11 @@ namespace Sweetener.Reliability
 
             return async () =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -254,10 +255,11 @@ namespace Sweetener.Reliability
 
             return async (cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -267,7 +269,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T10.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T10.cs
@@ -149,10 +149,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -323,10 +324,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -336,7 +338,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T11.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T11.cs
@@ -153,10 +153,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -331,10 +332,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -344,7 +346,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T12.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T12.cs
@@ -157,10 +157,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -339,10 +340,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -352,7 +354,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T13.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T13.cs
@@ -161,10 +161,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -347,10 +348,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -360,7 +362,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T14.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T14.cs
@@ -165,10 +165,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -355,10 +356,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -368,7 +370,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T15.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T15.cs
@@ -169,10 +169,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -363,10 +364,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -376,7 +378,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T16.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T16.cs
@@ -173,10 +173,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -371,10 +372,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -384,7 +386,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T17.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T17.cs
@@ -177,10 +177,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -379,10 +380,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -392,7 +394,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T2.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T2.cs
@@ -117,10 +117,11 @@ namespace Sweetener.Reliability
 
             return async (arg) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -259,10 +260,11 @@ namespace Sweetener.Reliability
 
             return async (arg, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -272,7 +274,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T3.cs
@@ -121,10 +121,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -267,10 +268,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -280,7 +282,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T4.cs
@@ -125,10 +125,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -275,10 +276,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -288,7 +290,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T5.cs
@@ -129,10 +129,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -283,10 +284,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -296,7 +298,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T6.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T6.cs
@@ -133,10 +133,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -291,10 +292,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -304,7 +306,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T7.cs
@@ -137,10 +137,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -299,10 +300,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -312,7 +314,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T8.cs
@@ -141,10 +141,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -307,10 +308,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -320,7 +322,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T9.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T9.cs
@@ -145,10 +145,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -315,10 +316,11 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken) =>
             {
-                Task<TResult> t = null;
+                Task<TResult> t;
                 int attempt = 0;
 
             Attempt:
+                t = null;
                 attempt++;
 
                 try
@@ -328,7 +330,8 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
-                    if (t.IsCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T1.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T1.cs
@@ -195,10 +195,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -208,7 +209,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T10.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T10.cs
@@ -222,10 +222,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -235,7 +236,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T11.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T11.cs
@@ -225,10 +225,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -238,7 +239,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T12.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T12.cs
@@ -228,10 +228,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -241,7 +242,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T13.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T13.cs
@@ -231,10 +231,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -244,7 +245,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T14.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T14.cs
@@ -234,10 +234,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -247,7 +248,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T15.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T15.cs
@@ -237,10 +237,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -250,7 +251,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T16.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T16.cs
@@ -240,10 +240,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -253,7 +254,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T17.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T17.cs
@@ -243,10 +243,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -256,7 +257,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T2.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T2.cs
@@ -198,10 +198,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T arg, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -211,7 +212,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T3.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T3.cs
@@ -201,10 +201,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -214,7 +215,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T4.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T4.cs
@@ -204,10 +204,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -217,7 +218,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T5.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T5.cs
@@ -207,10 +207,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -220,7 +221,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T6.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T6.cs
@@ -210,10 +210,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -223,7 +224,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T7.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T7.cs
@@ -213,10 +213,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -226,7 +227,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T8.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T8.cs
@@ -216,10 +216,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -229,7 +230,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T9.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T9.cs
@@ -219,10 +219,11 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
-            Task<TResult> t = null;
+            Task<TResult> t;
             int attempt = 0;
 
         Attempt:
+            t = null;
             attempt++;
 
             try
@@ -232,7 +233,8 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (t.IsCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;

--- a/src/Sweetener.Reliability/Func/TextTemplating/Func.Extensions.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/Func.Extensions.t4
@@ -43,7 +43,7 @@ namespace Sweetener.Reliability
         {
             string inputTypeParameters       = GetFuncTypeParameters(parameterCount, async, interruptable);
             string optionalToken             = interruptable ? optionalComma + "cancellationToken" : string.Empty;
-            string optionalCancellationCheck = interruptable ? (async ? "t.IsCanceled" : "e.IsCancellation(cancellationToken)") + " || " : string.Empty;
+            string optionalCancellationCheck = interruptable ? (async ? "isCanceled" : "e.IsCancellation(cancellationToken)") + " || " : string.Empty;
             string asyncOperationSuffx       = async ? ".ConfigureAwait(false)" : ".Wait(" + (interruptable ? "cancellationToken" : string.Empty) + ")";
 #>
         #region Func<<#= inputTypeParameters #>>
@@ -114,10 +114,18 @@ namespace Sweetener.Reliability
 
             return <#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalToken #>) =>
             {
-                <#= async ? "Task<TResult> t = null" : "TResult result" #>;
+                <#= async ? "Task<TResult> t" : "TResult result" #>;
                 int attempt = 0;
 
             Attempt:
+<#
+        if (async)
+        {
+#>
+                t = null;
+<#
+        }
+#>
                 attempt++;
 
                 try
@@ -140,6 +148,14 @@ namespace Sweetener.Reliability
                 }
                 catch (Exception e)
                 {
+<#
+        if (async && interruptable)
+        {
+#>
+                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+<#
+        }
+#>
                     if (<#= optionalCancellationCheck #>!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 

--- a/src/Sweetener.Reliability/Func/TextTemplating/ReliableFunc.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/ReliableFunc.t4
@@ -239,10 +239,18 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
-            <#= async ? "Task<TResult> t = null" : "TResult result" #>;
+            <#= async ? "Task<TResult> t" : "TResult result" #>;
             int attempt = 0;
 
         Attempt:
+<#
+        if (async)
+        {
+#>
+            t = null;
+<#
+        }
+#>
             attempt++;
 
             try
@@ -265,7 +273,15 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (<#= async ? "t.IsCanceled" : "e.IsCancellation(cancellationToken)" #> || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+<#
+        if (async)
+        {
+#>
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+<#
+        }
+#>
+                if (<#= async ? "isCanceled" : "e.IsCancellation(cancellationToken)" #> || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;


### PR DESCRIPTION
- Perform null-checks before determining cancellation
- Reset local Task variable before each execution attempt
- Refactor some test classes