### PR TITLE
Refactor Async Invoke Overloads

### DIFF
--- a/src/Sweetener.Reliability/Action/ReliableAction.T1.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T1.cs
@@ -139,8 +139,8 @@ namespace Sweetener.Reliability
         /// </remarks>
         /// <param name="arg">The parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T arg)
-            => await InvokeAsync(arg, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T arg)
+            => InvokeAsync(arg, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -237,8 +237,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T arg)
-            => await TryInvokeAsync(arg, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T arg)
+            => TryInvokeAsync(arg, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T10.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T10.cs
@@ -175,8 +175,8 @@ namespace Sweetener.Reliability
         /// <param name="arg9">The ninth parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg10">The tenth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -309,8 +309,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T11.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T11.cs
@@ -179,8 +179,8 @@ namespace Sweetener.Reliability
         /// <param name="arg10">The tenth parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg11">The eleventh parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -317,8 +317,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T12.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T12.cs
@@ -183,8 +183,8 @@ namespace Sweetener.Reliability
         /// <param name="arg11">The eleventh parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg12">The twelfth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -325,8 +325,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T13.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T13.cs
@@ -187,8 +187,8 @@ namespace Sweetener.Reliability
         /// <param name="arg12">The twelfth parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg13">The thirteenth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -333,8 +333,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T14.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T14.cs
@@ -191,8 +191,8 @@ namespace Sweetener.Reliability
         /// <param name="arg13">The thirteenth parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg14">The fourteenth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -341,8 +341,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T15.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T15.cs
@@ -195,8 +195,8 @@ namespace Sweetener.Reliability
         /// <param name="arg14">The fourteenth parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg15">The fifteenth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -349,8 +349,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T16.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T16.cs
@@ -199,8 +199,8 @@ namespace Sweetener.Reliability
         /// <param name="arg15">The fifteenth parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg16">The sixteenth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -357,8 +357,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T2.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T2.cs
@@ -143,8 +143,8 @@ namespace Sweetener.Reliability
         /// <param name="arg1">The first parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg2">The second parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2)
-            => await InvokeAsync(arg1, arg2, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2)
+            => InvokeAsync(arg1, arg2, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -245,8 +245,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2)
-            => await TryInvokeAsync(arg1, arg2, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2)
+            => TryInvokeAsync(arg1, arg2, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T3.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T3.cs
@@ -147,8 +147,8 @@ namespace Sweetener.Reliability
         /// <param name="arg2">The second parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg3">The third parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3)
-            => await InvokeAsync(arg1, arg2, arg3, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3)
+            => InvokeAsync(arg1, arg2, arg3, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -253,8 +253,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3)
-            => await TryInvokeAsync(arg1, arg2, arg3, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3)
+            => TryInvokeAsync(arg1, arg2, arg3, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T4.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T4.cs
@@ -151,8 +151,8 @@ namespace Sweetener.Reliability
         /// <param name="arg3">The third parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg4">The fourth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => InvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -261,8 +261,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T5.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T5.cs
@@ -155,8 +155,8 @@ namespace Sweetener.Reliability
         /// <param name="arg4">The fourth parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg5">The fifth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -269,8 +269,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T6.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T6.cs
@@ -159,8 +159,8 @@ namespace Sweetener.Reliability
         /// <param name="arg5">The fifth parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg6">The sixth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -277,8 +277,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T7.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T7.cs
@@ -163,8 +163,8 @@ namespace Sweetener.Reliability
         /// <param name="arg6">The sixth parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg7">The seventh parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -285,8 +285,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T8.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T8.cs
@@ -167,8 +167,8 @@ namespace Sweetener.Reliability
         /// <param name="arg7">The seventh parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg8">The eighth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -293,8 +293,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.T9.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T9.cs
@@ -171,8 +171,8 @@ namespace Sweetener.Reliability
         /// <param name="arg8">The eighth parameter of the method that this reliable delegate encapsulates.</param>
         /// <param name="arg9">The ninth parameter of the method that this reliable delegate encapsulates.</param>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -301,8 +301,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAction.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.cs
@@ -135,8 +135,8 @@ namespace Sweetener.Reliability
         /// If the encapsulated method succeeds without retrying, the method executes synchronously.
         /// </remarks>
         /// <returns>A task that represents the asynchronous invoke operation.</returns>
-        public async Task InvokeAsync()
-            => await InvokeAsync(CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync()
+            => InvokeAsync(CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -229,8 +229,8 @@ namespace Sweetener.Reliability
         /// parameter contains <see langword="true"/> if the encapsulated method completed without throwing
         /// an exception within the maximum number of retries; otherwise, <see langword="false"/>.
         /// </returns>
-        public async Task<bool> TryInvokeAsync()
-            => await TryInvokeAsync(CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync()
+            => TryInvokeAsync(CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T1.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T1.cs
@@ -101,8 +101,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T arg)
-            => await InvokeAsync(arg, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T arg)
+            => InvokeAsync(arg, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -162,8 +162,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T arg)
-            => await TryInvokeAsync(arg, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T arg)
+            => TryInvokeAsync(arg, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T10.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T10.cs
@@ -119,8 +119,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -198,8 +198,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T11.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T11.cs
@@ -121,8 +121,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -202,8 +202,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T12.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T12.cs
@@ -123,8 +123,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -206,8 +206,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T13.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T13.cs
@@ -125,8 +125,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -210,8 +210,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T14.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T14.cs
@@ -127,8 +127,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -214,8 +214,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T15.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T15.cs
@@ -129,8 +129,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -218,8 +218,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T16.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T16.cs
@@ -131,8 +131,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -222,8 +222,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T2.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T2.cs
@@ -103,8 +103,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2)
-            => await InvokeAsync(arg1, arg2, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2)
+            => InvokeAsync(arg1, arg2, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -166,8 +166,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2)
-            => await TryInvokeAsync(arg1, arg2, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2)
+            => TryInvokeAsync(arg1, arg2, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T3.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T3.cs
@@ -105,8 +105,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3)
-            => await InvokeAsync(arg1, arg2, arg3, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3)
+            => InvokeAsync(arg1, arg2, arg3, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -170,8 +170,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3)
-            => await TryInvokeAsync(arg1, arg2, arg3, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3)
+            => TryInvokeAsync(arg1, arg2, arg3, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T4.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T4.cs
@@ -107,8 +107,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => InvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -174,8 +174,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T5.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T5.cs
@@ -109,8 +109,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -178,8 +178,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T6.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T6.cs
@@ -111,8 +111,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -182,8 +182,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T7.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T7.cs
@@ -113,8 +113,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -186,8 +186,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T8.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T8.cs
@@ -115,8 +115,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -190,8 +190,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T9.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T9.cs
@@ -117,8 +117,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -194,8 +194,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.cs
@@ -99,8 +99,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task InvokeAsync()
-            => await InvokeAsync(CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync()
+            => InvokeAsync(CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -158,8 +158,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task"/>.
         /// </exception>
-        public async Task<bool> TryInvokeAsync()
-            => await TryInvokeAsync(CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync()
+            => TryInvokeAsync(CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Action/TextTemplating/ReliableAction.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/ReliableAction.t4
@@ -165,8 +165,8 @@ namespace Sweetener.Reliability
 <#
         }
 #>
-        public async Task InvokeAsync(<#= parameters #>)
-            => await InvokeAsync(<#= arguments #><#= optionalComma #>CancellationToken.None).ConfigureAwait(false);
+        public Task InvokeAsync(<#= parameters #>)
+            => InvokeAsync(<#= arguments #><#= optionalComma #>CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -354,8 +354,8 @@ namespace Sweetener.Reliability
 <#
         }
 #>
-        public async Task<bool> TryInvokeAsync(<#= parameters #>)
-            => await TryInvokeAsync(<#= arguments #><#= optionalComma #>CancellationToken.None).ConfigureAwait(false);
+        public Task<bool> TryInvokeAsync(<#= parameters #>)
+            => TryInvokeAsync(<#= arguments #><#= optionalComma #>CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T1.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T1.cs
@@ -187,8 +187,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync()
-            => await InvokeAsync(CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync()
+            => InvokeAsync(CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -252,8 +252,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync()
-            => await TryInvokeAsync(CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync()
+            => TryInvokeAsync(CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T10.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T10.cs
@@ -205,8 +205,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -288,8 +288,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T11.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T11.cs
@@ -207,8 +207,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -292,8 +292,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T12.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T12.cs
@@ -209,8 +209,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -296,8 +296,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T13.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T13.cs
@@ -211,8 +211,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -300,8 +300,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T14.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T14.cs
@@ -213,8 +213,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -304,8 +304,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T15.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T15.cs
@@ -215,8 +215,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -308,8 +308,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T16.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T16.cs
@@ -217,8 +217,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -312,8 +312,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T17.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T17.cs
@@ -219,8 +219,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -316,8 +316,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T2.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T2.cs
@@ -189,8 +189,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T arg)
-            => await InvokeAsync(arg, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T arg)
+            => InvokeAsync(arg, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -256,8 +256,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T arg)
-            => await TryInvokeAsync(arg, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T arg)
+            => TryInvokeAsync(arg, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T3.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T3.cs
@@ -191,8 +191,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2)
-            => await InvokeAsync(arg1, arg2, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2)
+            => InvokeAsync(arg1, arg2, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -260,8 +260,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2)
-            => await TryInvokeAsync(arg1, arg2, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2)
+            => TryInvokeAsync(arg1, arg2, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T4.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T4.cs
@@ -193,8 +193,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3)
-            => await InvokeAsync(arg1, arg2, arg3, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3)
+            => InvokeAsync(arg1, arg2, arg3, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -264,8 +264,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3)
-            => await TryInvokeAsync(arg1, arg2, arg3, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3)
+            => TryInvokeAsync(arg1, arg2, arg3, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T5.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T5.cs
@@ -195,8 +195,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => InvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -268,8 +268,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T6.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T6.cs
@@ -197,8 +197,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -272,8 +272,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T7.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T7.cs
@@ -199,8 +199,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -276,8 +276,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T8.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T8.cs
@@ -201,8 +201,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -280,8 +280,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T9.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T9.cs
@@ -203,8 +203,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -284,8 +284,8 @@ namespace Sweetener.Reliability
         /// <exception cref="InvalidOperationException">
         /// The encapsulated method returned <see langword="null"/> instead of a valid <see cref="Task{TResult}"/>.
         /// </exception>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T1.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T1.cs
@@ -230,8 +230,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync()
-            => await InvokeAsync(CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync()
+            => InvokeAsync(CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -351,8 +351,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync()
-            => await TryInvokeAsync(CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync()
+            => TryInvokeAsync(CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T10.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T10.cs
@@ -266,8 +266,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -423,8 +423,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T11.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T11.cs
@@ -270,8 +270,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -431,8 +431,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T12.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T12.cs
@@ -274,8 +274,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -439,8 +439,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T13.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T13.cs
@@ -278,8 +278,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -447,8 +447,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T14.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T14.cs
@@ -282,8 +282,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -455,8 +455,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T15.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T15.cs
@@ -286,8 +286,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -463,8 +463,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T16.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T16.cs
@@ -290,8 +290,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -471,8 +471,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T17.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T17.cs
@@ -294,8 +294,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -479,8 +479,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T2.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T2.cs
@@ -234,8 +234,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T arg)
-            => await InvokeAsync(arg, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T arg)
+            => InvokeAsync(arg, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -359,8 +359,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T arg)
-            => await TryInvokeAsync(arg, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T arg)
+            => TryInvokeAsync(arg, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T3.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T3.cs
@@ -238,8 +238,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2)
-            => await InvokeAsync(arg1, arg2, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2)
+            => InvokeAsync(arg1, arg2, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -367,8 +367,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2)
-            => await TryInvokeAsync(arg1, arg2, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2)
+            => TryInvokeAsync(arg1, arg2, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T4.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T4.cs
@@ -242,8 +242,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3)
-            => await InvokeAsync(arg1, arg2, arg3, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3)
+            => InvokeAsync(arg1, arg2, arg3, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -375,8 +375,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3)
-            => await TryInvokeAsync(arg1, arg2, arg3, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3)
+            => TryInvokeAsync(arg1, arg2, arg3, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T5.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T5.cs
@@ -246,8 +246,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => InvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -383,8 +383,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T6.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T6.cs
@@ -250,8 +250,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -391,8 +391,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T7.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T7.cs
@@ -254,8 +254,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -399,8 +399,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T8.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T8.cs
@@ -258,8 +258,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -407,8 +407,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T9.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T9.cs
@@ -262,8 +262,8 @@ namespace Sweetener.Reliability
         /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
         /// parameter contains the return value of the method that this reliable delegate encapsulates.
         /// </returns>
-        public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
-            => await InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -415,8 +415,8 @@ namespace Sweetener.Reliability
         /// parameter optionally contains the result of the encapsulated method if it succeeded.
         /// Otherwise the value is left undefined if the encapsulated method failed.
         /// </returns>
-        public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
-            => await TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.

--- a/src/Sweetener.Reliability/Func/TextTemplating/ReliableFunc.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/ReliableFunc.t4
@@ -234,8 +234,8 @@ namespace Sweetener.Reliability
 <#
         }
 #>
-        public async Task<TResult> InvokeAsync(<#= parameters #>)
-            => await InvokeAsync(<#= arguments #><#= optionalComma #>CancellationToken.None).ConfigureAwait(false);
+        public Task<TResult> InvokeAsync(<#= parameters #>)
+            => InvokeAsync(<#= arguments #><#= optionalComma #>CancellationToken.None);
 
         /// <summary>
         /// Asynchronously invokes the encapsulated method despite transient errors.
@@ -450,8 +450,8 @@ namespace Sweetener.Reliability
 <#
         }
 #>
-        public async Task<Optional<TResult>> TryInvokeAsync(<#= parameters #>)
-            => await TryInvokeAsync(<#= arguments #><#= optionalComma #>CancellationToken.None).ConfigureAwait(false);
+        public Task<Optional<TResult>> TryInvokeAsync(<#= parameters #>)
+            => TryInvokeAsync(<#= arguments #><#= optionalComma #>CancellationToken.None);
 
         /// <summary>
         /// Asynchronously attempts to successfully invoke the encapsulated method despite transient errors.


### PR DESCRIPTION
- Avoid `async`/`await` in some asynchronous method overloads