### PR TITLE
Add Static Methods for Reliably Invoking Delegates

### DIFF
--- a/src/Sweetener.Reliability.Test/Action/Reliably.Async.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Reliably.Async.Test.cs
@@ -1,0 +1,608 @@
+﻿// Generated from Reliably.Async.Test.tt
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Reliability.Test
+{
+    partial class ReliablyTest
+    {
+        #region InvokeAsync
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncAction_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task> nullAction = null;
+            Func<Task> testAction = () => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
+            {
+                Func<Task> inputAction = () =>
+                {
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.InvokeAsync(inputAction, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncAction_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task> nullAction = null;
+            Func<Task> testAction = () => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
+            {
+                Func<Task> inputAction = () =>
+                {
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.InvokeAsync(inputAction, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncAction_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task> nullAction = null;
+            Func<Task> testAction = () => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
+            {
+                Func<Task> inputAction = () =>
+                {
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.InvokeAsync(inputAction, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncAction_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task> nullAction = null;
+            Func<Task> testAction = () => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
+            {
+                Func<Task> inputAction = () =>
+                {
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.InvokeAsync(inputAction, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncAction_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task> nullAction = null;
+            Func<object, Task> testAction = s => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.InvokeAsync(inputAction, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncAction_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task> nullAction = null;
+            Func<object, Task> testAction = s => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.InvokeAsync(inputAction, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncAction_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task> nullAction = null;
+            Func<object, Task> testAction = s => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.InvokeAsync(inputAction, state, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncAction_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task> nullAction = null;
+            Func<object, Task> testAction = s => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.InvokeAsync(inputAction, state, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        #endregion
+
+        #region TryInvokeAsync
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncAction_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task> nullAction = null;
+            Func<Task> testAction = () => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                Func<Task> inputAction = () =>
+                {
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncAction_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task> nullAction = null;
+            Func<Task> testAction = () => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                Func<Task> inputAction = () =>
+                {
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncAction_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task> nullAction = null;
+            Func<Task> testAction = () => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                Func<Task> inputAction = () =>
+                {
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncAction_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task> nullAction = null;
+            Func<Task> testAction = () => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                Func<Task> inputAction = () =>
+                {
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncAction_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task> nullAction = null;
+            Func<object, Task> testAction = s => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncAction_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task> nullAction = null;
+            Func<object, Task> testAction = s => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncAction_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task> nullAction = null;
+            Func<object, Task> testAction = s => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, state, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncAction_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task> nullAction = null;
+            Func<object, Task> testAction = s => Task.CompletedTask;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                    return Task.CompletedTask;
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, state, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        #endregion
+    }
+}
+

--- a/src/Sweetener.Reliability.Test/Action/Reliably.Async.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Reliably.Async.Test.cs
@@ -17,10 +17,13 @@ namespace Sweetener.Reliability.Test
 
             Func<Task> nullAction = null;
             Func<Task> testAction = () => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task> nullTaskAction = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskAction, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -51,10 +54,13 @@ namespace Sweetener.Reliability.Test
 
             Func<Task> nullAction = null;
             Func<Task> testAction = () => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task> nullTaskAction = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskAction, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -85,10 +91,13 @@ namespace Sweetener.Reliability.Test
 
             Func<Task> nullAction = null;
             Func<Task> testAction = () => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task> nullTaskAction = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskAction, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -122,10 +131,13 @@ namespace Sweetener.Reliability.Test
 
             Func<Task> nullAction = null;
             Func<Task> testAction = () => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task> nullTaskAction = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -159,10 +171,13 @@ namespace Sweetener.Reliability.Test
 
             Func<object, Task> nullAction = null;
             Func<object, Task> testAction = s => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task> nullTaskAction = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskAction, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -195,10 +210,13 @@ namespace Sweetener.Reliability.Test
 
             Func<object, Task> nullAction = null;
             Func<object, Task> testAction = s => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task> nullTaskAction = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskAction, new object(), 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -231,10 +249,13 @@ namespace Sweetener.Reliability.Test
 
             Func<object, Task> nullAction = null;
             Func<object, Task> testAction = s => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task> nullTaskAction = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -270,10 +291,13 @@ namespace Sweetener.Reliability.Test
 
             Func<object, Task> nullAction = null;
             Func<object, Task> testAction = s => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task> nullTaskAction = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -313,10 +337,13 @@ namespace Sweetener.Reliability.Test
 
             Func<Task> nullAction = null;
             Func<Task> testAction = () => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task> nullTaskAction = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskAction, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -347,10 +374,13 @@ namespace Sweetener.Reliability.Test
 
             Func<Task> nullAction = null;
             Func<Task> testAction = () => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task> nullTaskAction = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskAction, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -381,10 +411,13 @@ namespace Sweetener.Reliability.Test
 
             Func<Task> nullAction = null;
             Func<Task> testAction = () => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task> nullTaskAction = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskAction, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -419,10 +452,13 @@ namespace Sweetener.Reliability.Test
 
             Func<Task> nullAction = null;
             Func<Task> testAction = () => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task> nullTaskAction = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -457,10 +493,13 @@ namespace Sweetener.Reliability.Test
 
             Func<object, Task> nullAction = null;
             Func<object, Task> testAction = s => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task> nullTaskAction = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskAction, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -493,10 +532,13 @@ namespace Sweetener.Reliability.Test
 
             Func<object, Task> nullAction = null;
             Func<object, Task> testAction = s => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task> nullTaskAction = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskAction, new object(), 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -529,10 +571,13 @@ namespace Sweetener.Reliability.Test
 
             Func<object, Task> nullAction = null;
             Func<object, Task> testAction = s => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task> nullTaskAction = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -569,10 +614,13 @@ namespace Sweetener.Reliability.Test
 
             Func<object, Task> nullAction = null;
             Func<object, Task> testAction = s => Task.CompletedTask;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task> nullTaskAction = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 

--- a/src/Sweetener.Reliability.Test/Action/Reliably.Async.Test.tt
+++ b/src/Sweetener.Reliability.Test/Action/Reliably.Async.Test.tt
@@ -1,0 +1,4 @@
+﻿<#
+    bool async = true;
+#>
+<#@ include file="TextTemplating\Reliably.Test.t4" #>

--- a/src/Sweetener.Reliability.Test/Action/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Reliably.Test.cs
@@ -1,0 +1,229 @@
+﻿// Generated from Reliably.Test.tt
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Reliability.Test
+{
+    partial class ReliablyTest
+    {
+        #region Invoke
+
+        [TestMethod]
+        public void Invoke_Action_DelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public void Invoke_Action_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public void Invoke_Action_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, t, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public void Invoke_Action_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, t, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public void Invoke_Action_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Reliably.Invoke(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public void Invoke_Action_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Reliably.Invoke(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public void Invoke_Action_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Reliably.Invoke(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public void Invoke_Action_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Reliably.Invoke(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+    #endregion
+
+    }
+}
+

--- a/src/Sweetener.Reliability.Test/Action/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Reliably.Test.cs
@@ -26,6 +26,7 @@ namespace Sweetener.Reliability.Test
 
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -49,6 +50,7 @@ namespace Sweetener.Reliability.Test
 
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -63,15 +65,16 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
 
 #nullable enable
 
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, t, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -89,15 +92,16 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
 
 #nullable enable
 
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, t, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -114,7 +118,7 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
+            Action<object> testAction = s => Operation.Null();
             Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                                        , DelayPolicy.None));
@@ -128,6 +132,7 @@ namespace Sweetener.Reliability.Test
                 Reliably.Invoke(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke);
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -141,7 +146,7 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
+            Action<object> testAction = s => Operation.Null();
             Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero));
@@ -155,6 +160,7 @@ namespace Sweetener.Reliability.Test
                 Reliably.Invoke(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke);
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -168,11 +174,11 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Action<object> testAction = s => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
 
 #nullable enable
 
@@ -182,6 +188,7 @@ namespace Sweetener.Reliability.Test
                 Reliably.Invoke(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke);
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -198,11 +205,11 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Action<object> testAction = s => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -212,6 +219,7 @@ namespace Sweetener.Reliability.Test
                 Reliably.Invoke(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke);
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -240,15 +248,16 @@ namespace Sweetener.Reliability.Test
 
 #nullable enable
 
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.InvokeAsync(a, n, e, d.Invoke).Wait();
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, n, e, d.Invoke), x).Wait();
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-        }
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task> invoke        = (a, t, n, e, d)    => Reliably.InvokeAsync(a, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
 
         [TestMethod]
         public async Task InvokeAsync_Action_ComplexDelayHandler()
@@ -264,15 +273,16 @@ namespace Sweetener.Reliability.Test
 
 #nullable enable
 
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.InvokeAsync(a, n, e, d.Invoke).Wait();
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, n, e, d.Invoke), x).Wait();
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-        }
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task> invoke        = (a, t, n, e, d)    => Reliably.InvokeAsync(a, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
 
         [TestMethod]
         public async Task InvokeAsync_Action_Interruptable_DelayHandler()
@@ -281,25 +291,26 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.InvokeAsync(a, t, n, e, d.Invoke).Wait();
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, t, n, e, d.Invoke), x).Wait();
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task> invoke        = (a, t, n, e, d)    => Reliably.InvokeAsync(a, t, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
 
             Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
-
 
         [TestMethod]
         public async Task InvokeAsync_Action_Interruptable_ComplexDelayHandler()
@@ -308,25 +319,26 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.InvokeAsync(a, t, n, e, d.Invoke).Wait();
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, t, n, e, d.Invoke), x).Wait();
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task> invoke        = (a, t, n, e, d)    => Reliably.InvokeAsync(a, t, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
 
             Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
-
 
         [TestMethod]
         public async Task InvokeAsync_Action_Stateful_DelayHandler()
@@ -334,7 +346,7 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
+            Action<object> testAction = s => Operation.Null();
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
             await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
@@ -342,19 +354,26 @@ namespace Sweetener.Reliability.Test
 
 #nullable enable
 
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>> invoke = (a, t, n, e, d) =>
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
             {
                 object state = new object();
-                Reliably.InvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke).Wait();
-            };
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, n, e, d.Invoke), x).Wait();
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-        }
+                Action<object> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                };
 
+                return Reliably.InvokeAsync(inputAction, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
 
         [TestMethod]
         public async Task InvokeAsync_Action_Stateful_ComplexDelayHandler()
@@ -362,7 +381,7 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
+            Action<object> testAction = s => Operation.Null();
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
             await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
@@ -370,19 +389,26 @@ namespace Sweetener.Reliability.Test
 
 #nullable enable
 
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>> invoke = (a, t, n, e, d) =>
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
             {
                 object state = new object();
-                Reliably.InvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke).Wait();
-            };
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, n, e, d.Invoke), x).Wait();
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-        }
+                Action<object> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                };
 
+                return Reliably.InvokeAsync(inputAction, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
 
         [TestMethod]
         public async Task InvokeAsync_Action_Stateful_Interruptable_DelayHandler()
@@ -390,30 +416,37 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            Action<object> testAction = s => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>> invoke = (a, t, n, e, d) =>
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
             {
                 object state = new object();
-                Reliably.InvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke).Wait();
+                Action<object> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                };
+
+                return Reliably.InvokeAsync(inputAction, state, t, n, e, d.Invoke);
             };
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, t, n, e, d.Invoke), x).Wait();
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
 
             Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
-
 
         [TestMethod]
         public async Task InvokeAsync_Action_Stateful_Interruptable_ComplexDelayHandler()
@@ -421,25 +454,33 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            Action<object> testAction = s => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>> invoke = (a, t, n, e, d) =>
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
             {
                 object state = new object();
-                Reliably.InvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke).Wait();
+                Action<object> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                };
+
+                return Reliably.InvokeAsync(inputAction, state, t, n, e, d.Invoke);
             };
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, t, n, e, d.Invoke), x).Wait();
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
 
             Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -466,6 +507,7 @@ namespace Sweetener.Reliability.Test
             Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) => Reliably.TryInvoke(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -490,6 +532,7 @@ namespace Sweetener.Reliability.Test
             Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) => Reliably.TryInvoke(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -504,10 +547,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
 
 #nullable enable
 
@@ -515,6 +558,7 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -532,10 +576,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -543,6 +587,7 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -559,7 +604,7 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
+            Action<object> testAction = s => Operation.Null();
             Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
             Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                                        , DelayPolicy.None));
@@ -574,6 +619,7 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -587,7 +633,7 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
+            Action<object> testAction = s => Operation.Null();
             Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
             Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero));
@@ -602,6 +648,7 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -615,11 +662,11 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Action<object> testAction = s => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
 
 #nullable enable
 
@@ -631,6 +678,7 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -647,11 +695,11 @@ namespace Sweetener.Reliability.Test
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Action<object> testAction = s => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -663,6 +711,7 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -691,16 +740,16 @@ namespace Sweetener.Reliability.Test
 
 #nullable enable
 
-            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, n, e, d.Invoke);
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
             Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
             Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
-
 
         [TestMethod]
         public async Task TryInvokeAsync_Action_ComplexDelayHandler()
@@ -716,16 +765,16 @@ namespace Sweetener.Reliability.Test
 
 #nullable enable
 
-            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, n, e, d.Invoke);
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
             Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
             Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
-
 
         [TestMethod]
         public async Task TryInvokeAsync_Action_Interruptable_DelayHandler()
@@ -734,17 +783,18 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
-            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, t, n, e, d.Invoke);
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, t, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -755,7 +805,6 @@ namespace Sweetener.Reliability.Test
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
-
         [TestMethod]
         public async Task TryInvokeAsync_Action_Interruptable_ComplexDelayHandler()
         {
@@ -763,17 +812,18 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
-            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, t, n, e, d.Invoke);
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, t, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -784,14 +834,13 @@ namespace Sweetener.Reliability.Test
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
-
         [TestMethod]
         public async Task TryInvokeAsync_Action_Stateful_DelayHandler()
         {
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
+            Action<object> testAction = s => Operation.Null();
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
             await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
@@ -802,10 +851,17 @@ namespace Sweetener.Reliability.Test
             Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
             {
                 object state = new object();
-                return Reliably.TryInvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke);
+                Action<object> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, state, n, e, d.Invoke);
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -813,14 +869,13 @@ namespace Sweetener.Reliability.Test
             Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
-
         [TestMethod]
         public async Task TryInvokeAsync_Action_Stateful_ComplexDelayHandler()
         {
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
+            Action<object> testAction = s => Operation.Null();
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
             await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
@@ -831,10 +886,17 @@ namespace Sweetener.Reliability.Test
             Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
             {
                 object state = new object();
-                return Reliably.TryInvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke);
+                Action<object> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, state, n, e, d.Invoke);
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
@@ -842,29 +904,35 @@ namespace Sweetener.Reliability.Test
             Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
-
         [TestMethod]
         public async Task TryInvokeAsync_Action_Stateful_Interruptable_DelayHandler()
         {
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            Action<object> testAction = s => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
             Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
             {
                 object state = new object();
-                return Reliably.TryInvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke);
+                Action<object> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, state, t, n, e, d.Invoke);
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
@@ -875,29 +943,35 @@ namespace Sweetener.Reliability.Test
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
-
         [TestMethod]
         public async Task TryInvokeAsync_Action_Stateful_Interruptable_ComplexDelayHandler()
         {
 #nullable disable
 
             Action<object> nullAction = null;
-            Action<object> testAction = (s) => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            Action<object> testAction = s => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
             Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
             {
                 object state = new object();
-                return Reliably.TryInvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke);
+                Action<object> inputAction = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    a();
+                };
+
+                return Reliably.TryInvokeAsync(inputAction, state, t, n, e, d.Invoke);
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));

--- a/src/Sweetener.Reliability.Test/Action/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Reliably.Test.cs
@@ -78,8 +78,8 @@ namespace Sweetener.Reliability.Test
             Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
             Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
 
-            Invoke_Action_Canceled_Delegate(invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
         [TestMethod]
@@ -104,8 +104,8 @@ namespace Sweetener.Reliability.Test
             Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
             Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
 
-            Invoke_Action_Canceled_Delegate(invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
         [TestMethod]
@@ -188,8 +188,8 @@ namespace Sweetener.Reliability.Test
             Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
             Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
 
-            Invoke_Action_Canceled_Delegate(invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
         [TestMethod]
@@ -218,12 +218,697 @@ namespace Sweetener.Reliability.Test
             Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
             Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
 
-            Invoke_Action_Canceled_Delegate(invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
     #endregion
 
+        #region InvokeAsync
+
+        [TestMethod]
+        public async Task InvokeAsync_Action_DelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.InvokeAsync(a, n, e, d.Invoke).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, n, e, d.Invoke), x).Wait();
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+
+        [TestMethod]
+        public async Task InvokeAsync_Action_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.InvokeAsync(a, n, e, d.Invoke).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, n, e, d.Invoke), x).Wait();
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+
+        [TestMethod]
+        public async Task InvokeAsync_Action_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.InvokeAsync(a, t, n, e, d.Invoke).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, t, n, e, d.Invoke), x).Wait();
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+
+        [TestMethod]
+        public async Task InvokeAsync_Action_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.InvokeAsync(a, t, n, e, d.Invoke).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, t, n, e, d.Invoke), x).Wait();
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+
+        [TestMethod]
+        public async Task InvokeAsync_Action_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Reliably.InvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke).Wait();
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, n, e, d.Invoke), x).Wait();
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+
+        [TestMethod]
+        public async Task InvokeAsync_Action_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Reliably.InvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke).Wait();
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, n, e, d.Invoke), x).Wait();
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+
+        [TestMethod]
+        public async Task InvokeAsync_Action_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Reliably.InvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke).Wait();
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, t, n, e, d.Invoke), x).Wait();
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+
+        [TestMethod]
+        public async Task InvokeAsync_Action_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Reliably.InvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke).Wait();
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a, t, n, e, d.Invoke), x).Wait();
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        #endregion
+
+        #region TryInvoke
+
+        [TestMethod]
+        public void TryInvoke_Action_DelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+
+#nullable enable
+
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) => Reliably.TryInvoke(a, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public void TryInvoke_Action_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+
+#nullable enable
+
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) => Reliably.TryInvoke(a, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public void TryInvoke_Action_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+
+#nullable enable
+
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) => Reliably.TryInvoke(a, t, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public void TryInvoke_Action_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+
+#nullable enable
+
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) => Reliably.TryInvoke(a, t, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public void TryInvoke_Action_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public void TryInvoke_Action_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        [TestMethod]
+        public void TryInvoke_Action_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                                        , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+        [TestMethod]
+        public void TryInvoke_Action_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        #endregion
+
+        #region TryInvokeAsync
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Action_DelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Action_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Action_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, t, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Action_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action nullAction = null;
+            Action testAction = Operation.Null;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, t, n, e, d.Invoke);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Action_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                return Reliably.TryInvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Action_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                return Reliably.TryInvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Action_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                return Reliably.TryInvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+        }
+
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Action_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Action<object> nullAction = null;
+            Action<object> testAction = (s) => Operation.Null();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                return Reliably.TryInvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state, t, n, e, d.Invoke);
+            };
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+        }
+
+        #endregion
     }
 }
 

--- a/src/Sweetener.Reliability.Test/Action/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Reliably.Test.cs
@@ -17,10 +17,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, ExceptionPolicy.Transient, (DelayHandler)null));
 
 #nullable enable
 
@@ -41,10 +41,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, null                     , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -65,10 +65,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null));
 
 #nullable enable
 
@@ -92,10 +92,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -119,10 +119,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null));
 
 #nullable enable
 
@@ -147,10 +147,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, null                     , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -175,10 +175,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null));
 
 #nullable enable
 
@@ -206,10 +206,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -230,7 +230,7 @@ namespace Sweetener.Reliability.Test
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
-    #endregion
+        #endregion
 
         #region InvokeAsync
 
@@ -241,10 +241,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -266,10 +266,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -291,10 +291,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -319,10 +319,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -347,10 +347,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -382,10 +382,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -417,10 +417,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -455,10 +455,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -497,10 +497,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, ExceptionPolicy.Transient, (DelayHandler)null));
 
 #nullable enable
 
@@ -522,10 +522,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, null                     , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -547,10 +547,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null));
 
 #nullable enable
 
@@ -576,10 +576,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -605,10 +605,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null));
 
 #nullable enable
 
@@ -634,10 +634,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, null                     , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -663,10 +663,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null));
 
 #nullable enable
 
