### PR TITLE
Add Missing -tr Option to Assembly Signing Script

### DIFF
--- a/eng/CI/Scripts/SignAssemblies.ps1
+++ b/eng/CI/Scripts/SignAssemblies.ps1
@@ -98,6 +98,7 @@ $Assemblies | % { $_.FullName } | Out-File -FilePath $Manifest
   -kvi $KeyVaultClientId `
   -kvs $KeyVaultClientSecret `
   -kvc $KeyVaultCertificateName `
+  -tr $TimestampUrl `
   -q `
   -ifl $Manifest
 


### PR DESCRIPTION
- Add missing timestamping service URL to `SignAssemblies.ps1`