### PR TITLE
Sign Assemblies and Packages with Trusted Code Signing Certificate

### DIFF
--- a/eng/CI/Templates/Steps.Package.yml
+++ b/eng/CI/Templates/Steps.Package.yml
@@ -12,7 +12,7 @@ parameters:
   default: 'https://sugarman-keyvault.vault.azure.net/'
 - name: certificateName
   type: string
-  default: 'Test-Certificate-2' # TODO: Update with real certificate
+  default: 'Sugarman-Code-Signing-Certificate-Test' # TODO: Update with real certificate
 - name: netfxTools
   type: string
   default: 'C:/Program Files (x86)/Microsoft SDKs/Windows/v10.0A/bin/NETFX 4.8 Tools'

--- a/eng/CI/Templates/Steps.Package.yml
+++ b/eng/CI/Templates/Steps.Package.yml
@@ -12,7 +12,7 @@ parameters:
   default: 'https://sugarman-keyvault.vault.azure.net/'
 - name: certificateName
   type: string
-  default: 'Sugarman-Code-Signing-Certificate-Test' # TODO: Update with real certificate
+  default: 'Sugarman-Code-Signing'
 - name: netfxTools
   type: string
   default: 'C:/Program Files (x86)/Microsoft SDKs/Windows/v10.0A/bin/NETFX 4.8 Tools'
@@ -60,7 +60,7 @@ steps:
   inputs:
     azureSubscription: 'Sweetener-Pipelines-Test'
     keyVaultName: 'Sugarman-KeyVault'
-    secretsFilter: 'Sweetener-Strong-Name-Key,Test-Client-Id,Test-Client-Secret'
+    secretsFilter: 'Sweetener-Strong-Name-Key,Sweetener-Pipelines-Client-Id,Sweetener-Pipelines-Client-Secret'
 
 - task: PowerShell@2
   displayName: 'Create .snk File'
@@ -78,8 +78,8 @@ steps:
                 -StrongNameKeyPath "$(Agent.TempDirectory)/${{ parameters.StrongNameKeyFile }}"
                 -KeyVaultUrl "${{ parameters.KeyVaultUrl }}"
                 -KeyVaultCertificateName "${{ parameters.CertificateName }}"
-                -KeyVaultClientId "$(Test-Client-Id)"
-                -KeyVaultClientSecret "$(Test-Client-Secret)"
+                -KeyVaultClientId "$(Sweetener-Pipelines-Client-Id)"
+                -KeyVaultClientSecret "$(Sweetener-Pipelines-Client-Secret)"
                 -NetFXTools "${{ parameters.NetFXTools }}"
                 -DotNetTools "${{ parameters.DotNetTools }}"'
     pwsh: true
@@ -112,8 +112,8 @@ steps:
                 -PackageVersion "$(Version.Package)"
                 -KeyVaultUrl "${{ parameters.KeyVaultUrl }}"
                 -KeyVaultCertificateName "${{ parameters.CertificateName }}"
-                -KeyVaultClientId "$(Test-Client-Id)"
-                -KeyVaultClientSecret "$(Test-Client-Secret)"
+                -KeyVaultClientId "$(Sweetener-Pipelines-Client-Id)"
+                -KeyVaultClientSecret "$(Sweetener-Pipelines-Client-Secret)"
                 -DotNetTools "${{ parameters.DotNetTools }}"'
     pwsh: true
 

--- a/eng/CI/Templates/Steps.Package.yml
+++ b/eng/CI/Templates/Steps.Package.yml
@@ -12,7 +12,7 @@ parameters:
   default: 'https://sugarman-keyvault.vault.azure.net/'
 - name: certificateName
   type: string
-  default: 'Sugarman-Code-Signing'
+  default: 'William-Sugarman-Code-Signing'
 - name: netfxTools
   type: string
   default: 'C:/Program Files (x86)/Microsoft SDKs/Windows/v10.0A/bin/NETFX 4.8 Tools'
@@ -58,7 +58,7 @@ steps:
 - task: AzureKeyVault@1
   displayName: 'Fetch Key Vault Secrets'
   inputs:
-    azureSubscription: 'Sweetener-Pipelines-Test'
+    azureSubscription: 'Sweetener-Pipelines'
     keyVaultName: 'Sugarman-KeyVault'
     secretsFilter: 'Sweetener-Strong-Name-Key,Sweetener-Pipelines-Client-Id,Sweetener-Pipelines-Client-Secret'
 


### PR DESCRIPTION
- Use trusted CA certificate instead of self-signed certificate
- Replace the services and secrets with new production-ready ones