@@ -696,10 +696,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null));
 
 #nullable enable
 
@@ -733,10 +733,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -758,10 +758,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -783,10 +783,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -812,10 +812,10 @@ namespace Sweetener.Reliability.Test
 
             Action nullAction = null;
             Action testAction = Operation.Null;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -841,10 +841,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -876,10 +876,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -911,10 +911,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , DelayPolicy.None)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (DelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -950,10 +950,10 @@ namespace Sweetener.Reliability.Test
 
             Action<object> nullAction = null;
             Action<object> testAction = s => Operation.Null();
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                                        , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (ComplexDelayHandler)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, null                     , (i, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler)null)).ConfigureAwait(false);
 
 #nullable enable
 

--- a/src/Sweetener.Reliability.Test/Action/Reliably.Test.tt
+++ b/src/Sweetener.Reliability.Test/Action/Reliably.Test.tt
@@ -1,0 +1,4 @@
+﻿<#
+    bool async = false;
+#>
+<#@ include file="TextTemplating\Reliably.Test.t4" #>

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
@@ -85,8 +85,8 @@ namespace Sweetener.Reliability.Test
                     {
 #>
 
-            Invoke_Action_Canceled_Delegate(invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_Canceled_Delay   (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
 <#
                     }
 #>
@@ -102,5 +102,278 @@ namespace Sweetener.Reliability.Test
 <#
     }
 #>
+        #region InvokeAsync
+<#
+    foreach (bool stateful in new bool[2] { false, true })
+    {
+        string inputActionType        = stateful ? "Action<object>"          : "Action";
+        string testAction             = stateful ? "(s) => Operation.Null()" : "Operation.Null";
+        string optionalStateArg       = stateful ? ", new object()"          : string.Empty;
+        string optionalStatefulSuffix = stateful ? "_Stateful"               : string.Empty;
+
+        foreach (bool interruptable in new bool[2] { false, true })
+        {
+            string optionalTokenArg    = interruptable ? ", t"            : string.Empty;
+            string optionalTokenSuffix = interruptable ? "_Interruptable" : string.Empty;
+
+            foreach (bool useComplexDelayHandler in new bool[2] { false, true })
+            {
+                string handlerType          = useComplexDelayHandler ? "ComplexDelayHandler"     : "DelayHandler";
+                string delayInputTypeParam  = useComplexDelayHandler ? "int, Exception"          : "int";
+                string delayInputArgs       = useComplexDelayHandler ? "(i, e)"                  : "i";
+                string noDelay              = useComplexDelayHandler ? "(i, e) => TimeSpan.Zero" : "DelayPolicy.None";
+                string delayCallExpectation = useComplexDelayHandler ? "ExceptionAsc(t)"         : "Asc()";
+                string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"    : "_DelayHandler";
+
+                string testName = "InvokeAsync_Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
+#>
+
+        [TestMethod]
+        public async Task <#= testName #>()
+        {
+#nullable disable
+
+            <#= inputActionType #> nullAction = null;
+            <#= inputActionType #> testAction = <#= testAction #>;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction<#= optionalStateArg #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction<#= optionalStateArg #>, 10, null                                        , <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+<#
+                if (stateful)
+                {
+#>
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Reliably.InvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state<#= optionalTokenArg #>, n, e, d.Invoke).Wait();
+            };
+<#
+                }
+                else
+                {
+#>
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.InvokeAsync(a<#= optionalTokenArg #>, n, e, d.Invoke).Wait();
+<#
+                }
+#>
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a<#= optionalTokenArg #>, n, e, d.Invoke), x).Wait();
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                if (interruptable)
+                {
+#>
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                }
+#>
+        }
+
+<#
+                }
+            }
+        }
+#>
+        #endregion
+
+<#
+    if (!async)
+    {
+#>
+        #region TryInvoke
+
+<#
+        foreach (bool stateful in new bool[2] { false, true })
+        {
+            string inputActionType        = stateful ? "Action<object>"          : "Action";
+            string testAction             = stateful ? "(s) => Operation.Null()" : "Operation.Null";
+            string optionalStateArg       = stateful ? ", new object()"          : string.Empty;
+            string optionalStatefulSuffix = stateful ? "_Stateful"               : string.Empty;
+
+            foreach (bool interruptable in new bool[2] { false, true })
+            {
+                string optionalTokenArg    = interruptable ? ", t"            : string.Empty;
+                string optionalTokenSuffix = interruptable ? "_Interruptable" : string.Empty;
+
+                foreach (bool useComplexDelayHandler in new bool[2] { false, true })
+                {
+                    string handlerType          = useComplexDelayHandler ? "ComplexDelayHandler"     : "DelayHandler";
+                    string delayInputTypeParam  = useComplexDelayHandler ? "int, Exception"          : "int";
+                    string delayInputArgs       = useComplexDelayHandler ? "(i, e)"                  : "i";
+                    string noDelay              = useComplexDelayHandler ? "(i, e) => TimeSpan.Zero" : "DelayPolicy.None";
+                    string delayCallExpectation = useComplexDelayHandler ? "ExceptionAsc(t)"         : "Asc()";
+                    string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"    : "_DelayHandler";
+
+                    string testName = "TryInvoke_Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
+#>
+        [TestMethod]
+        public void <#= testName #>()
+        {
+#nullable disable
+
+            <#= inputActionType #> nullAction = null;
+            <#= inputActionType #> testAction = <#= testAction #>;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction<#= optionalStateArg #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction<#= optionalStateArg #>, 10, null                                        , <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null));
+
+#nullable enable
+
+<#
+                    if (stateful)
+                    {
+#>
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); a(); }, state<#= optionalTokenArg #>, n, e, d.Invoke);
+            };
+<#
+                    }
+                    else
+                    {
+#>
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) => Reliably.TryInvoke(a<#= optionalTokenArg #>, n, e, d.Invoke);
+<#
+                    }
+#>
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+<#
+                    if (interruptable)
+                    {
+#>
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
+<#
+                    }
+#>
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                    if (interruptable)
+                    {
+#>
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                    }
+#>
+        }
+
+<#
+                }
+            }
+        }
+#>
+        #endregion
+<#
+    }
+#>
+
+        #region TryInvokeAsync
+<#
+    foreach (bool stateful in new bool[2] { false, true })
+    {
+        string inputActionType        = stateful ? "Action<object>"          : "Action";
+        string testAction             = stateful ? "(s) => Operation.Null()" : "Operation.Null";
+        string optionalStateArg       = stateful ? ", new object()"          : string.Empty;
+        string optionalStatefulSuffix = stateful ? "_Stateful"               : string.Empty;
+
+        foreach (bool interruptable in new bool[2] { false, true })
+        {
+            string optionalTokenArg    = interruptable ? ", t"            : string.Empty;
+            string optionalTokenSuffix = interruptable ? "_Interruptable" : string.Empty;
+
+            foreach (bool useComplexDelayHandler in new bool[2] { false, true })
+            {
+                string handlerType          = useComplexDelayHandler ? "ComplexDelayHandler"     : "DelayHandler";
+                string delayInputTypeParam  = useComplexDelayHandler ? "int, Exception"          : "int";
+                string delayInputArgs       = useComplexDelayHandler ? "(i, e)"                  : "i";
+                string noDelay              = useComplexDelayHandler ? "(i, e) => TimeSpan.Zero" : "DelayPolicy.None";
+                string delayCallExpectation = useComplexDelayHandler ? "ExceptionAsc(t)"         : "Asc()";
+                string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"    : "_DelayHandler";
+
+                string testName = "TryInvokeAsync_Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
+#>
+
+        [TestMethod]
+        public async Task <#= testName #>()
+        {
+#nullable disable
+
+            <#= inputActionType #> nullAction = null;
+            <#= inputActionType #> testAction = <#= testAction #>;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction<#= optionalStateArg #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction<#= optionalStateArg #>, 10, null                                        , <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+<#
+                if (stateful)
+                {
+#>
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                return Reliably.TryInvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state<#= optionalTokenArg #>, n, e, d.Invoke);
+            };
+<#
+                }
+                else
+                {
+#>
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a<#= optionalTokenArg #>, n, e, d.Invoke);
+<#
+                }
+#>
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+<#
+                if (interruptable)
+                {
+#>
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+<#
+                }
+#>
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                if (interruptable)
+                {
+#>
+
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                }
+#>
+        }
+
+<#
+                }
+            }
+        }
+#>
+        #endregion
     }
 }

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
@@ -13,6 +13,12 @@ namespace Sweetener.Reliability.Test
     partial class ReliablyTest
     {
 <#
+    string optionalAsyncPrefix = async ? "Async"                    : string.Empty;
+    string basicActionType     = async ? "Func<Task>"               : "Action";
+    string statefulActionType  = async ? "Func<object, Task>"       : "Action<object>";
+    string basicTestAction     = async ? "() => Task.CompletedTask" : "Operation.Null";
+    string statefulTestAction  = async ? "s => Task.CompletedTask"  : "s => Operation.Null()";
+
     if (!async)
     {
 #>
@@ -21,15 +27,16 @@ namespace Sweetener.Reliability.Test
 <#
         foreach (bool stateful in new bool[2] { false, true })
         {
-            string inputActionType        = stateful ? "Action<object>"          : "Action";
-            string testAction             = stateful ? "(s) => Operation.Null()" : "Operation.Null";
-            string optionalStateArg       = stateful ? ", new object()"          : string.Empty;
-            string optionalStatefulSuffix = stateful ? "_Stateful"               : string.Empty;
+            string inputActionType        = stateful ? statefulActionType : basicActionType;
+            string testAction             = stateful ? statefulTestAction : basicTestAction;
+            string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
+            string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
             foreach (bool interruptable in new bool[2] { false, true })
             {
-                string optionalTokenArg    = interruptable ? ", t"            : string.Empty;
-                string optionalTokenSuffix = interruptable ? "_Interruptable" : string.Empty;
+                string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
+                string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
+                string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
 
                 foreach (bool useComplexDelayHandler in new bool[2] { false, true })
                 {
@@ -40,7 +47,7 @@ namespace Sweetener.Reliability.Test
                     string delayCallExpectation = useComplexDelayHandler ? "ExceptionAsc(t)"         : "Asc()";
                     string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"    : "_DelayHandler";
 
-                    string testName = "Invoke_Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
+                    string testName = "Invoke_" + optionalAsyncPrefix + "Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
 #>
         [TestMethod]
         public void <#= testName #>()
@@ -49,10 +56,10 @@ namespace Sweetener.Reliability.Test
 
             <#= inputActionType #> nullAction = null;
             <#= inputActionType #> testAction = <#= testAction #>;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction<#= optionalStateArg #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction<#= optionalStateArg #>, 10, null                                        , <#= noDelay #>));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                                        , <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null));
 
 #nullable enable
 
@@ -75,6 +82,7 @@ namespace Sweetener.Reliability.Test
                     }
 #>
             Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+
             Invoke_Action_Success         (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
             Invoke_Action_Failure         (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
             Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
@@ -103,18 +111,21 @@ namespace Sweetener.Reliability.Test
     }
 #>
         #region InvokeAsync
+
 <#
     foreach (bool stateful in new bool[2] { false, true })
     {
-        string inputActionType        = stateful ? "Action<object>"          : "Action";
-        string testAction             = stateful ? "(s) => Operation.Null()" : "Operation.Null";
-        string optionalStateArg       = stateful ? ", new object()"          : string.Empty;
-        string optionalStatefulSuffix = stateful ? "_Stateful"               : string.Empty;
+        string inputActionType        = stateful ? statefulActionType : basicActionType;
+        string testAction             = stateful ? statefulTestAction : basicTestAction;
+        string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
+        string optionalStateArg       = stateful ? ", state"          : string.Empty;
+        string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
         foreach (bool interruptable in new bool[2] { false, true })
         {
-            string optionalTokenArg    = interruptable ? ", t"            : string.Empty;
-            string optionalTokenSuffix = interruptable ? "_Interruptable" : string.Empty;
+            string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
+            string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
+            string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
 
             foreach (bool useComplexDelayHandler in new bool[2] { false, true })
             {
@@ -125,9 +136,8 @@ namespace Sweetener.Reliability.Test
                 string delayCallExpectation = useComplexDelayHandler ? "ExceptionAsc(t)"         : "Asc()";
                 string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"    : "_DelayHandler";
 
-                string testName = "InvokeAsync_Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
+                string testName = "InvokeAsync_" + optionalAsyncPrefix + "Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
 #>
-
         [TestMethod]
         public async Task <#= testName #>()
         {
@@ -135,37 +145,67 @@ namespace Sweetener.Reliability.Test
 
             <#= inputActionType #> nullAction = null;
             <#= inputActionType #> testAction = <#= testAction #>;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction<#= optionalStateArg #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction<#= optionalStateArg #>, 10, null                                        , <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                                        , <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null)).ConfigureAwait(false);
 
 #nullable enable
 
 <#
-                if (stateful)
+                if (async || stateful)
                 {
 #>
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>> invoke = (a, t, n, e, d) =>
+            Func<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task> invoke = (a, t, n, e, d) =>
             {
+<#
+                    if (stateful)
+                    {
+#>
                 object state = new object();
-                Reliably.InvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state<#= optionalTokenArg #>, n, e, d.Invoke).Wait();
+<#
+                    }
+#>
+                <#= inputActionType #> inputAction = (<#= stateful ? "obj" : string.Empty #>) =>
+                {
+<#
+                    if (stateful)
+                    {
+#>
+                    Assert.AreSame(obj, state);
+<#
+                    }
+#>
+                    a();
+<#
+                    if (async)
+                    {
+#>
+                    return Task.CompletedTask;
+<#
+                    }
+#>
+                };
+
+                return Reliably.InvokeAsync(inputAction<#= optionalStateArg #><#= optionalTokenArg #>, n, e, d.Invoke);
             };
 <#
                 }
                 else
                 {
 #>
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.InvokeAsync(a<#= optionalTokenArg #>, n, e, d.Invoke).Wait();
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task> invoke        = (a, t, n, e, d)    => Reliably.InvokeAsync(a<#= optionalTokenArg #>, n, e, d.Invoke);
 <#
                 }
 #>
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => Reliably.InvokeAsync(a<#= optionalTokenArg #>, n, e, d.Invoke), x).Wait();
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_Failure         (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
 <#
                 if (interruptable)
                 {
@@ -194,15 +234,16 @@ namespace Sweetener.Reliability.Test
 <#
         foreach (bool stateful in new bool[2] { false, true })
         {
-            string inputActionType        = stateful ? "Action<object>"          : "Action";
-            string testAction             = stateful ? "(s) => Operation.Null()" : "Operation.Null";
-            string optionalStateArg       = stateful ? ", new object()"          : string.Empty;
-            string optionalStatefulSuffix = stateful ? "_Stateful"               : string.Empty;
+            string inputActionType        = stateful ? statefulActionType : basicActionType;
+            string testAction             = stateful ? statefulTestAction : basicTestAction;
+            string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
+            string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
             foreach (bool interruptable in new bool[2] { false, true })
             {
-                string optionalTokenArg    = interruptable ? ", t"            : string.Empty;
-                string optionalTokenSuffix = interruptable ? "_Interruptable" : string.Empty;
+                string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
+                string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
+                string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
 
                 foreach (bool useComplexDelayHandler in new bool[2] { false, true })
                 {
@@ -213,7 +254,7 @@ namespace Sweetener.Reliability.Test
                     string delayCallExpectation = useComplexDelayHandler ? "ExceptionAsc(t)"         : "Asc()";
                     string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"    : "_DelayHandler";
 
-                    string testName = "TryInvoke_Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
+                    string testName = "TryInvoke_" + optionalAsyncPrefix + "Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
 #>
         [TestMethod]
         public void <#= testName #>()
@@ -222,10 +263,10 @@ namespace Sweetener.Reliability.Test
 
             <#= inputActionType #> nullAction = null;
             <#= inputActionType #> testAction = <#= testAction #>;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction<#= optionalStateArg #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction<#= optionalStateArg #>, 10, null                                        , <#= noDelay #>));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                                        , <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null));
 
 #nullable enable
 
@@ -257,6 +298,7 @@ namespace Sweetener.Reliability.Test
 <#
                     }
 #>
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
@@ -280,23 +322,26 @@ namespace Sweetener.Reliability.Test
         }
 #>
         #endregion
+
 <#
     }
 #>
-
         #region TryInvokeAsync
+
 <#
     foreach (bool stateful in new bool[2] { false, true })
     {
-        string inputActionType        = stateful ? "Action<object>"          : "Action";
-        string testAction             = stateful ? "(s) => Operation.Null()" : "Operation.Null";
-        string optionalStateArg       = stateful ? ", new object()"          : string.Empty;
-        string optionalStatefulSuffix = stateful ? "_Stateful"               : string.Empty;
+        string inputActionType        = stateful ? statefulActionType : basicActionType;
+        string testAction             = stateful ? statefulTestAction : basicTestAction;
+        string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
+        string optionalStateArg       = stateful ? ", state"          : string.Empty;
+        string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
         foreach (bool interruptable in new bool[2] { false, true })
         {
-            string optionalTokenArg    = interruptable ? ", t"            : string.Empty;
-            string optionalTokenSuffix = interruptable ? "_Interruptable" : string.Empty;
+            string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
+            string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
+            string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
 
             foreach (bool useComplexDelayHandler in new bool[2] { false, true })
             {
@@ -307,9 +352,8 @@ namespace Sweetener.Reliability.Test
                 string delayCallExpectation = useComplexDelayHandler ? "ExceptionAsc(t)"         : "Asc()";
                 string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"    : "_DelayHandler";
 
-                string testName = "TryInvokeAsync_Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
+                string testName = "TryInvokeAsync_" + optionalAsyncPrefix + "Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
 #>
-
         [TestMethod]
         public async Task <#= testName #>()
         {
@@ -317,28 +361,56 @@ namespace Sweetener.Reliability.Test
 
             <#= inputActionType #> nullAction = null;
             <#= inputActionType #> testAction = <#= testAction #>;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction<#= optionalStateArg #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction<#= optionalStateArg #>, 10, null                                        , <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                                        , <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null)).ConfigureAwait(false);
 
 #nullable enable
 
 <#
-                if (stateful)
+                if (async || stateful)
                 {
 #>
             Func<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d) =>
             {
+<#
+                    if (stateful)
+                    {
+#>
                 object state = new object();
-                return Reliably.TryInvokeAsync(obj => { Assert.AreSame(obj, state); a(); }, state<#= optionalTokenArg #>, n, e, d.Invoke);
+<#
+                    }
+#>
+                <#= inputActionType #> inputAction = (<#= stateful ? "obj" : string.Empty #>) =>
+                {
+<#
+                    if (stateful)
+                    {
+#>
+                    Assert.AreSame(obj, state);
+<#
+                    }
+#>
+                    a();
+<#
+                    if (async)
+                    {
+#>
+                    return Task.CompletedTask;
+<#
+                    }
+#>
+                };
+
+                return Reliably.TryInvokeAsync(inputAction<#= optionalStateArg #><#= optionalTokenArg #>, n, e, d.Invoke);
             };
 <#
                 }
                 else
                 {
 #>
-            Func<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a<#= optionalTokenArg #>, n, e, d.Invoke);
+            Func  <Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a<#= optionalTokenArg #>, n, e, d.Invoke);
 <#
                 }
 #>
@@ -352,6 +424,7 @@ namespace Sweetener.Reliability.Test
 <#
                 }
 #>
+
             Invoke_Action_Success         (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
             Invoke_Action_Failure         (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
             Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
@@ -105,7 +105,7 @@ namespace Sweetener.Reliability.Test
             }
         }
 #>
-    #endregion
+        #endregion
 
 <#
     }
@@ -229,9 +229,9 @@ namespace Sweetener.Reliability.Test
         }
 
 <#
-                }
             }
         }
+    }
 #>
         #endregion
 
@@ -463,9 +463,9 @@ namespace Sweetener.Reliability.Test
         }
 
 <#
-                }
             }
         }
+    }
 #>
         #endregion
     }

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
@@ -1,0 +1,106 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System" #>
+<#@ include file="$(MSBuildProjectDirectory)\TextTemplating\Include.t4" #>// Generated from <#= GetTemplateFileName() #>
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Reliability.Test
+{
+    partial class ReliablyTest
+    {
+<#
+    if (!async)
+    {
+#>
+        #region Invoke
+
+<#
+        foreach (bool stateful in new bool[2] { false, true })
+        {
+            string inputActionType        = stateful ? "Action<object>"          : "Action";
+            string testAction             = stateful ? "(s) => Operation.Null()" : "Operation.Null";
+            string optionalStateArg       = stateful ? ", new object()"          : string.Empty;
+            string optionalStatefulSuffix = stateful ? "_Stateful"               : string.Empty;
+
+            foreach (bool interruptable in new bool[2] { false, true })
+            {
+                string optionalTokenArg    = interruptable ? ", t"            : string.Empty;
+                string optionalTokenSuffix = interruptable ? "_Interruptable" : string.Empty;
+
+                foreach (bool useComplexDelayHandler in new bool[2] { false, true })
+                {
+                    string handlerType          = useComplexDelayHandler ? "ComplexDelayHandler"     : "DelayHandler";
+                    string delayInputTypeParam  = useComplexDelayHandler ? "int, Exception"          : "int";
+                    string delayInputArgs       = useComplexDelayHandler ? "(i, e)"                  : "i";
+                    string noDelay              = useComplexDelayHandler ? "(i, e) => TimeSpan.Zero" : "DelayPolicy.None";
+                    string delayCallExpectation = useComplexDelayHandler ? "ExceptionAsc(t)"         : "Asc()";
+                    string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"    : "_DelayHandler";
+
+                    string testName = "Invoke_Action" + optionalStatefulSuffix + optionalTokenSuffix + delaySuffix;
+#>
+        [TestMethod]
+        public void <#= testName #>()
+        {
+#nullable disable
+
+            <#= inputActionType #> nullAction = null;
+            <#= inputActionType #> testAction = <#= testAction #>;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction<#= optionalStateArg #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction<#= optionalStateArg #>, 10, null                                        , <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction<#= optionalStateArg #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null));
+
+#nullable enable
+
+<#
+                    if (stateful)
+                    {
+#>
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>> invoke = (a, t, n, e, d) =>
+            {
+                object state = new object();
+                Reliably.Invoke(obj => { Assert.AreSame(obj, state); a(); }, state<#= optionalTokenArg #>, n, e, d.Invoke);
+            };
+<#
+                    }
+                    else
+                    {
+#>
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a<#= optionalTokenArg #>, n, e, d.Invoke);
+<#
+                    }
+#>
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
+            Invoke_Action_Success         (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_Failure         (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                    if (interruptable)
+                    {
+#>
+
+            Invoke_Action_Canceled_Delegate(invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delay   (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                    }
+#>
+        }
+
+<#
+                }
+            }
+        }
+#>
+    #endregion
+
+<#
+    }
+#>
+    }
+}

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
@@ -56,10 +56,10 @@ namespace Sweetener.Reliability.Test
 
             <#= inputActionType #> nullAction = null;
             <#= inputActionType #> testAction = <#= testAction #>;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                                        , <#= noDelay #>));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Transient, <#= noDelay #>));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Transient, <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                     , <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Transient, (<#= handlerType #>)null));
 
 #nullable enable
 
@@ -145,11 +145,21 @@ namespace Sweetener.Reliability.Test
 
             <#= inputActionType #> nullAction = null;
             <#= inputActionType #> testAction = <#= testAction #>;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                                        , <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                     , <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Transient, (<#= handlerType #>)null)).ConfigureAwait(false);
 
+<#
+                if (async)
+                {
+#>
+            <#= inputActionType #> nullTaskAction = <#= stateful ? "s" : "()" #> => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+
+<#
+                }
+#>
 #nullable enable
 
 <#
@@ -263,10 +273,10 @@ namespace Sweetener.Reliability.Test
 
             <#= inputActionType #> nullAction = null;
             <#= inputActionType #> testAction = <#= testAction #>;
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                                        , <#= noDelay #>));
-            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Transient, <#= noDelay #>));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Transient, <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                     , <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Transient, (<#= handlerType #>)null));
 
 #nullable enable
 
@@ -361,11 +371,21 @@ namespace Sweetener.Reliability.Test
 
             <#= inputActionType #> nullAction = null;
             <#= inputActionType #> testAction = <#= testAction #>;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Fail<OutOfMemoryException>(), <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                                        , <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Fail<OutOfMemoryException>(), (<#= handlerType #>)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, -3, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                     , <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Transient, (<#= handlerType #>)null)).ConfigureAwait(false);
 
+<#
+                if (async)
+                {
+#>
+            <#= inputActionType #> nullTaskAction = <#= stateful ? "s" : "()" #> => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskAction<#= optionalStateObj #><#= optionalTokenObj #>, 10, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+
+<#
+                }
+#>
 #nullable enable
 
 <#

--- a/src/Sweetener.Reliability.Test/Assert.Extensions.cs
+++ b/src/Sweetener.Reliability.Test/Assert.Extensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,6 +10,10 @@ namespace Sweetener.Reliability.Test
         public static void ThrowsException<T>(this Assert assert, Action action, bool allowedDerivedTypes = false)
             where T : Exception
             => ThrowsException(assert, action, typeof(T), allowedDerivedTypes);
+
+        public static void ThrowsException<T>(this Assert assert, Func<object> func, bool allowedDerivedTypes = false)
+            where T : Exception
+            => ThrowsException<T>(assert, () => { func(); }, allowedDerivedTypes);
 
         public static void ThrowsException(this Assert assert, Action action, Type exceptionType, bool allowedDerivedTypes = false)
         {
@@ -41,6 +44,9 @@ namespace Sweetener.Reliability.Test
                     Assert.AreEqual(exceptionType, e!.GetType());
             }
         }
+
+        public static void ThrowsException(this Assert assert, Func<object> func, Type exceptionType, bool allowedDerivedTypes = false)
+            => ThrowsException(assert, () => { func(); }, exceptionType, allowedDerivedTypes);
 
         public static Task ThrowsExceptionAsync<T>(this Assert assert, Func<Task> action, bool allowedDerivedTypes = false)
             where T : Exception

--- a/src/Sweetener.Reliability.Test/Assert.Extensions.cs
+++ b/src/Sweetener.Reliability.Test/Assert.Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -7,11 +8,11 @@ namespace Sweetener.Reliability.Test
 {
     internal static class AssertExtensions
     {
-        internal static void ThrowsException<T>(this Assert assert, Action action, bool allowedDerivedTypes = false)
+        public static void ThrowsException<T>(this Assert assert, Action action, bool allowedDerivedTypes = false)
             where T : Exception
             => ThrowsException(assert, action, typeof(T), allowedDerivedTypes);
 
-        internal static void ThrowsException(this Assert assert, Action action, Type exceptionType, bool allowedDerivedTypes = false)
+        public static void ThrowsException(this Assert assert, Action action, Type exceptionType, bool allowedDerivedTypes = false)
         {
             if (!typeof(Exception).IsAssignableFrom(exceptionType))
                 throw new ArgumentException($"Type '{exceptionType.Name}' is not an {nameof(Exception)}", nameof(exceptionType));
@@ -19,6 +20,40 @@ namespace Sweetener.Reliability.Test
             try
             {
                 action();
+                Assert.Fail($"Action did not throw an expected exception of type '{exceptionType.Name}'");
+            }
+            catch (AssertFailedException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                if (exceptionType != typeof(AggregateException) && e is AggregateException a && a.InnerException != null)
+                {
+                    e = a.InnerException;
+                    if (e is AssertFailedException)
+                        ExceptionDispatchInfo.Capture(e).Throw();
+                }
+
+                if (allowedDerivedTypes)
+                    Assert.IsInstanceOfType(e, exceptionType);
+                else
+                    Assert.AreEqual(exceptionType, e!.GetType());
+            }
+        }
+
+        public static Task ThrowsExceptionAsync<T>(this Assert assert, Func<Task> action, bool allowedDerivedTypes = false)
+            where T : Exception
+            => ThrowsExceptionAsync(assert, action, typeof(T), allowedDerivedTypes);
+
+        public static async Task ThrowsExceptionAsync(this Assert assert, Func<Task> action, Type exceptionType, bool allowedDerivedTypes = false)
+        {
+            if (!typeof(Exception).IsAssignableFrom(exceptionType))
+                throw new ArgumentException($"Type '{exceptionType.Name}' is not an {nameof(Exception)}", nameof(exceptionType));
+
+            try
+            {
+                await action().ConfigureAwait(false);
                 Assert.Fail($"Action did not throw an expected exception of type '{exceptionType.Name}'");
             }
             catch (AssertFailedException)

--- a/src/Sweetener.Reliability.Test/Func/Reliably.Async.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Reliably.Async.Test.cs
@@ -1,0 +1,1468 @@
+﻿// Generated from Reliably.Async.Test.tt
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Reliability.Test
+{
+    partial class ReliablyTest
+    {
+        #region InvokeAsync
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<string>(nullFunc, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync<string>(testFunc, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<string>(testFunc, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync        (testFunc, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<string>(nullTaskFunc, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<string>(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync<string>(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<string>(testFunc, CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync        (testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<string>(nullTaskFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<object, string>(nullFunc, new object(), 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync<object, string>(testFunc, new object(), -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<object, string>(testFunc, new object(), 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync                (testFunc, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<object, string>(nullTaskFunc, new object(), 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Stateful_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Stateful_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<object, string>(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync<object, string>(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<object, string>(testFunc, new object(), CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync                (testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<object, string>(nullTaskFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Stateful_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_AsyncFunc_Stateful_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        #endregion
+
+        #region TryInvokeAsync
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<string>(nullFunc, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync<string>(testFunc, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<string>(testFunc, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync        (testFunc, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<string>(nullTaskFunc, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<string>(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync<string>(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<string>(testFunc, CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync        (testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<string>(nullTaskFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<Task<string>> nullFunc = null;
+            Func<Task<string>> testFunc = () => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<Task<string>> nullTaskFunc = () => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                Func<Task<string>> inputFunc = () =>
+                {
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<object, string>(nullFunc, new object(), 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync<object, string>(testFunc, new object(), -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<object, string>(testFunc, new object(), 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync                (testFunc, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<object, string>(nullTaskFunc, new object(), 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Stateful_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Stateful_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<object, string>(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync<object, string>(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<object, string>(testFunc, new object(), CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync                (testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<object, string>(nullTaskFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Stateful_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_AsyncFunc_Stateful_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, Task<string>> nullFunc = null;
+            Func<object, Task<string>> testFunc = s => Task.FromResult("Hello World");
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, (ResultHandler<string>)null   , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+            Func<object, Task<string>> nullTaskFunc = s => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, Task<string>> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return Task.FromResult(f());
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        #endregion
+    }
+}
+

--- a/src/Sweetener.Reliability.Test/Func/Reliably.Async.Test.tt
+++ b/src/Sweetener.Reliability.Test/Func/Reliably.Async.Test.tt
@@ -1,0 +1,4 @@
+﻿<#
+    bool async = true;
+#>
+<#@ include file="TextTemplating\Reliably.Test.t4" #>

--- a/src/Sweetener.Reliability.Test/Func/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Reliably.Test.cs
@@ -1,0 +1,2420 @@
+﻿// Generated from Reliably.Test.tt
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Reliability.Test
+{
+    partial class ReliablyTest
+    {
+        #region Invoke
+
+        [TestMethod]
+        public void Invoke_Func_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, 10, ExceptionPolicy.Transient, (DelayHandler)null));
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> invoke       = (f, t, n, r, e, d)    => Reliably.Invoke(f, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, 10, null                     , (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null));
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> invoke       = (f, t, n, r, e, d)    => Reliably.Invoke(f, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null));
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> invoke       = (f, t, n, r, e, d)    => Reliably.Invoke(f, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null));
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> invoke       = (f, t, n, r, e, d)    => Reliably.Invoke(f, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, CancellationToken.None, 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null));
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> invoke       = (f, t, n, r, e, d)    => Reliably.Invoke(f, t, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null));
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> invoke       = (f, t, n, r, e, d)    => Reliably.Invoke(f, t, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null));
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> invoke       = (f, t, n, r, e, d)    => Reliably.Invoke(f, t, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null));
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> invoke       = (f, t, n, r, e, d)    => Reliably.Invoke(f, t, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null));
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                return Reliably.Invoke(obj => { Assert.AreSame(obj, state); return f(); }, state, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, new object(), 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, new object(), -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), 10, null                     , (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null));
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                return Reliably.Invoke(obj => { Assert.AreSame(obj, state); return f(); }, state, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Stateful_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null));
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                return Reliably.Invoke(obj => { Assert.AreSame(obj, state); return f(); }, state, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Stateful_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null));
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                return Reliably.Invoke(obj => { Assert.AreSame(obj, state); return f(); }, state, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null));
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                return Reliably.Invoke(obj => { Assert.AreSame(obj, state); return f(); }, state, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null));
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                return Reliably.Invoke(obj => { Assert.AreSame(obj, state); return f(); }, state, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Stateful_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null));
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                return Reliably.Invoke(obj => { Assert.AreSame(obj, state); return f(); }, state, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public void Invoke_Func_Stateful_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null));
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                return Reliably.Invoke(obj => { Assert.AreSame(obj, state); return f(); }, state, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        #endregion
+
+        #region InvokeAsync
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d)    => Reliably.InvokeAsync(f, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d)    => Reliably.InvokeAsync(f, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d)    => Reliably.InvokeAsync(f, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d)    => Reliably.InvokeAsync(f, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d)    => Reliably.InvokeAsync(f, t, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d)    => Reliably.InvokeAsync(f, t, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d)    => Reliably.InvokeAsync(f, t, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d)    => Reliably.InvokeAsync(f, t, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Stateful_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Stateful_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Stateful_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_Func_Stateful_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.InvokeAsync(inputFunc, state, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        #endregion
+
+        #region TryInvoke
+
+        [TestMethod]
+        public void TryInvoke_Func_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, 10, ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, -3, ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, 10, null                     , DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, 10, ExceptionPolicy.Transient, (DelayHandler)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
+            {
+                return Reliably.TryInvoke(f, n, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, 10, null                     , (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
+            {
+                return Reliably.TryInvoke(f, n, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
+            {
+                return Reliably.TryInvoke(f, n, r, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
+            {
+                return Reliably.TryInvoke(f, n, r, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, CancellationToken.None, 10, null                     , DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
+            {
+                return Reliably.TryInvoke(f, t, n, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
+            {
+                return Reliably.TryInvoke(f, t, n, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
+            {
+                return Reliably.TryInvoke(f, t, n, r, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
+            {
+                return Reliably.TryInvoke(f, t, n, r, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), 10, null                     , DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); return f(); }, state, n, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, new object(), 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, new object(), -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), 10, null                     , (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); return f(); }, state, n, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Stateful_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); return f(); }, state, n, r, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Stateful_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); return f(); }, state, n, r, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); return f(); }, state, t, n, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); return f(); }, state, t, n, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Stateful_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); return f(); }, state, t, n, r, e, d.Invoke, out x);
+            }
+        }
+
+        [TestMethod]
+        public void TryInvoke_Func_Stateful_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
+            {
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); return f(); }, state, t, n, r, e, d.Invoke, out x);
+            }
+        }
+
+        #endregion
+
+        #region TryInvokeAsync
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d)    => Reliably.TryInvokeAsync(f, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d)    => Reliably.TryInvokeAsync(f, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d)    => Reliably.TryInvokeAsync(f, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d)    => Reliably.TryInvokeAsync(f, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d)    => Reliably.TryInvokeAsync(f, t, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d)    => Reliably.TryInvokeAsync(f, t, n, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d)    => Reliably.TryInvokeAsync(f, t, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<string> nullFunc = null;
+            Func<string> testFunc = () => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d)    => Reliably.TryInvokeAsync(f, t, n, r, e, d.Invoke);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Stateful_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Stateful_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Stateful_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Stateful_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Stateful_Interruptable_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Stateful_Interruptable_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, -3, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, t, n, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Stateful_Interruptable_ResultPolicy_DelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+        }
+
+        [TestMethod]
+        public async Task TryInvokeAsync_Func_Stateful_Interruptable_ResultPolicy_ComplexDelayHandler()
+        {
+#nullable disable
+
+            Func<object, string> nullFunc = null;
+            Func<object, string> testFunc = s => "Hello World";
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, -3, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, null                          , ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), null                     , (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
+
+#nullable enable
+
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                Func<object, string> inputFunc = (obj) =>
+                {
+                    Assert.AreSame(obj, state);
+                    return f();
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc, state, t, n, r, e, d.Invoke);
+            };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+        }
+
+        #endregion
+    }
+}
+

--- a/src/Sweetener.Reliability.Test/Func/Reliably.Test.tt
+++ b/src/Sweetener.Reliability.Test/Func/Reliably.Test.tt
@@ -1,0 +1,4 @@
+﻿<#
+    bool async = false;
+#>
+<#@ include file="TextTemplating\Reliably.Test.t4" #>

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/Reliably.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/Reliably.Test.t4
@@ -1,0 +1,613 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System" #>
+<#@ import namespace="System.Globalization" #>
+<#@ include file="$(MSBuildProjectDirectory)\TextTemplating\Include.t4" #>// Generated from <#= GetTemplateFileName() #>
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Reliability.Test
+{
+    partial class ReliablyTest
+    {
+<#
+    string optionalAsyncPrefix = async ? "Async"                                  : string.Empty;
+    string basicFuncType       = async ? "Func<Task<string>>"                     : "Func<string>";
+    string statefulFuncType    = async ? "Func<object, Task<string>>"             : "Func<object, string>";
+    string basicTestFunc       = async ? "() => Task.FromResult(\"Hello World\")" : "() => \"Hello World\"";
+    string statefulTestFunc    = async ? "s => Task.FromResult(\"Hello World\")"  : "s => \"Hello World\"";
+
+    if (!async)
+    {
+#>
+        #region Invoke
+
+<#
+        foreach (bool stateful in new bool[2] { false, true })
+        {
+            string inputFuncType          = stateful ? statefulFuncType : basicFuncType;
+            string testFunc               = stateful ? statefulTestFunc : basicTestFunc;
+            string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
+            string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
+
+            foreach (bool interruptable in new bool[2] { false, true })
+            {
+                string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
+                string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
+                string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+
+                foreach (bool includeResultPolicy in new bool[2] { false, true })
+                {
+                    string passResultPolicy            = includeResultPolicy.ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
+                    string complexDelayCallExpectation = includeResultPolicy ? "AlternatingAsc(r, t)"             : "OnlyExceptionAsc<string>(t)";
+                    string optionalResultPolicyObj     = includeResultPolicy ? ", ResultPolicy.Default<string>()" : string.Empty;
+                    string optionalResultPolicyArg     = includeResultPolicy ? ", r"                              : string.Empty;
+                    string optionalResultPolicySuffix  = includeResultPolicy ? "_ResultPolicy"                    : string.Empty;
+
+                    foreach (bool useComplexDelayHandler in new bool[2] { false, true })
+                    {
+                        string handlerType          = useComplexDelayHandler ? "ComplexDelayHandler<string>" : "DelayHandler";
+                        string delayInputTypeParam  = useComplexDelayHandler ? "int, string, Exception?"     : "int";
+                        string delayInputArgs       = useComplexDelayHandler ? "(i, r, e)"                   : "i";
+                        string noDelay              = useComplexDelayHandler ? "(i, r, e) => TimeSpan.Zero"  : "DelayPolicy.None";
+                        string delayCallExpectation = useComplexDelayHandler ? complexDelayCallExpectation   : "Asc()";
+                        string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"        : "_DelayHandler";
+
+                        string testName = "Invoke_" + optionalAsyncPrefix + "Func" + optionalStatefulSuffix + optionalTokenSuffix + optionalResultPolicySuffix + delaySuffix;
+#>
+        [TestMethod]
+        public void <#= testName #>()
+        {
+#nullable disable
+
+            <#= inputFuncType #> nullFunc = null;
+            <#= inputFuncType #> testFunc = <#= testFunc #>;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(nullFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.Invoke(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, -3<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>));
+<#
+                        if (includeResultPolicy)
+                        {
+#>
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                          , ExceptionPolicy.Transient, <#= noDelay #>));
+<#
+                        }
+#>
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, null                     , <#= noDelay #>));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.Invoke(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, (<#= handlerType #>)null));
+
+#nullable enable
+
+<#
+                        if (stateful)
+                        {
+#>
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> invoke = (f, t, n, r, e, d) =>
+            {
+                object state = new object();
+                return Reliably.Invoke(obj => { Assert.AreSame(obj, state); return f(); }, state<#= optionalTokenArg #>, n<#= optionalResultPolicyArg #>, e, d.Invoke);
+            };
+<#
+                        }
+                        else
+                        {
+#>
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> invoke       = (f, t, n, r, e, d)    => Reliably.Invoke(f<#= optionalTokenArg #>, n<#= optionalResultPolicyArg #>, e, d.Invoke);
+<#
+                        }
+#>
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d));
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => invoke(f, t, n, r, e, d), x);
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>(), <#= passResultPolicy #>);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                        if (includeResultPolicy)
+                        {
+#>
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                        }
+#>
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                        if (interruptable)
+                        {
+#>
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                        }
+#>
+        }
+
+<#
+                    }
+                }
+            }
+        }
+#>
+        #endregion
+
+<#
+    }
+#>
+        #region InvokeAsync
+
+<#
+    foreach (bool stateful in new bool[2] { false, true })
+    {
+        string inputFuncType          = stateful ? statefulFuncType   : basicFuncType;
+        string testFunc               = stateful ? statefulTestFunc   : basicTestFunc;
+        string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
+        string optionalStateArg       = stateful ? ", state"          : string.Empty;
+        string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
+
+        foreach (bool interruptable in new bool[2] { false, true })
+        {
+            string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
+            string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
+            string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+
+            foreach (bool includeResultPolicy in new bool[2] { false, true })
+            {
+                string passResultPolicy            = includeResultPolicy.ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
+                string complexDelayCallExpectation = includeResultPolicy ? "AlternatingAsc(r, t)"             : "OnlyExceptionAsc<string>(t)";
+                string optionalResultPolicyObj     = includeResultPolicy ? ", ResultPolicy.Default<string>()" : string.Empty;
+                string optionalResultPolicyArg     = includeResultPolicy ? ", r"                              : string.Empty;
+                string optionalResultPolicySuffix  = includeResultPolicy ? "_ResultPolicy"                    : string.Empty;
+
+                foreach (bool useComplexDelayHandler in new bool[2] { false, true })
+                {
+                    string handlerType          = useComplexDelayHandler ? "ComplexDelayHandler<string>" : "DelayHandler";
+                    string delayInputTypeParam  = useComplexDelayHandler ? "int, string, Exception?"     : "int";
+                    string delayInputArgs       = useComplexDelayHandler ? "(i, r, e)"                   : "i";
+                    string noDelay              = useComplexDelayHandler ? "(i, r, e) => TimeSpan.Zero"  : "DelayPolicy.None";
+                    string delayCallExpectation = useComplexDelayHandler ? complexDelayCallExpectation   : "Asc()";
+                    string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"        : "_DelayHandler";
+                
+                    string testName = "InvokeAsync_" + optionalAsyncPrefix + "Func" + optionalStatefulSuffix + optionalTokenSuffix + optionalResultPolicySuffix + delaySuffix;
+#>
+        [TestMethod]
+        public async Task <#= testName #>()
+        {
+#nullable disable
+
+            <#= inputFuncType #> nullFunc = null;
+            <#= inputFuncType #> testFunc = <#= testFunc #>;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, -3<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+<#
+                    if (includeResultPolicy)
+                    {
+#>
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                          , ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+<#
+                    }
+#>
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, null                     , <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, (<#= handlerType #>)null)).ConfigureAwait(false);
+
+<#
+                    if (async)
+                    {
+#>
+            <#= inputFuncType #> nullTaskFunc = <#= stateful ? "s" : "()" #> => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+
+<#
+                    }
+#>
+#nullable enable
+
+<#
+                    if (async || stateful)
+                    {
+#>
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d) =>
+            {
+<#
+                        if (stateful)
+                        {
+#>
+                object state = new object();
+<#
+                        }
+#>
+                <#= inputFuncType #> inputFunc = (<#= stateful ? "obj" : string.Empty #>) =>
+                {
+<#
+                        if (stateful)
+                        {
+#>
+                    Assert.AreSame(obj, state);
+<#
+                        }
+                        
+                        if (async)
+                        {
+#>
+                    return Task.FromResult(f());
+<#
+                        }
+                        else
+                        {
+#>
+                    return f();
+<#
+                        }
+#>
+                };
+
+                return Reliably.InvokeAsync(inputFunc<#= optionalStateArg #><#= optionalTokenArg #>, n<#= optionalResultPolicyArg #>, e, d.Invoke);
+            };
+<#
+                    }
+                    else
+                    {
+#>
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task<string>> invoke = (f, t, n, r, e, d)    => Reliably.InvokeAsync(f<#= optionalTokenArg #>, n<#= optionalResultPolicyArg #>, e, d.Invoke);
+<#
+                    }
+#>
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> assertResult = (f, t, n, r, e, d, x) => Assert.AreEqual(x, invoke(f, t, n, r, e, d).Result);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type>   assertError  = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(f, t, n, r, e, d), x).Wait();
+
+            // Success
+            Invoke_Func_Success                   (assertResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>(), <#= passResultPolicy #>);
+            Invoke_Func_EventualSuccess           (assertResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                    if (includeResultPolicy)
+                    {
+#>
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Func_EventualFailure_Result    (assertResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Func_RetriesExhausted_Result   (assertResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                    }
+#>
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                    if (interruptable)
+                    {
+#>
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                    }
+#>
+        }
+
+<#
+                }
+            }
+        }
+    }
+#>
+        #endregion
+
+<#
+    if (!async)
+    {
+#>
+        #region TryInvoke
+
+<#
+        foreach (bool stateful in new bool[2] { false, true })
+        {
+            string inputFuncType          = stateful ? statefulFuncType : basicFuncType;
+            string testFunc               = stateful ? statefulTestFunc : basicTestFunc;
+            string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
+            string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
+
+            foreach (bool interruptable in new bool[2] { false, true })
+            {
+                string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
+                string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
+                string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+
+                foreach (bool includeResultPolicy in new bool[2] { false, true })
+                {
+                    string passResultPolicy            = includeResultPolicy.ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
+                    string complexDelayCallExpectation = includeResultPolicy ? "AlternatingAsc(r, t)"             : "OnlyExceptionAsc<string>(t)";
+                    string optionalResultPolicyObj     = includeResultPolicy ? ", ResultPolicy.Default<string>()" : string.Empty;
+                    string optionalResultPolicyArg     = includeResultPolicy ? ", r"                              : string.Empty;
+                    string optionalResultPolicySuffix  = includeResultPolicy ? "_ResultPolicy"                    : string.Empty;
+
+                    foreach (bool useComplexDelayHandler in new bool[2] { false, true })
+                    {
+                        string handlerType          = useComplexDelayHandler ? "ComplexDelayHandler<string>" : "DelayHandler";
+                        string delayInputTypeParam  = useComplexDelayHandler ? "int, string, Exception?"     : "int";
+                        string delayInputArgs       = useComplexDelayHandler ? "(i, r, e)"                   : "i";
+                        string noDelay              = useComplexDelayHandler ? "(i, r, e) => TimeSpan.Zero"  : "DelayPolicy.None";
+                        string delayCallExpectation = useComplexDelayHandler ? complexDelayCallExpectation   : "Asc()";
+                        string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"        : "_DelayHandler";
+
+                        string testName = "TryInvoke_" + optionalAsyncPrefix + "Func" + optionalStatefulSuffix + optionalTokenSuffix + optionalResultPolicySuffix + delaySuffix;
+#>
+        [TestMethod]
+        public void <#= testName #>()
+        {
+#nullable disable
+
+            <#= inputFuncType #> nullFunc = null;
+            <#= inputFuncType #> testFunc = <#= testFunc #>;
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(nullFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>, out string _));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Reliably.TryInvoke(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, -3<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>, out string _));
+<#
+                        if (includeResultPolicy)
+                        {
+#>
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                          , ExceptionPolicy.Transient, <#= noDelay #>, out string _));
+<#
+                        }
+#>
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, null                     , <#= noDelay #>, out string _));
+            Assert.ThrowsException<ArgumentNullException      >(() => Reliably.TryInvoke(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, (<#= handlerType #>)null, out string _));
+
+#nullable enable
+
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+<#
+                        if (interruptable)
+                        {
+#>
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
+<#
+                        }
+#>
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>(), <#= passResultPolicy #>);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                        if (includeResultPolicy)
+                        {
+#>
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                        }
+#>
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                        if (interruptable)
+                        {
+#>
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                        }
+#>
+
+            static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<<#= delayInputTypeParam #>, TimeSpan> d, out string x)
+            {
+<#
+                        if (stateful)
+                        {
+#>
+                object state = new object();
+                return Reliably.TryInvoke(obj => { Assert.AreSame(obj, state); return f(); }, state<#= optionalTokenArg #>, n<#= optionalResultPolicyArg #>, e, d.Invoke, out x);
+<#
+                        }
+                        else
+                        {
+#>
+                return Reliably.TryInvoke(f<#= optionalTokenArg #>, n<#= optionalResultPolicyArg #>, e, d.Invoke, out x);
+<#
+                        }
+#>
+            }
+        }
+
+<#
+                    }
+                }
+            }
+        }
+#>
+        #endregion
+
+<#
+    }
+#>
+        #region TryInvokeAsync
+
+<#
+    foreach (bool stateful in new bool[2] { false, true })
+    {
+        string inputFuncType          = stateful ? statefulFuncType : basicFuncType;
+        string testFunc               = stateful ? statefulTestFunc : basicTestFunc;
+        string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
+        string optionalStateArg       = stateful ? ", state"          : string.Empty;
+        string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
+
+        foreach (bool interruptable in new bool[2] { false, true })
+        {
+            string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
+            string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
+            string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+
+            foreach (bool includeResultPolicy in new bool[2] { false, true })
+            {
+                string passResultPolicy            = includeResultPolicy.ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
+                string complexDelayCallExpectation = includeResultPolicy ? "AlternatingAsc(r, t)"             : "OnlyExceptionAsc<string>(t)";
+                string optionalResultPolicyObj     = includeResultPolicy ? ", ResultPolicy.Default<string>()" : string.Empty;
+                string optionalResultPolicyArg     = includeResultPolicy ? ", r"                              : string.Empty;
+                string optionalResultPolicySuffix  = includeResultPolicy ? "_ResultPolicy"                    : string.Empty;
+
+                foreach (bool useComplexDelayHandler in new bool[2] { false, true })
+                {
+                    string handlerType          = useComplexDelayHandler ? "ComplexDelayHandler<string>" : "DelayHandler";
+                    string delayInputTypeParam  = useComplexDelayHandler ? "int, string, Exception?"     : "int";
+                    string delayInputArgs       = useComplexDelayHandler ? "(i, r, e)"                   : "i";
+                    string noDelay              = useComplexDelayHandler ? "(i, r, e) => TimeSpan.Zero"  : "DelayPolicy.None";
+                    string delayCallExpectation = useComplexDelayHandler ? complexDelayCallExpectation   : "Asc()";
+                    string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"        : "_DelayHandler";
+
+                    string testName = "TryInvokeAsync_" + optionalAsyncPrefix + "Func" + optionalStatefulSuffix + optionalTokenSuffix + optionalResultPolicySuffix + delaySuffix;
+#>
+        [TestMethod]
+        public async Task <#= testName #>()
+        {
+#nullable disable
+
+            <#= inputFuncType #> nullFunc = null;
+            <#= inputFuncType #> testFunc = <#= testFunc #>;
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, -3<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+<#
+                    if (includeResultPolicy)
+                    {
+#>
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                          , ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+<#
+                    }
+#>
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, null                     , <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, (<#= handlerType #>)null)).ConfigureAwait(false);
+
+<#
+                    if (async)
+                    {
+#>
+            <#= inputFuncType #> nullTaskFunc = <#= stateful ? "s" : "()" #> => null;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+
+<#
+                    }
+#>
+#nullable enable
+
+<#
+                    if (async || stateful)
+                    {
+#>
+            Func<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d) =>
+            {
+<#
+                        if (stateful)
+                        {
+#>
+                object state = new object();
+<#
+                        }
+#>
+                <#= inputFuncType #> inputFunc = (<#= stateful ? "obj" : string.Empty #>) =>
+                {
+<#
+                        if (stateful)
+                        {
+#>
+                    Assert.AreSame(obj, state);
+<#
+                        }
+                    
+                        if (async)
+                        {
+#>
+                    return Task.FromResult(f());
+<#
+                        }
+                        else
+                        {
+#>
+                    return f();
+<#
+                        }
+#>
+                };
+
+                return Reliably.TryInvokeAsync(inputFunc<#= optionalStateArg #><#= optionalTokenArg #>, n<#= optionalResultPolicyArg #>, e, d.Invoke);
+            };
+<#
+                    }
+                    else
+                    {
+#>
+            Func  <Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Task<Optional<string>>> tryInvoke = (f, t, n, r, e, d)    => Reliably.TryInvokeAsync(f<#= optionalTokenArg #>, n<#= optionalResultPolicyArg #>, e, d.Invoke);
+<#
+                    }
+#>
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+<#
+                    if (interruptable)
+                    {
+#>
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
+<#
+                    }
+#>
+
+            // Success
+            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>(), <#= passResultPolicy #>);
+            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                    if (includeResultPolicy)
+                    {
+#>
+
+            // Failure (Result)
+            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+<#
+                    }
+#>
+
+            // Failure (Exception)
+            Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                    if (interruptable)
+                    {
+#>
+
+            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+<#
+                    }
+#>
+        }
+
+<#
+                }
+            }
+        }
+    }
+#>
+        #endregion
+    }
+}

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/Reliably.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/Reliably.Test.t4
@@ -151,6 +151,7 @@ namespace Sweetener.Reliability.Test
     {
         string inputFuncType          = stateful ? statefulFuncType   : basicFuncType;
         string testFunc               = stateful ? statefulTestFunc   : basicTestFunc;
+        string ctorTypeArgs           = stateful ? "<object, string>" : "<string>";
         string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
         string optionalStateArg       = stateful ? ", state"          : string.Empty;
         string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
@@ -177,6 +178,10 @@ namespace Sweetener.Reliability.Test
                     string noDelay              = useComplexDelayHandler ? "(i, r, e) => TimeSpan.Zero"  : "DelayPolicy.None";
                     string delayCallExpectation = useComplexDelayHandler ? complexDelayCallExpectation   : "Asc()";
                     string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"        : "_DelayHandler";
+
+                    // Our ctor can be ambiguous between Func<Task<T>> and Func<T> under specific circumstances
+                    string optionalCtorTypeArgs = async && useComplexDelayHandler && !includeResultPolicy ? ctorTypeArgs : string.Empty;
+                    string optionalCtorSpacing  = new string(' ', optionalCtorTypeArgs.Length);
                 
                     string testName = "InvokeAsync_" + optionalAsyncPrefix + "Func" + optionalStatefulSuffix + optionalTokenSuffix + optionalResultPolicySuffix + delaySuffix;
 #>
@@ -187,25 +192,25 @@ namespace Sweetener.Reliability.Test
 
             <#= inputFuncType #> nullFunc = null;
             <#= inputFuncType #> testFunc = <#= testFunc #>;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(nullFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, -3<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<#= optionalCtorTypeArgs #>(nullFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.InvokeAsync<#= optionalCtorTypeArgs #>(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, -3<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
 <#
                     if (includeResultPolicy)
                     {
 #>
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                          , ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10, <#= async ? "(ResultHandler<string>)null   " : "null                          " #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
 <#
                     }
 #>
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, null                     , <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, (<#= handlerType #>)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<#= optionalCtorTypeArgs #>(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, null                     , <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.InvokeAsync<#= optionalCtorSpacing #>(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, (<#= handlerType #>)null)).ConfigureAwait(false);
 
 <#
                     if (async)
                     {
 #>
             <#= inputFuncType #> nullTaskFunc = <#= stateful ? "s" : "()" #> => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<#= optionalCtorTypeArgs #>(nullTaskFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
 
 <#
                     }
@@ -447,6 +452,7 @@ namespace Sweetener.Reliability.Test
     {
         string inputFuncType          = stateful ? statefulFuncType : basicFuncType;
         string testFunc               = stateful ? statefulTestFunc : basicTestFunc;
+        string ctorTypeArgs           = stateful ? "<object, string>" : "<string>";
         string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
         string optionalStateArg       = stateful ? ", state"          : string.Empty;
         string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
@@ -474,6 +480,10 @@ namespace Sweetener.Reliability.Test
                     string delayCallExpectation = useComplexDelayHandler ? complexDelayCallExpectation   : "Asc()";
                     string delaySuffix          = useComplexDelayHandler ? "_ComplexDelayHandler"        : "_DelayHandler";
 
+                    // Our ctor can be ambiguous between Func<Task<T>> and Func<T> under specific circumstances
+                    string optionalCtorTypeArgs = async && useComplexDelayHandler && !includeResultPolicy ? ctorTypeArgs : string.Empty;
+                    string optionalCtorSpacing  = new string(' ', optionalCtorTypeArgs.Length);
+
                     string testName = "TryInvokeAsync_" + optionalAsyncPrefix + "Func" + optionalStatefulSuffix + optionalTokenSuffix + optionalResultPolicySuffix + delaySuffix;
 #>
         [TestMethod]
@@ -483,25 +493,25 @@ namespace Sweetener.Reliability.Test
 
             <#= inputFuncType #> nullFunc = null;
             <#= inputFuncType #> testFunc = <#= testFunc #>;
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(nullFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, -3<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<#= optionalCtorTypeArgs #>(nullFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => Reliably.TryInvokeAsync<#= optionalCtorTypeArgs #>(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, -3<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
 <#
                     if (includeResultPolicy)
                     {
 #>
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10, null                          , ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10, <#= async ? "(ResultHandler<string>)null   " : "null                          " #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
 <#
                     }
 #>
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, null                     , <#= noDelay #>)).ConfigureAwait(false);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, (<#= handlerType #>)null)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<#= optionalCtorTypeArgs #>(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, null                     , <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync<#= optionalCtorSpacing #>(testFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, (<#= handlerType #>)null)).ConfigureAwait(false);
 
 <#
                     if (async)
                     {
 #>
             <#= inputFuncType #> nullTaskFunc = <#= stateful ? "s" : "()" #> => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<#= optionalCtorTypeArgs #>(nullTaskFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
 
 <#
                     }

--- a/src/Sweetener.Reliability.Test/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Reliably.Test.cs
@@ -1,0 +1,261 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Reliability.Test
+{
+    [TestClass]
+    public partial class ReliablyTest
+    {
+        #region Invoke_Action_Success
+
+        private void Invoke_Action_Success<TDelayHandler, TDelayHandlerProxy>(
+            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create a "successful" user-defined action
+            ActionProxy action = new ActionProxy(Operation.Null);
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<Exception, bool> exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fatal.Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Define expectations
+            exceptionHandler.Invoking += Expect.Nothing<Exception>();
+            addDelayObservation(delayHandler);
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(action.Invoke, tokenSource.Token, 42, exceptionHandler.Invoke, delayHandler.Proxy);
+
+            // Validate the number of calls
+            Assert.AreEqual(1, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Action_Failure
+
+        private void Invoke_Action_Failure<TDelayHandler, TDelayHandlerProxy>(
+            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler, Type> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create an "unsuccessful" user-defined action
+            ActionProxy action = new ActionProxy(() => throw new OutOfMemoryException());
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<Exception, bool> exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<OutOfMemoryException>().Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Define expectations
+            exceptionHandler.Invoking += Expect.Exception(typeof(OutOfMemoryException));
+            addDelayObservation(delayHandler);
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(action.Invoke, tokenSource.Token, 42, exceptionHandler.Invoke, delayHandler.Proxy, typeof(OutOfMemoryException));
+
+            // Validate the number of calls
+            Assert.AreEqual(1, action          .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Action_EventualSuccess
+
+        private void Invoke_Action_EventualSuccess<TDelayHandler, TDelayHandlerProxy>(
+            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, Type> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create a "successful" user-defined action that completes after 1 IOException
+            ActionProxy action = new ActionProxy(FlakyAction.Create<IOException>(1));
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<Exception, bool> exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            action          .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            exceptionHandler.Invoking += Expect.Exception(typeof(IOException));
+            addDelayObservation(delayHandler, typeof(IOException));
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(action.Invoke, tokenSource.Token, 42, exceptionHandler.Invoke, delayHandler.Proxy);
+
+            // Validate the number of calls
+            Assert.AreEqual(2, action          .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(1, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Action_EventualFailure
+
+        private void Invoke_Action_EventualFailure<TDelayHandler, TDelayHandlerProxy>(
+            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler, Type> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, Type> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create an "unsuccessful" user-defined action that fails after 2 transient exceptions
+            ActionProxy action = new ActionProxy(FlakyAction.Create<IOException, OutOfMemoryException>(2));
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<Exception, bool> exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            action          .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            exceptionHandler.Invoking += Expect.Exceptions(typeof(IOException), typeof(OutOfMemoryException), 2);
+            addDelayObservation(delayHandler, typeof(IOException));
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(action.Invoke, tokenSource.Token, 42, exceptionHandler.Invoke, delayHandler.Proxy, typeof(OutOfMemoryException));
+
+            // Validate the number of calls
+            Assert.AreEqual(3, action          .Calls);
+            Assert.AreEqual(3, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Action_RetriesExhausted
+
+        private void Invoke_Action_RetriesExhausted<TDelayHandler, TDelayHandlerProxy>(
+            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler, Type> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, Type> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create an "unsuccessful" user-defined action that exhausts the configured number of retries
+            ActionProxy action = new ActionProxy(() => throw new IOException());
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<Exception, bool> exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            action          .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            exceptionHandler.Invoking += Expect.Exception(typeof(IOException));
+            addDelayObservation(delayHandler, typeof(IOException));
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(action.Invoke, tokenSource.Token, 2, exceptionHandler.Invoke, delayHandler.Proxy, typeof(IOException));
+
+            // Validate the number of calls
+            Assert.AreEqual(3, action          .Calls);
+            Assert.AreEqual(3, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Action_Canceled_Delegate
+
+        private void Invoke_Action_Canceled_Delegate<TDelayHandler, TDelayHandlerProxy>(
+            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler> invoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, Type> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+
+            // Create a user-defined action that will throw an exception depending on whether its canceled
+            ActionProxy action = new ActionProxy(
+                () =>
+                {
+                    tokenSource.Token.ThrowIfCancellationRequested();
+                    throw new IOException();
+                });
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            action          .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            exceptionHandler.Invoking += Expect.Exception(typeof(IOException));
+            addDelayObservation(delayHandler, typeof(IOException));
+
+            // Cancel the action on its 2nd attempt
+            action.Invoking += (c) =>
+            {
+                if (c.Calls == 2)
+                    tokenSource.Cancel();
+            };
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(action.Invoke, tokenSource.Token, Retries.Infinite, exceptionHandler.Invoke, delayHandler.Proxy), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(2, action          .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(1, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Action_Canceled_Delay
+
+        private void Invoke_Action_Canceled_Delay<TDelayHandler, TDelayHandlerProxy>(
+            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler> invoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, Type> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+
+            // Create an "unsuccessful" user-defined action that continues to fail with transient exceptions until it's canceled
+            ActionProxy action = new ActionProxy(() => throw new IOException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            action          .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            exceptionHandler.Invoking += Expect.Exception(typeof(IOException));
+            addDelayObservation(delayHandler, typeof(IOException));
+
+            // Cancel the delay on its 2nd invocation
+            delayHandler.Invoking += (c) =>
+            {
+                if (c.Calls == 2)
+                    tokenSource.Cancel();
+            };
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(action.Invoke, tokenSource.Token, Retries.Infinite, exceptionHandler.Invoke, delayHandler.Proxy), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(2, action          .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
+        }
+
+        #endregion
+    }
+}

--- a/src/Sweetener.Reliability.Test/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Reliably.Test.cs
@@ -22,7 +22,7 @@ namespace Sweetener.Reliability.Test
             ActionProxy action = new ActionProxy(Operation.Null);
 
             // Declare the various proxies for the input delegates
-            FuncProxy<Exception, bool> exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fatal.Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Fatal.Invoke);
             TDelayHandlerProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
 
             // Define expectations
@@ -54,7 +54,7 @@ namespace Sweetener.Reliability.Test
             ActionProxy action = new ActionProxy(() => throw new OutOfMemoryException());
 
             // Declare the various proxies for the input delegates
-            FuncProxy<Exception, bool> exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<OutOfMemoryException>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<OutOfMemoryException>().Invoke);
             TDelayHandlerProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
 
             // Define expectations
@@ -86,7 +86,7 @@ namespace Sweetener.Reliability.Test
             ActionProxy action = new ActionProxy(FlakyAction.Create<IOException>(1));
 
             // Declare the various proxies for the input delegates
-            FuncProxy<Exception, bool> exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
             TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
 
             // Define expectations
@@ -119,7 +119,7 @@ namespace Sweetener.Reliability.Test
             ActionProxy action = new ActionProxy(FlakyAction.Create<IOException, OutOfMemoryException>(2));
 
             // Declare the various proxies for the input delegates
-            FuncProxy<Exception, bool> exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
             TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
 
             // Define expectations
@@ -152,7 +152,7 @@ namespace Sweetener.Reliability.Test
             ActionProxy action = new ActionProxy(() => throw new IOException());
 
             // Declare the various proxies for the input delegates
-            FuncProxy<Exception, bool> exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
             TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
 
             // Define expectations
@@ -192,7 +192,7 @@ namespace Sweetener.Reliability.Test
                 });
 
             // Declare the various proxies for the input delegates
-            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
             TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
 
             // Define expectations
@@ -233,7 +233,7 @@ namespace Sweetener.Reliability.Test
             ActionProxy action = new ActionProxy(() => throw new IOException());
 
             // Declare the various proxies for the input delegates and event handlers
-            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
             TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
 
             // Define expectations
@@ -255,6 +255,432 @@ namespace Sweetener.Reliability.Test
             Assert.AreEqual(2, action          .Calls);
             Assert.AreEqual(2, exceptionHandler.Calls);
             Assert.AreEqual(2, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Func_Success
+
+        private void Invoke_Func_Success<TDelayHandler, TDelayHandlerProxy>(
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, string> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create a "successful" user-defined function
+            FuncProxy<string> func = new FuncProxy<string>(() => "Success");
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<string, ResultKind> resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Success" ? ResultKind.Successful : ResultKind.Fatal);
+            FuncProxy<Exception, bool>    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Fatal.Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Define expectations
+            resultHandler   .Invoking += Expect.Result("Success");
+            exceptionHandler.Invoking += Expect.Nothing<Exception>();
+            addDelayObservation(delayHandler);
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, "Success");
+
+            // Validate the number of calls
+            Assert.AreEqual(1, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Func_Failure_Result
+
+        private void Invoke_Func_Failure_Result<TDelayHandler, TDelayHandlerProxy>(
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, string> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create an "unsuccessful" user-defined function that returns a fatal result
+            FuncProxy<string> func = new FuncProxy<string>(() => "Failure");
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<string, ResultKind> resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Failure" ? ResultKind.Fatal : ResultKind.Successful);
+            FuncProxy<Exception, bool>    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Fatal.Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Define expectations
+            resultHandler   .Invoking += Expect.Result("Failure");
+            exceptionHandler.Invoking += Expect.Nothing<Exception>();
+            addDelayObservation(delayHandler);
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, "Failure");
+
+            // Validate the number of calls
+            Assert.AreEqual(1, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Func_Failure_Exception
+
+        private void Invoke_Func_Failure_Exception<TDelayHandler, TDelayHandlerProxy>(
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, Type> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create an "unsuccessful" user-defined function that throws a fatal exception
+            FuncProxy<string> func = new FuncProxy<string>(() => throw new OutOfMemoryException());
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<string, ResultKind> resultHandler    = new FuncProxy<string, ResultKind>(r => ResultKind.Successful);
+            FuncProxy<Exception, bool>    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Fail<OutOfMemoryException>().Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Define expectations
+            resultHandler   .Invoking += Expect.Nothing<string>();
+            exceptionHandler.Invoking += Expect.Exception(typeof(OutOfMemoryException));
+            addDelayObservation(delayHandler);
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, typeof(OutOfMemoryException));
+
+            // Validate the number of calls
+            Assert.AreEqual(1, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Func_EventualSuccess
+
+        private void Invoke_Func_EventualSuccess<TDelayHandler, TDelayHandlerProxy>(
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, string, Type> addDelayObservation,
+            bool passResultHandler = true)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create a "successful" user-defined action that completes after either
+            // (1) 2 IOExceptions OR
+            // (2) an IOException and a transient result
+            Func<string> flakyFunc = passResultHandler
+                ? FlakyFunc.Create<string, IOException>("Try Again", "Success", 2)
+                : FlakyFunc.Create<string, IOException>(             "Success", 2);
+            FuncProxy<string> func = new FuncProxy<string>(flakyFunc);
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<string, ResultKind> resultHandler = new FuncProxy<string, ResultKind>(r =>
+                r switch
+                {
+                    "Try Again" => ResultKind.Transient,
+                    "Success"   => ResultKind.Successful,
+                    _           => ResultKind.Fatal,
+                });
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            func            .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            resultHandler   .Invoking += Expect.Results("Try Again", "Success", 1);
+            exceptionHandler.Invoking += Expect.Exception(typeof(IOException));
+            addDelayObservation(delayHandler, "Try Again", typeof(IOException));
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy);
+
+            // Validate the number of calls
+            int x = passResultHandler ? 2 : 0;
+            int y = passResultHandler ? 1 : 2;
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(x, resultHandler   .Calls);
+            Assert.AreEqual(y, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Func_EventualFailure_Result
+
+        private void Invoke_Func_EventualFailure_Result<TDelayHandler, TDelayHandlerProxy>(
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, string> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, string, Type> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create an "unsuccessful" user-defined action that completes after a transient result and exception
+            Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Try Again", "Failure", 2);
+            FuncProxy<string> func = new FuncProxy<string>(flakyFunc);
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<string, ResultKind> resultHandler = new FuncProxy<string, ResultKind>(r =>
+                r switch
+                {
+                    "Try Again" => ResultKind.Transient,
+                    "Failure"   => ResultKind.Fatal,
+                    _           => ResultKind.Successful,
+                });
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            func            .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            resultHandler   .Invoking += Expect.Results("Try Again", "Failure", 1);
+            exceptionHandler.Invoking += Expect.Exception(typeof(IOException));
+            addDelayObservation(delayHandler, "Try Again", typeof(IOException));
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, "Failure");
+
+            // Validate the number of calls
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(2, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Func_EventualFailure_Exception
+
+        internal void Invoke_Func_EventualFailure_Exception<TDelayHandler, TDelayHandlerProxy>(
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, Type> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, string, Type> addDelayObservation,
+            bool passResultHandler = true)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create an "unsuccessful" user-defined action that completes after either
+            // (1) 2 IOExceptions OR
+            // (2) an IOException and a transient result
+            Func<string> flakyFunc = passResultHandler
+                ? FlakyFunc.Create<string, IOException, OutOfMemoryException>("Try Again", 2)
+                : FlakyFunc.Create<string, IOException, OutOfMemoryException>(             2);
+            FuncProxy<string> func = new FuncProxy<string>(flakyFunc);
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<string, ResultKind> resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Try Again" ? ResultKind.Transient : ResultKind.Successful);
+            FuncProxy<Exception, bool>    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            func            .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            resultHandler   .Invoking += Expect.Result("Try Again");
+            exceptionHandler.Invoking += Expect.Exceptions(typeof(IOException), typeof(OutOfMemoryException), passResultHandler ? 1 : 2);
+            addDelayObservation(delayHandler, "Try Again", typeof(IOException));
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, typeof(OutOfMemoryException));
+
+            // Validate the number of calls
+            int x = passResultHandler ? 1 : 0;
+            int y = passResultHandler ? 2 : 3;
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(x, resultHandler   .Calls);
+            Assert.AreEqual(y, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Func_RetriesExhausted_Result
+
+        internal void Invoke_Func_RetriesExhausted_Result<TDelayHandler, TDelayHandlerProxy>(
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, string> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, string, Type> addDelayObservation)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create an "unsuccessful" user-defined action that eventually exhausts all of its retries
+            Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Try Again");
+            FuncProxy<string> func = new FuncProxy<string>(flakyFunc);
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<string, ResultKind> resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Try Again" ? ResultKind.Transient : ResultKind.Fatal);
+            FuncProxy<Exception, bool>    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            func            .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            resultHandler   .Invoking += Expect.Result("Try Again");
+            exceptionHandler.Invoking += Expect.Exception(typeof(IOException));
+            addDelayObservation(delayHandler, "Try Again", typeof(IOException));
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, "Try Again");
+
+            // Validate the number of calls
+            Assert.AreEqual(4, func            .Calls);
+            Assert.AreEqual(2, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Func_RetriesExhausted_Exception
+
+        internal void Invoke_Func_RetriesExhausted_Exception<TDelayHandler, TDelayHandlerProxy>(
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, Type> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, string, Type> addDelayObservation,
+            bool passResultHandler = true)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            // Create an "unsuccessful" user-defined action that eventually exhausts all of its retries
+            Func<string> flakyFunc = passResultHandler
+                ? FlakyFunc.Create<string, IOException>("Try Again")
+                : () => throw new IOException();
+            FuncProxy<string> func = new FuncProxy<string>(flakyFunc);
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<string, ResultKind> resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Try Again" ? ResultKind.Transient : ResultKind.Successful);
+            FuncProxy<Exception, bool>    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Retry<IOException>().Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            func            .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            resultHandler   .Invoking += Expect.Result("Try Again");
+            exceptionHandler.Invoking += Expect.Exception(typeof(IOException));
+            addDelayObservation(delayHandler, "Try Again", typeof(IOException));
+
+            // Invoke
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, typeof(IOException));
+
+            // Validate the number of calls
+            int x = passResultHandler ? 1 : 0;
+            int y = passResultHandler ? 2 : 3;
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(x, resultHandler   .Calls);
+            Assert.AreEqual(y, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Func_Canceled_Delegate
+
+        internal void Invoke_Func_Canceled_Delegate<TDelayHandler, TDelayHandlerProxy>(
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, Type> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, string, Type> addDelayObservation,
+            bool passResultHandler = true)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+
+            // Create a user-defined action that will throw an exception depending on whether it's canceled
+            Func<string> flakyFunc = passResultHandler ? FlakyFunc.Create<string, IOException>("Try Again") : () => throw new IOException();
+            FuncProxy<string> func = new FuncProxy<string>(() =>
+            {
+                tokenSource.Token.ThrowIfCancellationRequested();
+                return flakyFunc();
+            });
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<string, ResultKind> resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Try Again" ? ResultKind.Transient : ResultKind.Successful);
+            FuncProxy<Exception, bool>    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            func            .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            resultHandler   .Invoking += Expect.Result("Try Again");
+            exceptionHandler.Invoking += Expect.Exception(typeof(IOException));
+            addDelayObservation(delayHandler, "Try Again", typeof(IOException));
+
+            // Cancel the function after 2 or 3 invocations
+            int i = passResultHandler ? 3 : 2;
+
+            func.Invoking += c =>
+            {
+                if (c.Calls == i)
+                    tokenSource.Cancel();
+            };
+
+            // Invoke, retry, and cancel
+            assertInvoke(func.Invoke, tokenSource.Token, Retries.Infinite, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, typeof(OperationCanceledException));
+
+            // Validate the number of calls
+            int r = i - 1;
+            int x = passResultHandler ? r / 2 : 0;
+            int y = passResultHandler ? r / 2 : r;
+            Assert.AreEqual(i, func            .Calls);
+            Assert.AreEqual(x, resultHandler   .Calls);
+            Assert.AreEqual(y, exceptionHandler.Calls);
+            Assert.AreEqual(r, delayHandler    .Calls);
+        }
+
+        #endregion
+
+        #region Invoke_Func_Canceled_Delay
+
+        internal void Invoke_Func_Canceled_Delay<TDelayHandler, TDelayHandlerProxy>(
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, Type> assertInvoke,
+            Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
+            Action<TDelayHandlerProxy, string, Type> addDelayObservation,
+            bool passResultHandler = true)
+            where TDelayHandler      : Delegate
+            where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+
+            // Create an "unsuccessful" user-defined func that continues to fail with transient exceptions until it's canceled
+            Func<string> flakyFunc = passResultHandler ? FlakyFunc.Create<string, IOException>("Try Again") : () => throw new IOException();
+            FuncProxy<string> func = new FuncProxy<string>(flakyFunc);
+
+            // Declare the various proxies for the input delegates
+            FuncProxy<string, ResultKind> resultHandler    = new FuncProxy<string, ResultKind>(r => r == "Try Again" ? ResultKind.Transient : ResultKind.Successful);
+            FuncProxy<Exception, bool>    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayHandlerProxy delayHandler = delayHandlerFactory(Constants.Delay);
+
+            // Define expectations
+            func            .Invoking += Expect.AfterDelay(Constants.MinDelay);
+            resultHandler   .Invoking += Expect.Result("Try Again");
+            exceptionHandler.Invoking += Expect.Exception(typeof(IOException));
+            addDelayObservation(delayHandler, "Try Again", typeof(IOException));
+
+            // Cancel the delay after 1 or 2 invocations
+            int r = passResultHandler ? 2 : 1;
+
+            delayHandler.Invoking += c =>
+            {
+                if (c.Calls == r)
+                    tokenSource.Cancel();
+            };
+
+            // Invoke, retry, and cancel
+            assertInvoke(func.Invoke, tokenSource.Token, Retries.Infinite, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, typeof(TaskCanceledException));
+
+            // Validate the number of calls
+            int x = passResultHandler ? r / 2 : 0;
+            int y = passResultHandler ? r / 2 : r;
+            Assert.AreEqual(r, func            .Calls);
+            Assert.AreEqual(x, resultHandler   .Calls);
+            Assert.AreEqual(y, exceptionHandler.Calls);
+            Assert.AreEqual(r, delayHandler    .Calls);
         }
 
         #endregion

--- a/src/Sweetener.Reliability.Test/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Reliably.Test.cs
@@ -264,7 +264,8 @@ namespace Sweetener.Reliability.Test
         private void Invoke_Func_Success<TDelayHandler, TDelayHandlerProxy>(
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, string> assertInvoke,
             Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
-            Action<TDelayHandlerProxy> addDelayObservation)
+            Action<TDelayHandlerProxy> addDelayObservation,
+            bool passResultHandler)
             where TDelayHandler      : Delegate
             where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
         {
@@ -286,8 +287,9 @@ namespace Sweetener.Reliability.Test
                 assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, "Success");
 
             // Validate the number of calls
+            int x = passResultHandler ? 1 : 0;
             Assert.AreEqual(1, func            .Calls);
-            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(x, resultHandler   .Calls);
             Assert.AreEqual(0, exceptionHandler.Calls);
             Assert.AreEqual(0, delayHandler    .Calls);
         }
@@ -367,10 +369,10 @@ namespace Sweetener.Reliability.Test
         #region Invoke_Func_EventualSuccess
 
         private void Invoke_Func_EventualSuccess<TDelayHandler, TDelayHandlerProxy>(
-            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler> assertInvoke,
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, string> assertInvoke,
             Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
             Action<TDelayHandlerProxy, string, Type> addDelayObservation,
-            bool passResultHandler = true)
+            bool passResultHandler)
             where TDelayHandler      : Delegate
             where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
         {
@@ -401,7 +403,7 @@ namespace Sweetener.Reliability.Test
 
             // Invoke
             using (CancellationTokenSource tokenSource = new CancellationTokenSource())
-                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy);
+                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, "Success");
 
             // Validate the number of calls
             int x = passResultHandler ? 2 : 0;
@@ -463,7 +465,7 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, Type> assertInvoke,
             Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
             Action<TDelayHandlerProxy, string, Type> addDelayObservation,
-            bool passResultHandler = true)
+            bool passResultHandler)
             where TDelayHandler      : Delegate
             where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
         {
@@ -527,7 +529,7 @@ namespace Sweetener.Reliability.Test
 
             // Invoke
             using (CancellationTokenSource tokenSource = new CancellationTokenSource())
-                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, "Try Again");
+                assertInvoke(func.Invoke, tokenSource.Token, 3, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, "Try Again");
 
             // Validate the number of calls
             Assert.AreEqual(4, func            .Calls);
@@ -544,7 +546,7 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, Type> assertInvoke,
             Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
             Action<TDelayHandlerProxy, string, Type> addDelayObservation,
-            bool passResultHandler = true)
+            bool passResultHandler)
             where TDelayHandler      : Delegate
             where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
         {
@@ -567,7 +569,7 @@ namespace Sweetener.Reliability.Test
 
             // Invoke
             using (CancellationTokenSource tokenSource = new CancellationTokenSource())
-                assertInvoke(func.Invoke, tokenSource.Token, 42, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, typeof(IOException));
+                assertInvoke(func.Invoke, tokenSource.Token, 2, resultHandler.Invoke, exceptionHandler.Invoke, delayHandler.Proxy, typeof(IOException));
 
             // Validate the number of calls
             int x = passResultHandler ? 1 : 0;
@@ -586,7 +588,7 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, Type> assertInvoke,
             Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
             Action<TDelayHandlerProxy, string, Type> addDelayObservation,
-            bool passResultHandler = true)
+            bool passResultHandler)
             where TDelayHandler      : Delegate
             where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
         {
@@ -641,7 +643,7 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, TDelayHandler, Type> assertInvoke,
             Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
             Action<TDelayHandlerProxy, string, Type> addDelayObservation,
-            bool passResultHandler = true)
+            bool passResultHandler)
             where TDelayHandler      : Delegate
             where TDelayHandlerProxy : DelegateProxy<TDelayHandler>
         {

--- a/src/Sweetener.Reliability.Test/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Reliably.Test.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Sweetener.Reliability.Test
@@ -174,7 +175,7 @@ namespace Sweetener.Reliability.Test
         #region Invoke_Action_Canceled_Delegate
 
         private void Invoke_Action_Canceled_Delegate<TDelayHandler, TDelayHandlerProxy>(
-            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler> invoke,
+            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler, Type> assertInvoke,
             Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
             Action<TDelayHandlerProxy, Type> addDelayObservation)
             where TDelayHandler      : Delegate
@@ -207,7 +208,7 @@ namespace Sweetener.Reliability.Test
             };
 
             // Invoke, retry, and cancel
-            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(action.Invoke, tokenSource.Token, Retries.Infinite, exceptionHandler.Invoke, delayHandler.Proxy), allowedDerivedTypes: true);
+            assertInvoke(action.Invoke, tokenSource.Token, Retries.Infinite, exceptionHandler.Invoke, delayHandler.Proxy, typeof(OperationCanceledException));
 
             // Validate the number of calls
             Assert.AreEqual(2, action          .Calls);
@@ -220,7 +221,7 @@ namespace Sweetener.Reliability.Test
         #region Invoke_Action_Canceled_Delay
 
         private void Invoke_Action_Canceled_Delay<TDelayHandler, TDelayHandlerProxy>(
-            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler> invoke,
+            Action<Action, CancellationToken, int, ExceptionHandler, TDelayHandler, Type> assertInvoke,
             Func<TimeSpan, TDelayHandlerProxy> delayHandlerFactory,
             Action<TDelayHandlerProxy, Type> addDelayObservation)
             where TDelayHandler      : Delegate
@@ -248,7 +249,7 @@ namespace Sweetener.Reliability.Test
             };
 
             // Invoke, retry, and cancel
-            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(action.Invoke, tokenSource.Token, Retries.Infinite, exceptionHandler.Invoke, delayHandler.Proxy), allowedDerivedTypes: true);
+            assertInvoke(action.Invoke, tokenSource.Token, Retries.Infinite, exceptionHandler.Invoke, delayHandler.Proxy, typeof(TaskCanceledException));
 
             // Validate the number of calls
             Assert.AreEqual(2, action          .Calls);

--- a/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
+++ b/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
@@ -95,6 +95,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Expect.Arguments.tt</DependentUpon>
     </Compile>
+    <Compile Update="Func\Reliably.Async.Test.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.Async.Test.tt</DependentUpon>
+    </Compile>
     <Compile Update="Func\Reliably.Test.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -179,6 +184,10 @@
     <None Update="Func\ReliableFunc.Test.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ReliableFunc.Test.tt.out</LastGenOutput>
+    </None>
+    <None Update="Func\Reliably.Async.Test.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.Async.Test.cs</LastGenOutput>
     </None>
     <None Update="Func\Reliably.Test.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
+++ b/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
@@ -95,6 +95,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Expect.Arguments.tt</DependentUpon>
     </Compile>
+    <Compile Update="Func\Reliably.Test.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.Test.tt</DependentUpon>
+    </Compile>
     <Compile Update="Policies\Exception\ExceptionPolicy.Fail.Test.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -174,6 +179,10 @@
     <None Update="Func\ReliableFunc.Test.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ReliableFunc.Test.tt.out</LastGenOutput>
+    </None>
+    <None Update="Func\Reliably.Test.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.Test.cs</LastGenOutput>
     </None>
     <None Update="Policies\Exception\ExceptionPolicy.Fail.Test.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
+++ b/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
@@ -75,6 +75,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ReliableFunc.Test.tt</DependentUpon>
     </Compile>
+    <Compile Update="Action\Reliably.Async.Test.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.Async.Test.tt</DependentUpon>
+    </Compile>
     <Compile Update="Action\Reliably.Test.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -133,6 +138,10 @@
     <None Update="Action\ReliableAsyncAction.Test.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ReliableAsyncAction.Test.tt.out</LastGenOutput>
+    </None>
+    <None Update="Action\Reliably.Async.Test.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.Async.Test.cs</LastGenOutput>
     </None>
     <None Update="Action\Reliably.Test.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
+++ b/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
@@ -75,6 +75,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ReliableFunc.Test.tt</DependentUpon>
     </Compile>
+    <Compile Update="Action\Reliably.Test.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.Test.tt</DependentUpon>
+    </Compile>
     <Compile Update="Expectations\Arguments.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -128,6 +133,10 @@
     <None Update="Action\ReliableAsyncAction.Test.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ReliableAsyncAction.Test.tt.out</LastGenOutput>
+    </None>
+    <None Update="Action\Reliably.Test.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.Test.cs</LastGenOutput>
     </None>
     <None Update="Expectations\Arguments.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
+++ b/src/Sweetener.Reliability.Test/Sweetener.Reliability.Test.csproj
@@ -75,15 +75,15 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ReliableFunc.Test.tt</DependentUpon>
     </Compile>
-    <Compile Update="Action\Reliably.Async.Test.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Reliably.Async.Test.tt</DependentUpon>
-    </Compile>
     <Compile Update="Action\Reliably.Test.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Reliably.Test.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Action\Reliably.Async.Test.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.Async.Test.tt</DependentUpon>
     </Compile>
     <Compile Update="Expectations\Arguments.cs">
       <DesignTime>True</DesignTime>
@@ -95,15 +95,15 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Expect.Arguments.tt</DependentUpon>
     </Compile>
-    <Compile Update="Func\Reliably.Async.Test.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Reliably.Async.Test.tt</DependentUpon>
-    </Compile>
     <Compile Update="Func\Reliably.Test.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Reliably.Test.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Func\Reliably.Async.Test.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.Async.Test.tt</DependentUpon>
     </Compile>
     <Compile Update="Policies\Exception\ExceptionPolicy.Fail.Test.cs">
       <DesignTime>True</DesignTime>
@@ -149,13 +149,13 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ReliableAsyncAction.Test.tt.out</LastGenOutput>
     </None>
-    <None Update="Action\Reliably.Async.Test.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>Reliably.Async.Test.cs</LastGenOutput>
-    </None>
     <None Update="Action\Reliably.Test.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Reliably.Test.cs</LastGenOutput>
+    </None>
+    <None Update="Action\Reliably.Async.Test.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.Async.Test.cs</LastGenOutput>
     </None>
     <None Update="Expectations\Arguments.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
@@ -185,13 +185,13 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ReliableFunc.Test.tt.out</LastGenOutput>
     </None>
-    <None Update="Func\Reliably.Async.Test.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>Reliably.Async.Test.cs</LastGenOutput>
-    </None>
     <None Update="Func\Reliably.Test.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Reliably.Test.cs</LastGenOutput>
+    </None>
+    <None Update="Func\Reliably.Async.Test.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.Async.Test.cs</LastGenOutput>
     </None>
     <None Update="Policies\Exception\ExceptionPolicy.Fail.Test.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/Sweetener.Reliability/Action/Reliably.Async.cs
+++ b/src/Sweetener.Reliability/Action/Reliably.Async.cs
@@ -136,6 +136,7 @@ namespace Sweetener.Reliability
         /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -148,13 +149,14 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static Task InvokeAsync<T>(Func<T, Task> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static Task InvokeAsync<TState>(Func<TState, Task> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => InvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -167,13 +169,14 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static Task InvokeAsync<T>(Func<T, Task> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static Task InvokeAsync<TState>(Func<TState, Task> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
             => InvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
 
         /// <summary>
         /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -191,13 +194,14 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static Task InvokeAsync<T>(Func<T, Task> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static Task InvokeAsync<TState>(Func<TState, Task> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => InvokeAsync(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -215,7 +219,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static async Task InvokeAsync<T>(Func<T, Task> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static async Task InvokeAsync<TState>(Func<TState, Task> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
@@ -401,6 +405,7 @@ namespace Sweetener.Reliability
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -416,12 +421,13 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static Task<bool> TryInvokeAsync<T>(Func<T, Task> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static Task<bool> TryInvokeAsync<TState>(Func<TState, Task> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => TryInvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -437,12 +443,13 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static Task<bool> TryInvokeAsync<T>(Func<T, Task> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static Task<bool> TryInvokeAsync<TState>(Func<TState, Task> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
             => TryInvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
 
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -464,12 +471,13 @@ namespace Sweetener.Reliability
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static Task<bool> TryInvokeAsync<T>(Func<T, Task> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static Task<bool> TryInvokeAsync<TState>(Func<TState, Task> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => TryInvokeAsync(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -491,7 +499,7 @@ namespace Sweetener.Reliability
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static async Task<bool> TryInvokeAsync<T>(Func<T, Task> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static async Task<bool> TryInvokeAsync<TState>(Func<TState, Task> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
             if (action == null)
                 throw new ArgumentNullException(nameof(action));

--- a/src/Sweetener.Reliability/Action/Reliably.Async.cs
+++ b/src/Sweetener.Reliability/Action/Reliably.Async.cs
@@ -1,0 +1,544 @@
+﻿// Generated from Reliably.Async.tt
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sweetener.Reliability
+{
+    static partial class Reliably
+    {
+        #region InvokeAsync
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task InvokeAsync(Func<Task> action, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task InvokeAsync(Func<Task> action, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => InvokeAsync(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task InvokeAsync(Func<Task> action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(action, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task InvokeAsync(Func<Task> action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            Task? t = null;
+            attempt++;
+
+            try
+            {
+                t = action();
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+                return;
+            }
+            catch (Exception e)
+            {
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+        }
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task InvokeAsync<T>(Func<T, Task> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task InvokeAsync<T>(Func<T, Task> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => InvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task InvokeAsync<T>(Func<T, Task> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task InvokeAsync<T>(Func<T, Task> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            Task? t = null;
+            attempt++;
+
+            try
+            {
+                t = action(state);
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+                return;
+            }
+            catch (Exception e)
+            {
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+        }
+
+        #endregion
+
+        #region TryInvokeAsync
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<bool> TryInvokeAsync(Func<Task> action, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<bool> TryInvokeAsync(Func<Task> action, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => TryInvokeAsync(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<bool> TryInvokeAsync(Func<Task> action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(action, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<bool> TryInvokeAsync(Func<Task> action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            Task? t;
+            int attempt = 0;
+
+        Attempt:
+            t = null;
+            attempt++;
+
+            try
+            {
+                t = action();
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception e)
+            {
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled)
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    return false;
+
+                await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+        }
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<bool> TryInvokeAsync<T>(Func<T, Task> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<bool> TryInvokeAsync<T>(Func<T, Task> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => TryInvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<bool> TryInvokeAsync<T>(Func<T, Task> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<bool> TryInvokeAsync<T>(Func<T, Task> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            Task? t;
+            int attempt = 0;
+
+        Attempt:
+            t = null;
+            attempt++;
+
+            try
+            {
+                t = action(state);
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception e)
+            {
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled)
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    return false;
+
+                await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+        }
+
+        #endregion
+    }
+}
+

--- a/src/Sweetener.Reliability/Action/Reliably.Async.tt
+++ b/src/Sweetener.Reliability/Action/Reliably.Async.tt
@@ -1,0 +1,4 @@
+﻿<#
+    bool async = true;
+#>
+<#@ include file="TextTemplating\Reliably.t4" #>

--- a/src/Sweetener.Reliability/Action/Reliably.cs
+++ b/src/Sweetener.Reliability/Action/Reliably.cs
@@ -124,6 +124,7 @@ namespace Sweetener.Reliability
         /// Invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -135,13 +136,14 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static void Invoke<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static void Invoke<TState>(Action<TState> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => Invoke(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -153,13 +155,14 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static void Invoke<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static void Invoke<TState>(Action<TState> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
             => Invoke(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
 
         /// <summary>
         /// Invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -177,13 +180,14 @@ namespace Sweetener.Reliability
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static void Invoke<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static void Invoke<TState>(Action<TState> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => Invoke(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -201,7 +205,7 @@ namespace Sweetener.Reliability
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static void Invoke<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static void Invoke<TState>(Action<TState> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
@@ -354,6 +358,7 @@ namespace Sweetener.Reliability
         /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -366,13 +371,14 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static Task InvokeAsync<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static Task InvokeAsync<TState>(Action<TState> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => InvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -385,13 +391,14 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static Task InvokeAsync<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static Task InvokeAsync<TState>(Action<TState> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
             => InvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
 
         /// <summary>
         /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -409,13 +416,14 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static Task InvokeAsync<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static Task InvokeAsync<TState>(Action<TState> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => InvokeAsync(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
         /// using the provided execution policies.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -433,7 +441,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static async Task InvokeAsync<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static async Task InvokeAsync<TState>(Action<TState> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
@@ -599,6 +607,7 @@ namespace Sweetener.Reliability
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -614,12 +623,13 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static bool TryInvoke<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static bool TryInvoke<TState>(Action<TState> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => TryInvoke(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -635,12 +645,13 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static bool TryInvoke<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static bool TryInvoke<TState>(Action<TState> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
             => TryInvoke(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
 
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -662,12 +673,13 @@ namespace Sweetener.Reliability
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static bool TryInvoke<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static bool TryInvoke<TState>(Action<TState> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => TryInvoke(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -689,7 +701,7 @@ namespace Sweetener.Reliability
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static bool TryInvoke<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static bool TryInvoke<TState>(Action<TState> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
@@ -859,6 +871,7 @@ namespace Sweetener.Reliability
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -874,12 +887,13 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static Task<bool> TryInvokeAsync<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static Task<bool> TryInvokeAsync<TState>(Action<TState> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => TryInvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
@@ -895,12 +909,13 @@ namespace Sweetener.Reliability
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
         /// </exception>
-        public static Task<bool> TryInvokeAsync<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static Task<bool> TryInvokeAsync<TState>(Action<TState> action, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
             => TryInvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
 
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -922,12 +937,13 @@ namespace Sweetener.Reliability
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static Task<bool> TryInvokeAsync<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+        public static Task<bool> TryInvokeAsync<TState>(Action<TState> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
             => TryInvokeAsync(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
 
         /// <summary>
         /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
         /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="action"/>.</typeparam>
         /// <param name="action">The action to reliably invoke.</param>
         /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
@@ -949,7 +965,7 @@ namespace Sweetener.Reliability
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
-        public static async Task<bool> TryInvokeAsync<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        public static async Task<bool> TryInvokeAsync<TState>(Action<TState> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
             if (action == null)
                 throw new ArgumentNullException(nameof(action));

--- a/src/Sweetener.Reliability/Action/Reliably.cs
+++ b/src/Sweetener.Reliability/Action/Reliably.cs
@@ -1,0 +1,992 @@
+﻿// Generated from Reliably.tt
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sweetener.Reliability
+{
+    static partial class Reliably
+    {
+        #region Invoke
+
+        /// <summary>
+        /// Invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static void Invoke(Action action, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static void Invoke(Action action, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => Invoke(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static void Invoke(Action action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(action, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static void Invoke(Action action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                action();
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+        }
+
+        /// <summary>
+        /// Invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static void Invoke<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static void Invoke<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => Invoke(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static void Invoke<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static void Invoke<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                action(state);
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+        }
+
+        #endregion
+
+        #region InvokeAsync
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task InvokeAsync(Action action, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task InvokeAsync(Action action, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => InvokeAsync(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task InvokeAsync(Action action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(action, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task InvokeAsync(Action action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                action();
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task InvokeAsync<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task InvokeAsync<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => InvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task InvokeAsync<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="action" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>A task that represents the asynchronous invoke operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task InvokeAsync<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                action(state);
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+        }
+
+        #endregion
+
+        #region TryInvoke
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke(Action action, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvoke(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke(Action action, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => TryInvoke(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke(Action action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvoke(action, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke(Action action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                action();
+                return true;
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken))
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    return false;
+
+                Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvoke(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => TryInvoke(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvoke(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                action(state);
+                return true;
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken))
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    return false;
+
+                Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+        }
+
+        #endregion
+
+        #region TryInvokeAsync
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<bool> TryInvokeAsync(Action action, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<bool> TryInvokeAsync(Action action, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => TryInvokeAsync(action, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<bool> TryInvokeAsync(Action action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(action, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<bool> TryInvokeAsync(Action action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                action();
+                return true;
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken))
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    return false;
+
+                await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<bool> TryInvokeAsync<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<bool> TryInvokeAsync<T>(Action<T> action, T state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => TryInvokeAsync(action, state, CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<bool> TryInvokeAsync<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(action, state, cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="action" /> despite transient problems.
+        /// </summary>
+        /// <param name="action">The action to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="action" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="action" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="action" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="action" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<bool> TryInvokeAsync<T>(Action<T> action, T state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                action(state);
+                return true;
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken))
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    return false;
+
+                await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+        }
+
+        #endregion
+    }
+}
+

--- a/src/Sweetener.Reliability/Action/Reliably.tt
+++ b/src/Sweetener.Reliability/Action/Reliably.tt
@@ -1,0 +1,4 @@
+﻿<#
+    bool async = false;
+#>
+<#@ include file="TextTemplating\Reliably.t4" #>

--- a/src/Sweetener.Reliability/Action/TextTemplating/Reliably.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/Reliably.t4
@@ -1,0 +1,419 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System" #>
+<#@ include file="$(MSBuildProjectDirectory)\TextTemplating\Include.t4" #>// Generated from <#= GetTemplateFileName() #>
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sweetener.Reliability
+{
+    static partial class Reliably
+    {
+<#
+    string cancellationCheck = async ? "isCanceled" : "e.IsCancellation(cancellationToken)";
+
+    if (!async)
+    {
+#>
+        #region Invoke
+<#
+        foreach (bool stateful in new bool[2] { false, true })
+        {
+            string inputActionType    = stateful ? "Action<T>" : "Action";
+            string optionalStateParam = stateful ? "T state, " : string.Empty;
+            string optionalStateArg   = stateful ? "state, "   : string.Empty;
+            string optionalTypeParam  = stateful ? "<T>"       : string.Empty;
+#>
+
+<#
+            PrintReliablyInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false);
+#>
+        public static void Invoke<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(action, <#= optionalStateArg #>CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+<#
+            PrintReliablyInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false);
+#>
+        public static void Invoke<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => Invoke(action, <#= optionalStateArg #>CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+<#
+            PrintReliablyInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static void Invoke<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(action, <#= optionalStateArg #>cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+<#
+            PrintReliablyInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static void Invoke<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                action(<#= stateful ? "state" : string.Empty #>);
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+        }
+<#
+        }
+#>
+
+        #endregion
+
+<#
+    }
+#>
+        #region InvokeAsync
+
+<#
+    foreach (bool stateful in new bool[2] { false, true })
+    {
+        string inputActionType    = async ? (stateful ? "Func<T, Task>" : "Func<Task>") : (stateful ? "Action<T>" : "Action");
+
+        string optionalStateParam = stateful ? "T state, " : string.Empty;
+        string optionalStateArg   = stateful ? "state, "   : string.Empty;
+        string optionalTypeParam  = stateful ? "<T>"       : string.Empty;
+
+        PrintReliablyInvokeActionXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false);
+#>
+        public static Task InvokeAsync<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(action, <#= optionalStateArg #>CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+<#
+        PrintReliablyInvokeActionXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false);
+#>
+        public static Task InvokeAsync<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => InvokeAsync(action, <#= optionalStateArg #>CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+<#
+        PrintReliablyInvokeActionXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task InvokeAsync<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(action, <#= optionalStateArg #>cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+<#
+        PrintReliablyInvokeActionXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task InvokeAsync<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+<#
+        if (async)
+        {
+#>
+            Task? t = null;
+<#
+        }
+#>
+            attempt++;
+
+            try
+            {
+<#
+        if (async)
+        {
+#>
+                t = action(<#= stateful ? "state" : string.Empty #>);
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+                return;
+<#
+        }
+        else
+        {
+#>
+                action(<#= stateful ? "state" : string.Empty #>);
+<#
+        }
+#>
+            }
+            catch (Exception e)
+            {
+<#
+        if (async)
+        {
+#>
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+<#
+        }
+#>
+                if (<#= cancellationCheck #> || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+<#
+        if (async)
+        {
+#>
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+<#
+        }
+#>
+        }
+
+<#
+    }
+#>
+        #endregion
+
+<#
+    if (!async)
+    {
+#>
+        #region TryInvoke
+<#
+        foreach (bool stateful in new bool[2] { false, true })
+        {
+            string inputActionType    = stateful ? "Action<T>" : "Action";
+            string optionalStateParam = stateful ? "T state, " : string.Empty;
+            string optionalStateArg   = stateful ? "state, "   : string.Empty;
+            string optionalTypeParam  = stateful ? "<T>"       : string.Empty;
+#>
+
+<#
+            PrintReliablyTryInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false);
+#>
+        public static bool TryInvoke<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvoke(action, <#= optionalStateArg #>CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+<#
+            PrintReliablyTryInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false);
+#>
+        public static bool TryInvoke<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => TryInvoke(action, <#= optionalStateArg #>CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+<#
+            PrintReliablyTryInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvoke(action, <#= optionalStateArg #>cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+<#
+            PrintReliablyTryInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                action(<#= stateful ? "state" : string.Empty #>);
+                return true;
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken))
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    return false;
+
+                Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+        }
+<#
+        }
+#>
+
+        #endregion
+
+<#
+    }
+#>
+        #region TryInvokeAsync
+<#
+    foreach (bool stateful in new bool[2] { false, true })
+    {
+        string inputActionType    = async ? (stateful ? "Func<T, Task>" : "Func<Task>") : (stateful ? "Action<T>" : "Action");
+
+        string optionalStateParam = stateful ? "T state, " : string.Empty;
+        string optionalStateArg   = stateful ? "state, "   : string.Empty;
+        string optionalTypeParam  = stateful ? "<T>"       : string.Empty;
+#>
+
+<#
+        PrintReliablyTryInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false);
+#>
+        public static Task<bool> TryInvokeAsync<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(action, <#= optionalStateArg #>CancellationToken.None, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+<#
+        PrintReliablyTryInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false);
+#>
+        public static Task<bool> TryInvokeAsync<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+            => TryInvokeAsync(action, <#= optionalStateArg #>CancellationToken.None, maxRetries, exceptionHandler, delayHandler);
+
+<#
+        PrintReliablyTryInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<bool> TryInvokeAsync<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(action, <#= optionalStateArg #>cancellationToken, maxRetries, exceptionHandler, delayHandler.ToComplex());
+
+<#
+        PrintReliablyTryInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<bool> TryInvokeAsync<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+<#
+        if (async)
+        {
+#>
+            Task? t;
+<#
+        }
+#>
+            int attempt = 0;
+
+        Attempt:
+<#
+        if (async)
+        {
+#>
+            t = null;
+<#
+        }
+#>
+            attempt++;
+
+            try
+            {
+<#
+        if (async)
+        {
+#>
+                t = action(<#= stateful ? "state" : string.Empty #>);
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+<#
+        }
+        else
+        {
+#>
+                action(<#= stateful ? "state" : string.Empty #>);
+<#
+        }
+#>
+                return true;
+            }
+            catch (Exception e)
+            {
+<#
+        if (async)
+        {
+#>
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+<#
+        }
+#>
+                if (<#= cancellationCheck #>)
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    return false;
+
+                await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+<#
+        if (async)
+        {
+#>
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+<#
+        }
+#>
+        }
+<#
+    }
+#>
+
+        #endregion
+    }
+}

--- a/src/Sweetener.Reliability/Action/TextTemplating/Reliably.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/Reliably.t4
@@ -22,10 +22,10 @@ namespace Sweetener.Reliability
 <#
         foreach (bool stateful in new bool[2] { false, true })
         {
-            string inputActionType    = stateful ? "Action<T>" : "Action";
-            string optionalStateParam = stateful ? "T state, " : string.Empty;
-            string optionalStateArg   = stateful ? "state, "   : string.Empty;
-            string optionalTypeParam  = stateful ? "<T>"       : string.Empty;
+            string inputActionType    = stateful ? "Action<TState>" : "Action";
+            string optionalStateParam = stateful ? "TState state, " : string.Empty;
+            string optionalStateArg   = stateful ? "state, "        : string.Empty;
+            string optionalTypeParam  = stateful ? "<TState>"       : string.Empty;
 #>
 
 <#
@@ -97,11 +97,11 @@ namespace Sweetener.Reliability
 <#
     foreach (bool stateful in new bool[2] { false, true })
     {
-        string inputActionType    = async ? (stateful ? "Func<T, Task>" : "Func<Task>") : (stateful ? "Action<T>" : "Action");
+        string inputActionType    = async ? (stateful ? "Func<TState, Task>" : "Func<Task>") : (stateful ? "Action<TState>" : "Action");
 
-        string optionalStateParam = stateful ? "T state, " : string.Empty;
-        string optionalStateArg   = stateful ? "state, "   : string.Empty;
-        string optionalTypeParam  = stateful ? "<T>"       : string.Empty;
+        string optionalStateParam = stateful ? "TState state, " : string.Empty;
+        string optionalStateArg   = stateful ? "state, "        : string.Empty;
+        string optionalTypeParam  = stateful ? "<TState>"       : string.Empty;
 
         PrintReliablyInvokeActionXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false);
 #>
@@ -215,10 +215,10 @@ namespace Sweetener.Reliability
 <#
         foreach (bool stateful in new bool[2] { false, true })
         {
-            string inputActionType    = stateful ? "Action<T>" : "Action";
-            string optionalStateParam = stateful ? "T state, " : string.Empty;
-            string optionalStateArg   = stateful ? "state, "   : string.Empty;
-            string optionalTypeParam  = stateful ? "<T>"       : string.Empty;
+            string inputActionType    = stateful ? "Action<TState>" : "Action";
+            string optionalStateParam = stateful ? "TState state, " : string.Empty;
+            string optionalStateArg   = stateful ? "state, "        : string.Empty;
+            string optionalTypeParam  = stateful ? "<TState>"       : string.Empty;
 #>
 
 <#
@@ -293,11 +293,11 @@ namespace Sweetener.Reliability
 <#
     foreach (bool stateful in new bool[2] { false, true })
     {
-        string inputActionType    = async ? (stateful ? "Func<T, Task>" : "Func<Task>") : (stateful ? "Action<T>" : "Action");
+        string inputActionType    = async ? (stateful ? "Func<TState, Task>" : "Func<Task>") : (stateful ? "Action<TState>" : "Action");
 
-        string optionalStateParam = stateful ? "T state, " : string.Empty;
-        string optionalStateArg   = stateful ? "state, "   : string.Empty;
-        string optionalTypeParam  = stateful ? "<T>"       : string.Empty;
+        string optionalStateParam = stateful ? "TState state, " : string.Empty;
+        string optionalStateArg   = stateful ? "state, "        : string.Empty;
+        string optionalTypeParam  = stateful ? "<TState>"       : string.Empty;
 #>
 
 <#

--- a/src/Sweetener.Reliability/Func/Reliably.Async.cs
+++ b/src/Sweetener.Reliability/Func/Reliably.Async.cs
@@ -1,0 +1,1082 @@
+﻿// Generated from Reliably.Async.tt
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sweetener.Reliability
+{
+    static partial class Reliably
+    {
+        #region InvokeAsync
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> func, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> func, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            Task<TResult>? t;
+            int attempt = 0;
+
+        Attempt:
+            t = null;
+            attempt++;
+
+            try
+            {
+                t = func();
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+            TResult result = t.Result;
+            ResultKind kind = resultHandler(result);
+            if (kind != ResultKind.Transient || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                return result;
+
+            await Task.Delay(delayHandler(attempt, result, default), cancellationToken).ConfigureAwait(false);
+            goto Attempt;
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+        }
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, state, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<TResult> InvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            Task<TResult>? t;
+            int attempt = 0;
+
+        Attempt:
+            t = null;
+            attempt++;
+
+            try
+            {
+                t = func(state);
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+            TResult result = t.Result;
+            ResultKind kind = resultHandler(result);
+            if (kind != ResultKind.Transient || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                return result;
+
+            await Task.Delay(delayHandler(attempt, result, default), cancellationToken).ConfigureAwait(false);
+            goto Attempt;
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+        }
+
+        #endregion
+
+        #region TryInvokeAsync
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<Task<TResult>> func, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<Task<TResult>> func, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<Task<TResult>> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<Task<TResult>> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<Task<TResult>> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<Task<TResult>> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<Task<TResult>> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<Task<TResult>> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            Task<TResult>? t;
+            int attempt = 0;
+
+        Attempt:
+            t = null;
+            attempt++;
+
+            try
+            {
+                t = func();
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled)
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    goto Fail;
+
+                await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+            TResult result = t.Result;
+            switch (resultHandler(result))
+            {
+                case ResultKind.Successful:
+                    return result;
+                case ResultKind.Fatal:
+                    goto Fail;
+                default:
+                    if (maxRetries != Retries.Infinite && attempt > maxRetries)
+                        goto Fail;
+
+                    Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+                    goto Attempt;
+            }
+
+        Fail:
+            return Optional<TResult>.Undefined;
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+        }
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, state, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            Task<TResult>? t;
+            int attempt = 0;
+
+        Attempt:
+            t = null;
+            attempt++;
+
+            try
+            {
+                t = func(state);
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                if (isCanceled)
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    goto Fail;
+
+                await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+            TResult result = t.Result;
+            switch (resultHandler(result))
+            {
+                case ResultKind.Successful:
+                    return result;
+                case ResultKind.Fatal:
+                    goto Fail;
+                default:
+                    if (maxRetries != Retries.Infinite && attempt > maxRetries)
+                        goto Fail;
+
+                    Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+                    goto Attempt;
+            }
+
+        Fail:
+            return Optional<TResult>.Undefined;
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+        }
+
+        #endregion
+    }
+}
+

--- a/src/Sweetener.Reliability/Func/Reliably.Async.tt
+++ b/src/Sweetener.Reliability/Func/Reliably.Async.tt
@@ -1,0 +1,4 @@
+﻿<#
+    bool async = true;
+#>
+<#@ include file="TextTemplating\Reliably.t4" #>

--- a/src/Sweetener.Reliability/Func/Reliably.cs
+++ b/src/Sweetener.Reliability/Func/Reliably.cs
@@ -1,0 +1,2104 @@
+﻿// Generated from Reliably.tt
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sweetener.Reliability
+{
+    static partial class Reliably
+    {
+        #region Invoke
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static TResult Invoke<TResult>(Func<TResult> func, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static TResult Invoke<TResult>(Func<TResult> func, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => Invoke(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static TResult Invoke<TResult>(Func<TResult> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static TResult Invoke<TResult>(Func<TResult> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => Invoke(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => Invoke(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            TResult result;
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                result = func();
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+
+            ResultKind kind = resultHandler(result);
+            if (kind != ResultKind.Transient || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                return result;
+
+            Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+            goto Attempt;
+        }
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static TResult Invoke<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static TResult Invoke<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => Invoke(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static TResult Invoke<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static TResult Invoke<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => Invoke(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => Invoke(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, state, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>The return value of the <paramref name="func" />.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            TResult result;
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                result = func(state);
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+
+            ResultKind kind = resultHandler(result);
+            if (kind != ResultKind.Transient || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                return result;
+
+            Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+            goto Attempt;
+        }
+
+        #endregion
+
+        #region InvokeAsync
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TResult>(Func<TResult> func, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TResult>(Func<TResult> func, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TResult>(Func<TResult> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TResult>(Func<TResult> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<TResult> InvokeAsync<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            TResult result;
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                result = func();
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+            ResultKind kind = resultHandler(result);
+            if (kind != ResultKind.Transient || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                return result;
+
+            await Task.Delay(delayHandler(attempt, result, default), cancellationToken).ConfigureAwait(false);
+            goto Attempt;
+        }
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, state, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously invokes the given <paramref name="func" /> despite transient problems
+        /// using the provided execution policies.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter contains the return value of the <paramref name="func" />
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<TResult> InvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            TResult result;
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                result = func(state);
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+            ResultKind kind = resultHandler(result);
+            if (kind != ResultKind.Transient || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                return result;
+
+            await Task.Delay(delayHandler(attempt, result, default), cancellationToken).ConfigureAwait(false);
+            goto Attempt;
+        }
+
+        #endregion
+
+        #region TryInvoke
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke<TResult>(Func<TResult> func, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke<TResult>(Func<TResult> func, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+            => TryInvoke(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler, out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke<TResult>(Func<TResult> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke<TResult>(Func<TResult> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+            => TryInvoke(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler, out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+            => TryInvoke(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler, out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                result = func();
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken))
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    goto Fail;
+
+                Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+
+            switch (resultHandler(result))
+            {
+                case ResultKind.Successful:
+                    return true;
+                case ResultKind.Fatal:
+                    goto Fail;
+                default:
+                    if (maxRetries != Retries.Infinite && attempt > maxRetries)
+                        goto Fail;
+
+                    Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+                    goto Attempt;
+            }
+
+        Fail:
+            result = default!;
+            return false;
+        }
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+            => TryInvoke(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler, out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static bool TryInvoke<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+            => TryInvoke(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler, out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+            => TryInvoke(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler, out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, state, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+        /// <summary>
+        /// Attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <param name="result">
+        /// When this method returns, contains the result of the <paramref name="func" />,
+        /// if it completed successfully, or the default value if it failed. The parameter
+        /// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="func" /> was invoked sucessfully;
+        /// otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                result = func(state);
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken))
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    goto Fail;
+
+                Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+
+            switch (resultHandler(result))
+            {
+                case ResultKind.Successful:
+                    return true;
+                case ResultKind.Fatal:
+                    goto Fail;
+                default:
+                    if (maxRetries != Retries.Infinite && attempt > maxRetries)
+                        goto Fail;
+
+                    Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+                    goto Attempt;
+            }
+
+        Fail:
+            result = default!;
+            return false;
+        }
+
+        #endregion
+
+        #region TryInvokeAsync
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<TResult> func, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<TResult> func, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<TResult> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<TResult> func, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            TResult result;
+            attempt++;
+
+            try
+            {
+                result = func();
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken))
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    goto Fail;
+
+                await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+            switch (resultHandler(result))
+            {
+                case ResultKind.Successful:
+                    return result;
+                case ResultKind.Fatal:
+                    goto Fail;
+                default:
+                    if (maxRetries != Retries.Infinite && attempt > maxRetries)
+                        goto Fail;
+
+                    Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+                    goto Attempt;
+            }
+
+        Fail:
+            return Optional<TResult>.Undefined;
+        }
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, state, CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, state, CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, state, cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, state, cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+        /// <summary>
+        /// Asynchronously attempts to successfully invoke the <paramref name="func" /> despite transient problems.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state object passed to the <paramref name="func"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the result produced by the <paramref name="func"/>.</typeparam>
+        /// <param name="func">The func to reliably invoke.</param>
+        /// <param name="state">An object containing data to be used by the <paramref name="func" /> delegate.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="func" /> was canceled.</param>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="resultHandler">A function that determines which results are valid.</param>
+        /// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+        /// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+        /// <returns>
+        /// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+        /// parameter optionally contains the return value of the <paramref name="func" />.
+        /// if the delegate was invoked successfully.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="func" />, <paramref name="resultHandler" /> <paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+        /// </exception>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            TResult result;
+            attempt++;
+
+            try
+            {
+                result = func(state);
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken))
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    goto Fail;
+
+                await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+            switch (resultHandler(result))
+            {
+                case ResultKind.Successful:
+                    return result;
+                case ResultKind.Fatal:
+                    goto Fail;
+                default:
+                    if (maxRetries != Retries.Infinite && attempt > maxRetries)
+                        goto Fail;
+
+                    Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+                    goto Attempt;
+            }
+
+        Fail:
+            return Optional<TResult>.Undefined;
+        }
+
+        #endregion
+    }
+}
+

--- a/src/Sweetener.Reliability/Func/Reliably.tt
+++ b/src/Sweetener.Reliability/Func/Reliably.tt
@@ -1,0 +1,4 @@
+﻿<#
+    bool async = false;
+#>
+<#@ include file="TextTemplating\Reliably.t4" #>

--- a/src/Sweetener.Reliability/Func/TextTemplating/Reliably.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/Reliably.t4
@@ -1,0 +1,601 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System" #>
+<#@ include file="$(MSBuildProjectDirectory)\TextTemplating\Include.t4" #>// Generated from <#= GetTemplateFileName() #>
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sweetener.Reliability
+{
+    static partial class Reliably
+    {
+<#
+    string resultType        = async ? "Task<TResult>" : "TResult";
+    string cancellationCheck = async ? "isCanceled"    : "e.IsCancellation(cancellationToken)";
+
+    if (!async)
+    {
+#>
+        #region Invoke
+<#
+        foreach (bool stateful in new bool[2] { false, true })
+        {
+            string typeParam          = stateful ? "<TState, TResult>" : "<TResult>";
+            string optionalStateParam = stateful ? "TState state, "    : string.Empty;
+            string optionalStateArg   = stateful ? "state, "           : string.Empty;
+#>
+
+<#
+            PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false, hasResultHandler: false);
+#>
+        public static TResult Invoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+            PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false, hasResultHandler: false);
+#>
+        public static TResult Invoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => Invoke(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+<#
+            PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false, hasResultHandler: true);
+#>
+        public static TResult Invoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+            PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false, hasResultHandler: true);
+#>
+        public static TResult Invoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => Invoke(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+<#
+            PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true, hasResultHandler: false);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, <#= optionalStateArg #>cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+            PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true, hasResultHandler: false);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => Invoke(func, <#= optionalStateArg #>cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+<#
+            PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true, hasResultHandler: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => Invoke(func, <#= optionalStateArg #>cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+            PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true, hasResultHandler: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static TResult Invoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            TResult result;
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                result = func(<#= stateful ? "state" : string.Empty #>);
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+
+            ResultKind kind = resultHandler(result);
+            if (kind != ResultKind.Transient || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                return result;
+
+            Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+            goto Attempt;
+        }
+<#
+        }
+#>
+
+        #endregion
+
+<#
+    }
+#>
+        #region InvokeAsync
+
+<#
+    foreach (bool stateful in new bool[2] { false, true })
+    {
+        string typeParam          = stateful ? "<TState, TResult>"       : "<TResult>";
+        string funcTypeParam      = stateful ? $"<TState, {resultType}>" : $"<{resultType}>";
+        string optionalStateParam = stateful ? "TState state, "          : string.Empty;
+        string optionalStateArg   = stateful ? "state, "                 : string.Empty;
+
+        PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false, hasResultHandler: false);
+#>
+        public static Task<TResult> InvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+        PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false, hasResultHandler: false);
+#>
+        public static Task<TResult> InvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+<#
+        PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false, hasResultHandler: true);
+#>
+        public static Task<TResult> InvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+        PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false, hasResultHandler: true);
+#>
+        public static Task<TResult> InvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+<#
+        PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true, hasResultHandler: false);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, <#= optionalStateArg #>cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+        PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true, hasResultHandler: false);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => InvokeAsync(func, <#= optionalStateArg #>cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+<#
+        PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true, hasResultHandler: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<TResult> InvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => InvokeAsync(func, <#= optionalStateArg #>cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+        PrintReliablyInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true, hasResultHandler: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<TResult> InvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            <#= async ? "Task<TResult>? t" : "TResult result" #>;
+            int attempt = 0;
+
+        Attempt:
+<#
+        if (async)
+        {
+#>
+            t = null;
+<#
+        }
+#>
+            attempt++;
+
+            try
+            {
+<#
+        if (async)
+        {
+#>
+                t = func(<#= stateful ? "state" : string.Empty #>);
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+<#
+        }
+        else
+        {
+#>
+                result = func(<#= stateful ? "state" : string.Empty #>);
+<#
+        }
+#>
+            }
+            catch (Exception e)
+            {
+<#
+        if (async)
+        {
+#>
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+<#
+        }
+#>
+                if (<#= cancellationCheck #> || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    throw;
+
+                await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+<#
+        if (async)
+        {
+#>
+            TResult result = t.Result;
+<#
+        }
+#>
+            ResultKind kind = resultHandler(result);
+            if (kind != ResultKind.Transient || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                return result;
+
+            await Task.Delay(delayHandler(attempt, result, default), cancellationToken).ConfigureAwait(false);
+            goto Attempt;
+<#
+        if (async)
+        {
+#>
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+<#
+        }
+#>
+        }
+
+<#
+    }
+#>
+        #endregion
+
+<#
+    if (!async)
+    {
+#>
+        #region TryInvoke
+<#
+        foreach (bool stateful in new bool[2] { false, true })
+        {
+            string typeParam          = stateful ? "<TState, TResult>" : "<TResult>";
+            string optionalStateParam = stateful ? "TState state, "    : string.Empty;
+            string optionalStateArg   = stateful ? "state, "           : string.Empty;
+#>
+
+<#
+            PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false, hasResultHandler: false);
+#>
+        public static bool TryInvoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+<#
+            PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false, hasResultHandler: false);
+#>
+        public static bool TryInvoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+            => TryInvoke(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler, out result);
+
+<#
+            PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false, hasResultHandler: true);
+#>
+        public static bool TryInvoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+<#
+            PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: false, hasResultHandler: true);
+#>
+        public static bool TryInvoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+            => TryInvoke(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler, out result);
+
+<#
+            PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true, hasResultHandler: false);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, <#= optionalStateArg #>cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+<#
+            PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true, hasResultHandler: false);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+            => TryInvoke(func, <#= optionalStateArg #>cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler, out result);
+
+<#
+            PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true, hasResultHandler: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler, out TResult result)
+            => TryInvoke(func, <#= optionalStateArg #>cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>(), out result);
+
+<#
+            PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true, hasResultHandler: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static bool TryInvoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+            int attempt = 0;
+
+        Attempt:
+            attempt++;
+
+            try
+            {
+                result = func(<#= stateful ? "state" : string.Empty #>);
+            }
+            catch (Exception e)
+            {
+                if (e.IsCancellation(cancellationToken))
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    goto Fail;
+
+                Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
+                goto Attempt;
+            }
+
+            switch (resultHandler(result))
+            {
+                case ResultKind.Successful:
+                    return true;
+                case ResultKind.Fatal:
+                    goto Fail;
+                default:
+                    if (maxRetries != Retries.Infinite && attempt > maxRetries)
+                        goto Fail;
+
+                    Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+                    goto Attempt;
+            }
+
+        Fail:
+            result = default!;
+            return false;
+        }
+<#
+        }
+#>
+
+        #endregion
+
+<#
+    }
+#>
+        #region TryInvokeAsync
+
+<#
+    foreach (bool stateful in new bool[2] { false, true })
+    {
+        string typeParam          = stateful ? "<TState, TResult>"       : "<TResult>";
+        string funcTypeParam      = stateful ? $"<TState, {resultType}>" : $"<{resultType}>";
+        string optionalStateParam = stateful ? "TState state, "          : string.Empty;
+        string optionalStateArg   = stateful ? "state, "                 : string.Empty;
+
+        PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false, hasResultHandler: false);
+#>
+        public static Task<Optional<TResult>> TryInvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+        PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false, hasResultHandler: false);
+#>
+        public static Task<Optional<TResult>> TryInvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+<#
+        PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false, hasResultHandler: true);
+#>
+        public static Task<Optional<TResult>> TryInvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+        PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: false, hasResultHandler: true);
+#>
+        public static Task<Optional<TResult>> TryInvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, <#= optionalStateArg #>CancellationToken.None, maxRetries, resultHandler, exceptionHandler, delayHandler);
+
+<#
+        PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true, hasResultHandler: false);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, <#= optionalStateArg #>cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+        PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true, hasResultHandler: false);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+            => TryInvokeAsync(func, <#= optionalStateArg #>cancellationToken, maxRetries, ResultPolicy.Default<TResult>(), exceptionHandler, delayHandler);
+
+<#
+        PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true, hasResultHandler: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static Task<Optional<TResult>> TryInvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, DelayHandler delayHandler)
+            => TryInvokeAsync(func, <#= optionalStateArg #>cancellationToken, maxRetries, resultHandler, exceptionHandler, delayHandler.ToComplex<TResult>());
+
+<#
+        PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true, hasResultHandler: true);
+#>
+        [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
+        public static async Task<Optional<TResult>> TryInvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            if (maxRetries < Retries.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(maxRetries));
+
+            if (resultHandler == null)
+                throw new ArgumentNullException(nameof(resultHandler));
+
+            if (exceptionHandler == null)
+                throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (delayHandler == null)
+                throw new ArgumentNullException(nameof(delayHandler));
+
+<#
+        if (async)
+        {
+#>
+            Task<TResult>? t;
+<#
+        }
+#>
+            int attempt = 0;
+
+        Attempt:
+<#
+        if (async)
+        {
+#>
+            t = null;
+<#
+        }
+        else
+        {
+#>
+            TResult result;
+<#
+        }
+#>
+            attempt++;
+
+            try
+            {
+<#
+        if (async)
+        {
+#>
+                t = func(<#= stateful ? "state" : string.Empty #>);
+                if (t == null)
+                    goto Invalid;
+
+                await t.ConfigureAwait(false);
+<#
+        }
+        else
+        {
+#>
+                result = func(<#= stateful ? "state" : string.Empty #>);
+<#
+        }
+#>
+            }
+            catch (Exception e)
+            {
+<#
+        if (async)
+        {
+#>
+                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+<#
+        }
+#>
+                if (<#= cancellationCheck #>)
+                    throw;
+
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    goto Fail;
+
+                await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
+                goto Attempt;
+            }
+
+<#
+        if (async)
+        {
+#>
+            TResult result = t.Result;
+<#
+        }
+#>
+            switch (resultHandler(result))
+            {
+                case ResultKind.Successful:
+                    return result;
+                case ResultKind.Fatal:
+                    goto Fail;
+                default:
+                    if (maxRetries != Retries.Infinite && attempt > maxRetries)
+                        goto Fail;
+
+                    Task.Delay(delayHandler(attempt, result, default), cancellationToken).Wait();
+                    goto Attempt;
+            }
+
+        Fail:
+            return Optional<TResult>.Undefined;
+<#
+        if (async)
+        {
+#>
+
+        Invalid:
+            throw new InvalidOperationException(SR.InvalidTaskResult);
+<#
+        }
+#>
+        }
+
+<#
+    }
+#>
+        #endregion
+    }
+}

--- a/src/Sweetener.Reliability/Reliably.cs
+++ b/src/Sweetener.Reliability/Reliably.cs
@@ -1,0 +1,16 @@
+﻿namespace Sweetener.Reliability
+{
+    /// <summary>
+    /// A collection of methods to reliablty invoke user-defined delegates.
+    /// </summary>
+    public static partial class Reliably
+    {
+        // Implemenations of Invoke, InvokeAsync, TryInvoke, and TryInvokeAsync are spread across
+        // multiple partial classes for both synchronous and asynchronous delegates
+        // See the following source files for details:
+        // - Action/Reliably.cs
+        // - Action/Reliably.Async.cs
+        // - Func/Reliably.cs
+        // - Func/Reliably.Async.cs
+    }
+}

--- a/src/Sweetener.Reliability/Sweetener.Reliability.csproj
+++ b/src/Sweetener.Reliability/Sweetener.Reliability.csproj
@@ -102,6 +102,16 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ReliableFunc.Create.tt</DependentUpon>
     </Compile>
+    <Compile Update="Func\Reliably.Async.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.Async.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Func\Reliably.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.tt</DependentUpon>
+    </Compile>
     <Compile Update="Policies\Exception\ExceptionPolicy.Fail.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -175,6 +185,14 @@
     <None Update="Func\ReliableFunc.Create.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ReliableFunc.Create.tt.out</LastGenOutput>
+    </None>
+    <None Update="Func\Reliably.Async.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.Async.cs</LastGenOutput>
+    </None>
+    <None Update="Func\Reliably.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.cs</LastGenOutput>
     </None>
     <None Update="Policies\Exception\ExceptionPolicy.Fail.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/Sweetener.Reliability/Sweetener.Reliability.csproj
+++ b/src/Sweetener.Reliability/Sweetener.Reliability.csproj
@@ -57,6 +57,16 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ReliableAsyncAction.Create.tt</DependentUpon>
     </Compile>
+    <Compile Update="Action\Reliably.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Action\Reliably.Async.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.Async.tt</DependentUpon>
+    </Compile>
     <Compile Update="Cancellation.Extensions.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -129,6 +139,14 @@
     <None Update="Action\ReliableAsyncAction.Create.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ReliableAsyncAction.Create.tt.out</LastGenOutput>
+    </None>
+    <None Update="Action\Reliably.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.cs</LastGenOutput>
+    </None>
+    <None Update="Action\Reliably.Async.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.Async.cs</LastGenOutput>
     </None>
     <None Update="Cancellation.Extensions.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/Sweetener.Reliability/Sweetener.Reliability.csproj
+++ b/src/Sweetener.Reliability/Sweetener.Reliability.csproj
@@ -102,15 +102,15 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ReliableFunc.Create.tt</DependentUpon>
     </Compile>
-    <Compile Update="Func\Reliably.Async.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Reliably.Async.tt</DependentUpon>
-    </Compile>
     <Compile Update="Func\Reliably.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Reliably.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Func\Reliably.Async.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Reliably.Async.tt</DependentUpon>
     </Compile>
     <Compile Update="Policies\Exception\ExceptionPolicy.Fail.cs">
       <DesignTime>True</DesignTime>
@@ -186,13 +186,13 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ReliableFunc.Create.tt.out</LastGenOutput>
     </None>
-    <None Update="Func\Reliably.Async.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>Reliably.Async.cs</LastGenOutput>
-    </None>
     <None Update="Func\Reliably.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Reliably.cs</LastGenOutput>
+    </None>
+    <None Update="Func\Reliably.Async.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Reliably.Async.cs</LastGenOutput>
     </None>
     <None Update="Policies\Exception\ExceptionPolicy.Fail.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/Sweetener.Reliability/TextTemplating/Include.t4
+++ b/src/Sweetener.Reliability/TextTemplating/Include.t4
@@ -91,19 +91,19 @@
 <#+
     }
 
-        public void PrintReliablyInvokeActionXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken)
-        => PrintReliablyXmlDoc(indent, isTry: false, isFunc: false, isStateful, isAsync, hasToken);
+    public void PrintReliablyInvokeActionXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken)
+        => PrintReliablyXmlDoc(indent, isTry: false, isFunc: false, isStateful, isAsync, hasToken, false);
 
-    public void PrintReliablyInvokeFuncXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken)
-        => PrintReliablyXmlDoc(indent, isTry: false, isFunc: true, isStateful, isAsync, hasToken);
+    public void PrintReliablyInvokeFuncXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken, bool hasResultHandler)
+        => PrintReliablyXmlDoc(indent, isTry: false, isFunc: true, isStateful, isAsync, hasToken, hasResultHandler);
 
     public void PrintReliablyTryInvokeActionXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken)
-        => PrintReliablyXmlDoc(indent, isTry: true, isFunc: false, isStateful, isAsync, hasToken);
+        => PrintReliablyXmlDoc(indent, isTry: true, isFunc: false, isStateful, isAsync, hasToken, false);
 
-    public void PrintReliablyTryInvokeFuncXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken)
-        => PrintReliablyXmlDoc(indent, isTry: true, isFunc: true, isStateful, isAsync, hasToken);
+    public void PrintReliablyTryInvokeFuncXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken, bool hasResultHandler)
+        => PrintReliablyXmlDoc(indent, isTry: true, isFunc: true, isStateful, isAsync, hasToken, hasResultHandler);
 
-    private void PrintReliablyXmlDoc(int indent, bool isTry, bool isFunc, bool isStateful, bool isAsync, bool hasToken)
+    private void PrintReliablyXmlDoc(int indent, bool isTry, bool isFunc, bool isStateful, bool isAsync, bool hasToken, bool hasResultHandler)
     {
         string spaces = new string(' ', indent * SpacesPerTab);
         string delegateName = isFunc ? "func" : "action";
@@ -123,6 +123,20 @@
 <#= spaces #>/// <#= isAsync ? "Asynchronously i" : "I" #>nvokes the given <paramref name="<#= delegateName #>" /> despite transient problems
 <#= spaces #>/// using the provided execution policies.
 <#= spaces #>/// </summary>
+<#+
+        }
+
+        if (isStateful)
+        {
+#>
+<#= spaces #>/// <typeparam name="TState">The type of the state object passed to the <paramref name="<#= delegateName #>"/>.</typeparam>
+<#+
+        }
+
+        if (isFunc)
+        {
+#>
+<#= spaces #>/// <typeparam name="TResult">The type of the result produced by the <paramref name="<#= delegateName #>"/>.</typeparam>
 <#+
         }
 
@@ -148,7 +162,7 @@
 <#= spaces #>/// <param name="maxRetries">The maximum number of retry attempts.</param>
 <#+
 
-        if (isFunc)
+        if (isFunc && hasResultHandler)
         {
 #>
 <#= spaces #>/// <param name="resultHandler">A function that determines which results are valid.</param>
@@ -202,7 +216,7 @@
             else
             {
 #>
-<#= spaces #>/// <returns>The return value of the <paramref name="<#= delegateName #>.</returns>
+<#= spaces #>/// <returns>The return value of the <paramref name="<#= delegateName #>" />.</returns>
 <#+
             }
         }
@@ -228,7 +242,7 @@
 
 #>
 <#= spaces #>/// <exception cref="ArgumentNullException">
-<#= spaces #>/// <paramref name="<#= delegateName #>" />, <#= isFunc ? "<paramref name=\"resultHandler\" /> " : "" #><paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+<#= spaces #>/// <paramref name="<#= delegateName #>" />, <#= isFunc && hasResultHandler ? "<paramref name=\"resultHandler\" /> " : "" #><paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
 <#= spaces #>/// </exception>
 <#= spaces #>/// <exception cref="ArgumentOutOfRangeException">
 <#= spaces #>/// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.

--- a/src/Sweetener.Reliability/TextTemplating/Include.t4
+++ b/src/Sweetener.Reliability/TextTemplating/Include.t4
@@ -90,4 +90,164 @@
 <#= spaces #>/// </exception>
 <#+
     }
+
+        public void PrintReliablyInvokeActionXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken)
+        => PrintReliablyXmlDoc(indent, isTry: false, isFunc: false, isStateful, isAsync, hasToken);
+
+    public void PrintReliablyInvokeFuncXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken)
+        => PrintReliablyXmlDoc(indent, isTry: false, isFunc: true, isStateful, isAsync, hasToken);
+
+    public void PrintReliablyTryInvokeActionXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken)
+        => PrintReliablyXmlDoc(indent, isTry: true, isFunc: false, isStateful, isAsync, hasToken);
+
+    public void PrintReliablyTryInvokeFuncXmlDoc(int indent, bool isStateful, bool isAsync, bool hasToken)
+        => PrintReliablyXmlDoc(indent, isTry: true, isFunc: true, isStateful, isAsync, hasToken);
+
+    private void PrintReliablyXmlDoc(int indent, bool isTry, bool isFunc, bool isStateful, bool isAsync, bool hasToken)
+    {
+        string spaces = new string(' ', indent * SpacesPerTab);
+        string delegateName = isFunc ? "func" : "action";
+
+        if (isTry)
+        {
+#>
+<#= spaces #>/// <summary>
+<#= spaces #>/// <#= isAsync ? "Asynchronously a" : "A" #>ttempts to successfully invoke the <paramref name="<#= delegateName #>" /> despite transient problems.
+<#= spaces #>/// </summary>
+<#+
+        }
+        else
+        {
+#>
+<#= spaces #>/// <summary>
+<#= spaces #>/// <#= isAsync ? "Asynchronously i" : "I" #>nvokes the given <paramref name="<#= delegateName #>" /> despite transient problems
+<#= spaces #>/// using the provided execution policies.
+<#= spaces #>/// </summary>
+<#+
+        }
+
+#>
+<#= spaces #>/// <param name="<#= delegateName #>">The <#= delegateName #> to reliably invoke.</param>
+<#+
+
+        if (isStateful)
+        {
+#>
+<#= spaces #>/// <param name="state">An object containing data to be used by the <paramref name="<#= delegateName #>" /> delegate.</param>
+<#+
+        }
+
+        if (hasToken)
+        {
+#>
+<#= spaces #>/// <param name="cancellationToken">The <see cref="CancellationToken" /> used to determine whether the <paramref name="<#= delegateName #>" /> was canceled.</param>
+<#+
+        }
+
+#>
+<#= spaces #>/// <param name="maxRetries">The maximum number of retry attempts.</param>
+<#+
+
+        if (isFunc)
+        {
+#>
+<#= spaces #>/// <param name="resultHandler">A function that determines which results are valid.</param>
+<#+
+        }
+
+#>
+<#= spaces #>/// <param name="exceptionHandler">A function that determines which exceptions are transient.</param>
+<#= spaces #>/// <param name="delayHandler">A function that determines how long wait to wait between attempts.</param>
+<#+
+
+        if (isTry && isFunc && !isAsync)
+        {
+#>
+<#= spaces #>/// <param name="result">
+<#= spaces #>/// When this method returns, contains the result of the <paramref name="<#= delegateName #>" />,
+<#= spaces #>/// if it completed successfully, or the default value if it failed. The parameter
+<#= spaces #>/// is passed unitialized; any value originally supplied in <paramref name="result" /> will be overwritten.
+<#= spaces #>/// </param>
+<#+
+        }
+
+        if (isTry && !isAsync)
+        {
+#>
+<#= spaces #>/// <returns>
+<#= spaces #>/// <see langword="true" /> if <paramref name="<#= delegateName #>" /> was invoked sucessfully;
+<#= spaces #>/// otherwise, <see langword="false" />.
+<#= spaces #>/// </returns>
+<#+
+        }
+        else if (isFunc)
+        {
+            if (isAsync)
+            {
+#>
+<#= spaces #>/// <returns>
+<#= spaces #>/// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+<#= spaces #>/// parameter <#= isTry ? "optionally " : string.Empty #>contains the return value of the <paramref name="<#= delegateName #>" /><#= isTry ? "." : string.Empty #>
+<#+
+                if (isTry)
+                {
+#>
+<#= spaces #>/// if the delegate was invoked successfully.
+<#+
+                }
+#>
+<#= spaces #>/// </returns>
+<#+
+            }
+            else
+            {
+#>
+<#= spaces #>/// <returns>The return value of the <paramref name="<#= delegateName #>.</returns>
+<#+
+            }
+        }
+        else if (isAsync)
+        {
+            if (isTry)
+            {
+#>
+<#= spaces #>/// <returns>
+<#= spaces #>/// A task that represents the asynchronous invoke operation. The value of the <c>TResult</c>
+<#= spaces #>/// parameter contains <see langword="true" /> if <paramref name="<#= delegateName #>" />
+<#= spaces #>/// was invoked sucessfully; otherwise, <see langword="false" />.
+<#= spaces #>/// </returns>
+<#+
+            }
+            else
+            {
+#>
+<#= spaces #>/// <returns>A task that represents the asynchronous invoke operation.</returns>
+<#+
+            }
+        }
+
+#>
+<#= spaces #>/// <exception cref="ArgumentNullException">
+<#= spaces #>/// <paramref name="<#= delegateName #>" />, <#= isFunc ? "<paramref name=\"resultHandler\" /> " : "" #><paramref name="exceptionHandler" />, or <paramref name="delayHandler" /> is <see langword="null" />.
+<#= spaces #>/// </exception>
+<#= spaces #>/// <exception cref="ArgumentOutOfRangeException">
+<#= spaces #>/// <paramref name="maxRetries" /> is a negative number other than <c>-1</c>, which represents an infinite number of retries.
+<#= spaces #>/// </exception>
+<#+
+        if (hasToken)
+        {
+#>
+<#= spaces #>/// <exception cref="ObjectDisposedException">
+<#= spaces #>/// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
+<#= spaces #>/// </exception>
+<#+
+        }
+
+        if (hasToken && !isAsync)
+        {
+#>
+<#= spaces #>/// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+<#+
+        }
+    }
 #>


### PR DESCRIPTION
- Add new static class `Reliably` that provides method for invoking delegates reliably
    - Includes methods:
        - `Invoke`
        - `InvokeAsync`
        - `TryInvoke`
        - `TryInvokeAsync`
- Begin centralizing XML doc
- Add new tests for each method