### PR TITLE
Refactor CancellationToken Usage

### DIFF
--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T1.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T1.Test.Base.cs
@@ -240,6 +240,46 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT2_Canceled
+
+        internal void WithRetryT2_Canceled<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(
+            Func<Action<CancellationToken>, TActionProxy> actionFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TAction, int, ExceptionHandler, TDelayPolicy, TAction> withRetry,
+            Action<TAction, int, CancellationToken> invoke)
+            where TAction           : Delegate
+            where TDelayPolicy      : Delegate
+            where TActionProxy      : DelegateProxy<TAction>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined action
+            TActionProxy action = actionFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable action
+            TAction reliableAction = withRetry(
+                action.Proxy,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Invoke
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT2_Canceled_Action
 
         internal void WithRetryT2_Canceled_Action<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T1.Test.cs
@@ -109,6 +109,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT2_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT2_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT2_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT2_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT2_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
@@ -143,6 +144,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT2_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT2_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT2_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT2_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT2_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T2.Test.cs
@@ -109,6 +109,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT3_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT3_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT3_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT3_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT3_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
@@ -143,6 +144,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT3_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT3_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT3_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT3_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT3_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T3.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T3.Test.Base.cs
@@ -240,6 +240,46 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT4_Canceled
+
+        internal void WithRetryT4_Canceled<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(
+            Func<Action<CancellationToken>, TActionProxy> actionFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TAction, int, ExceptionHandler, TDelayPolicy, TAction> withRetry,
+            Action<TAction, int, string, double, CancellationToken> invoke)
+            where TAction           : Delegate
+            where TDelayPolicy      : Delegate
+            where TActionProxy      : DelegateProxy<TAction>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined action
+            TActionProxy action = actionFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable action
+            TAction reliableAction = withRetry(
+                action.Proxy,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Invoke
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT4_Canceled_Action
 
         internal void WithRetryT4_Canceled_Action<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T3.Test.cs
@@ -109,6 +109,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT4_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT4_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT4_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT4_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT4_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
@@ -143,6 +144,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT4_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT4_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT4_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT4_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT4_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T4.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T4.Test.Base.cs
@@ -240,6 +240,46 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT5_Canceled
+
+        internal void WithRetryT5_Canceled<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(
+            Func<Action<CancellationToken>, TActionProxy> actionFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TAction, int, ExceptionHandler, TDelayPolicy, TAction> withRetry,
+            Action<TAction, int, string, double, long, CancellationToken> invoke)
+            where TAction           : Delegate
+            where TDelayPolicy      : Delegate
+            where TActionProxy      : DelegateProxy<TAction>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined action
+            TActionProxy action = actionFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable action
+            TAction reliableAction = withRetry(
+                action.Proxy,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Invoke
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, 1000L, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT5_Canceled_Action
 
         internal void WithRetryT5_Canceled_Action<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T4.Test.cs
@@ -109,6 +109,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT5_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT5_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT5_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT5_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT5_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
@@ -143,6 +144,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT5_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT5_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT5_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT5_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT5_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T5.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T5.Test.Base.cs
@@ -240,6 +240,46 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT6_Canceled
+
+        internal void WithRetryT6_Canceled<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(
+            Func<Action<CancellationToken>, TActionProxy> actionFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TAction, int, ExceptionHandler, TDelayPolicy, TAction> withRetry,
+            Action<TAction, int, string, double, long, ushort, CancellationToken> invoke)
+            where TAction           : Delegate
+            where TDelayPolicy      : Delegate
+            where TActionProxy      : DelegateProxy<TAction>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined action
+            TActionProxy action = actionFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable action
+            TAction reliableAction = withRetry(
+                action.Proxy,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Invoke
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, 1000L, (ushort)1, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT6_Canceled_Action
 
         internal void WithRetryT6_Canceled_Action<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T5.Test.cs
@@ -109,6 +109,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT6_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT6_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT6_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT6_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT6_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
@@ -143,6 +144,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT6_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT6_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT6_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT6_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT6_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T6.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T6.Test.Base.cs
@@ -240,6 +240,46 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT7_Canceled
+
+        internal void WithRetryT7_Canceled<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(
+            Func<Action<CancellationToken>, TActionProxy> actionFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TAction, int, ExceptionHandler, TDelayPolicy, TAction> withRetry,
+            Action<TAction, int, string, double, long, ushort, byte, CancellationToken> invoke)
+            where TAction           : Delegate
+            where TDelayPolicy      : Delegate
+            where TActionProxy      : DelegateProxy<TAction>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined action
+            TActionProxy action = actionFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable action
+            TAction reliableAction = withRetry(
+                action.Proxy,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Invoke
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT7_Canceled_Action
 
         internal void WithRetryT7_Canceled_Action<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T6.Test.cs
@@ -109,6 +109,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT7_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT7_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT7_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT7_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT7_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
@@ -143,6 +144,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT7_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT7_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT7_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT7_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT7_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T7.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T7.Test.Base.cs
@@ -240,6 +240,46 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT8_Canceled
+
+        internal void WithRetryT8_Canceled<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(
+            Func<Action<CancellationToken>, TActionProxy> actionFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TAction, int, ExceptionHandler, TDelayPolicy, TAction> withRetry,
+            Action<TAction, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke)
+            where TAction           : Delegate
+            where TDelayPolicy      : Delegate
+            where TActionProxy      : DelegateProxy<TAction>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined action
+            TActionProxy action = actionFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable action
+            TAction reliableAction = withRetry(
+                action.Proxy,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Invoke
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT8_Canceled_Action
 
         internal void WithRetryT8_Canceled_Action<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T7.Test.cs
@@ -109,6 +109,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT8_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT8_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT8_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT8_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT8_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
@@ -143,6 +144,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT8_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT8_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT8_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT8_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT8_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T8.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T8.Test.Base.cs
@@ -240,6 +240,46 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT9_Canceled
+
+        internal void WithRetryT9_Canceled<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(
+            Func<Action<CancellationToken>, TActionProxy> actionFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TAction, int, ExceptionHandler, TDelayPolicy, TAction> withRetry,
+            Action<TAction, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke)
+            where TAction           : Delegate
+            where TDelayPolicy      : Delegate
+            where TActionProxy      : DelegateProxy<TAction>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined action
+            TActionProxy action = actionFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable action
+            TAction reliableAction = withRetry(
+                action.Proxy,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Invoke
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), 112U, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT9_Canceled_Action
 
         internal void WithRetryT9_Canceled_Action<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.T8.Test.cs
@@ -109,6 +109,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT9_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT9_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT9_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT9_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT9_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
@@ -143,6 +144,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT9_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT9_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT9_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT9_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT9_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.Test.Base.cs
@@ -240,6 +240,46 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT1_Canceled
+
+        internal void WithRetryT1_Canceled<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(
+            Func<Action<CancellationToken>, TActionProxy> actionFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TAction, int, ExceptionHandler, TDelayPolicy, TAction> withRetry,
+            Action<TAction, CancellationToken> invoke)
+            where TAction           : Delegate
+            where TDelayPolicy      : Delegate
+            where TActionProxy      : DelegateProxy<TAction>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined action
+            TActionProxy action = actionFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable action
+            TAction reliableAction = withRetry(
+                action.Proxy,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Invoke
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT1_Canceled_Action
 
         internal void WithRetryT1_Canceled_Action<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.Test.Base.tt
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.Test.Base.tt
@@ -265,6 +265,46 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetry<#= suffix #>_Canceled
+
+        internal void WithRetry<#= suffix #>_Canceled<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(
+            Func<Action<CancellationToken>, TActionProxy> actionFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TAction, int, ExceptionHandler, TDelayPolicy, TAction> withRetry,
+            Action<TAction<#= optionalComma #><#= typeArguments #>, CancellationToken> invoke)
+            where TAction           : Delegate
+            where TDelayPolicy      : Delegate
+            where TActionProxy      : DelegateProxy<TAction>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined action
+            TActionProxy action = actionFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable action
+            TAction reliableAction = withRetry(
+                action.Proxy,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Invoke
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction<#= optionalComma #><#= argumentValues #>, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetry<#= suffix #>_Canceled_Action
 
         internal void WithRetry<#= suffix #>_Canceled_Action<TAction, TDelayPolicy, TActionProxy, TDelayPolicyProxy>(

--- a/src/Sweetener.Reliability.Test/Action/Action.Extensions.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Action.Extensions.Test.cs
@@ -110,6 +110,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT1_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT1_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT1_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT1_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT1_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
         }
@@ -144,6 +145,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_EventualSuccess (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT1_EventualFailure (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT1_RetriesExhausted(actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT1_Canceled        (actionFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT1_Canceled_Action (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT1_Canceled_Delay  (actionFactory, delayHandlerFactory, withRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
         }

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T1.Test.cs
@@ -125,6 +125,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT2_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT2_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT2_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT2_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT2_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
 
@@ -168,6 +169,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT2_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT2_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT2_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT2_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT2_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
 

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T2.Test.cs
@@ -125,6 +125,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT3_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT3_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT3_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT3_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT3_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
 
@@ -168,6 +169,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT3_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT3_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT3_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT3_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT3_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
 

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T3.Test.cs
@@ -125,6 +125,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT4_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT4_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT4_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT4_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT4_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
 
@@ -168,6 +169,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT4_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT4_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT4_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT4_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT4_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
 

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T4.Test.cs
@@ -125,6 +125,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT5_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT5_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT5_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT5_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT5_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
 
@@ -168,6 +169,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT5_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT5_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT5_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT5_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT5_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
 

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T5.Test.cs
@@ -125,6 +125,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT6_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT6_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT6_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT6_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT6_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
 
@@ -168,6 +169,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT6_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT6_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT6_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT6_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT6_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
 

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T6.Test.cs
@@ -125,6 +125,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT7_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT7_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT7_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT7_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT7_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
 
@@ -168,6 +169,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT7_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT7_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT7_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT7_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT7_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
 

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T7.Test.cs
@@ -125,6 +125,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT8_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT8_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT8_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT8_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT8_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
 
@@ -168,6 +169,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT8_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT8_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT8_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT8_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT8_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
 

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.T8.Test.cs
@@ -125,6 +125,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT9_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT9_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT9_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT9_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT9_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
 
@@ -168,6 +169,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT9_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT9_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT9_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT9_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT9_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
 

--- a/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/AsyncAction.Extensions.Test.cs
@@ -126,6 +126,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT1_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT1_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
+            WithRetryT1_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT1_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
             WithRetryT1_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.Asc());
 
@@ -169,6 +170,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_EventualSuccess (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT1_EventualFailure (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT1_RetriesExhausted(actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
+            WithRetryT1_Canceled        (actionFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT1_Canceled_Action (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
             WithRetryT1_Canceled_Delay  (actionFactory, delayHandlerFactory, withAsyncRetry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.ExceptionAsc(e));
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T1.Test.cs
@@ -206,6 +206,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invoke, addEventHandlers);
                     Invoke_Canceled_Action(invoke, addEventHandlers);
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
@@ -236,6 +237,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers);
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
                 }
@@ -265,6 +267,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg, t) => r.TryInvoke(arg, t), addEventHandlers);
                     Invoke_Canceled_Action((r, arg, t) => r.TryInvoke(arg, t), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg, t) => r.TryInvoke(arg, t), addEventHandlers);
                 }
@@ -294,6 +297,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg, t) => r.TryInvokeAsync(arg, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg, t) => r.TryInvokeAsync(arg, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg, t) => r.TryInvokeAsync(arg, t).Wait(), addEventHandlers);
                 }
@@ -575,6 +579,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAction<int>, int, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            ActionProxy<int, CancellationToken> action = new ActionProxy<int, CancellationToken>(
+                (arg, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAction
+            ReliableAction<int> reliableAction = new ReliableAction<int>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAction.Retrying         += retryHandler    .Invoke;
+                reliableAction.Failed           += failedHandler   .Invoke;
+                reliableAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T2.Test.cs
@@ -206,6 +206,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invoke, addEventHandlers);
                     Invoke_Canceled_Action(invoke, addEventHandlers);
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
@@ -236,6 +237,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers);
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
                 }
@@ -265,6 +267,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, t) => r.TryInvoke(arg1, arg2, t), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, t) => r.TryInvoke(arg1, arg2, t), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, t) => r.TryInvoke(arg1, arg2, t), addEventHandlers);
                 }
@@ -294,6 +297,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, t) => r.TryInvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, t) => r.TryInvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, t) => r.TryInvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                 }
@@ -575,6 +579,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAction<int, string>, int, string, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            ActionProxy<int, string, CancellationToken> action = new ActionProxy<int, string, CancellationToken>(
+                (arg1, arg2, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAction
+            ReliableAction<int, string> reliableAction = new ReliableAction<int, string>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAction.Retrying         += retryHandler    .Invoke;
+                reliableAction.Failed           += failedHandler   .Invoke;
+                reliableAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T3.Test.cs
@@ -206,6 +206,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invoke, addEventHandlers);
                     Invoke_Canceled_Action(invoke, addEventHandlers);
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
@@ -236,6 +237,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers);
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
                 }
@@ -265,6 +267,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, t) => r.TryInvoke(arg1, arg2, arg3, t), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, t) => r.TryInvoke(arg1, arg2, arg3, t), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, t) => r.TryInvoke(arg1, arg2, arg3, t), addEventHandlers);
                 }
@@ -294,6 +297,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, t) => r.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, t) => r.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, t) => r.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                 }
@@ -575,6 +579,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAction<int, string, double>, int, string, double, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            ActionProxy<int, string, double, CancellationToken> action = new ActionProxy<int, string, double, CancellationToken>(
+                (arg1, arg2, arg3, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAction
+            ReliableAction<int, string, double> reliableAction = new ReliableAction<int, string, double>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAction.Retrying         += retryHandler    .Invoke;
+                reliableAction.Failed           += failedHandler   .Invoke;
+                reliableAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T4.Test.cs
@@ -206,6 +206,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invoke, addEventHandlers);
                     Invoke_Canceled_Action(invoke, addEventHandlers);
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
@@ -236,6 +237,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers);
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
                 }
@@ -265,6 +267,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, t) => r.TryInvoke(arg1, arg2, arg3, arg4, t), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, t) => r.TryInvoke(arg1, arg2, arg3, arg4, t), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, t) => r.TryInvoke(arg1, arg2, arg3, arg4, t), addEventHandlers);
                 }
@@ -294,6 +297,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                 }
@@ -575,6 +579,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAction<int, string, double, long>, int, string, double, long, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            ActionProxy<int, string, double, long, CancellationToken> action = new ActionProxy<int, string, double, long, CancellationToken>(
+                (arg1, arg2, arg3, arg4, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAction
+            ReliableAction<int, string, double, long> reliableAction = new ReliableAction<int, string, double, long>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAction.Retrying         += retryHandler    .Invoke;
+                reliableAction.Failed           += failedHandler   .Invoke;
+                reliableAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, 1000L, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T5.Test.cs
@@ -206,6 +206,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invoke, addEventHandlers);
                     Invoke_Canceled_Action(invoke, addEventHandlers);
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
@@ -236,6 +237,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers);
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
                 }
@@ -265,6 +267,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, t), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, t), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, t), addEventHandlers);
                 }
@@ -294,6 +297,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                 }
@@ -575,6 +579,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAction<int, string, double, long, ushort>, int, string, double, long, ushort, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            ActionProxy<int, string, double, long, ushort, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAction
+            ReliableAction<int, string, double, long, ushort> reliableAction = new ReliableAction<int, string, double, long, ushort>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAction.Retrying         += retryHandler    .Invoke;
+                reliableAction.Failed           += failedHandler   .Invoke;
+                reliableAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, 1000L, (ushort)1, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T6.Test.cs
@@ -206,6 +206,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invoke, addEventHandlers);
                     Invoke_Canceled_Action(invoke, addEventHandlers);
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
@@ -236,6 +237,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers);
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
                 }
@@ -265,6 +267,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, arg6, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, t), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, arg6, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, t), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, arg6, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, t), addEventHandlers);
                 }
@@ -294,6 +297,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, arg6, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, arg6, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, arg6, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                 }
@@ -575,6 +579,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAction<int, string, double, long, ushort, byte>, int, string, double, long, ushort, byte, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            ActionProxy<int, string, double, long, ushort, byte, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAction
+            ReliableAction<int, string, double, long, ushort, byte> reliableAction = new ReliableAction<int, string, double, long, ushort, byte>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAction.Retrying         += retryHandler    .Invoke;
+                reliableAction.Failed           += failedHandler   .Invoke;
+                reliableAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T7.Test.cs
@@ -206,6 +206,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invoke, addEventHandlers);
                     Invoke_Canceled_Action(invoke, addEventHandlers);
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
@@ -236,6 +237,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers);
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
                 }
@@ -265,6 +267,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t), addEventHandlers);
                 }
@@ -294,6 +297,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                 }
@@ -575,6 +579,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAction<int, string, double, long, ushort, byte, TimeSpan>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAction
+            ReliableAction<int, string, double, long, ushort, byte, TimeSpan> reliableAction = new ReliableAction<int, string, double, long, ushort, byte, TimeSpan>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAction.Retrying         += retryHandler    .Invoke;
+                reliableAction.Failed           += failedHandler   .Invoke;
+                reliableAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAction.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAction.T8.Test.cs
@@ -206,6 +206,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invoke, addEventHandlers);
                     Invoke_Canceled_Action(invoke, addEventHandlers);
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
@@ -236,6 +237,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers);
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
                 }
@@ -265,6 +267,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => r.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t), addEventHandlers);
                 }
@@ -294,6 +297,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                 }
@@ -575,6 +579,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAction<int, string, double, long, ushort, byte, TimeSpan, uint>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> action = new ActionProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAction
+            ReliableAction<int, string, double, long, ushort, byte, TimeSpan, uint> reliableAction = new ReliableAction<int, string, double, long, ushort, byte, TimeSpan, uint>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAction.Retrying         += retryHandler    .Invoke;
+                reliableAction.Failed           += failedHandler   .Invoke;
+                reliableAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAction, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), 112U, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T2.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, t) => r.TryInvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, t) => r.TryInvokeAsync(arg1, arg2, t).Wait(), addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action((r, arg1, arg2, t) => r.TryInvokeAsync(arg1, arg2, t).Wait(), addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay ((r, arg1, arg2, t) => r.TryInvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
@@ -519,6 +521,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncAction<int, string>, int, string, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            FuncProxy<int, string, CancellationToken, Task> action = new FuncProxy<int, string, CancellationToken, Task>(
+                (arg1, arg2, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAsyncAction
+            ReliableAsyncAction<int, string> reliableAsyncAction = new ReliableAsyncAction<int, string>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAsyncAction.Retrying         += retryHandler    .Invoke;
+                reliableAsyncAction.Failed           += failedHandler   .Invoke;
+                reliableAsyncAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAsyncAction, 42, "foo", tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T3.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, t) => r.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, t) => r.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, t) => r.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, t) => r.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
@@ -519,6 +521,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncAction<int, string, double>, int, string, double, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            FuncProxy<int, string, double, CancellationToken, Task> action = new FuncProxy<int, string, double, CancellationToken, Task>(
+                (arg1, arg2, arg3, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAsyncAction
+            ReliableAsyncAction<int, string, double> reliableAsyncAction = new ReliableAsyncAction<int, string, double>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAsyncAction.Retrying         += retryHandler    .Invoke;
+                reliableAsyncAction.Failed           += failedHandler   .Invoke;
+                reliableAsyncAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAsyncAction, 42, "foo", 3.14D, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T4.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
@@ -519,6 +521,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncAction<int, string, double, long>, int, string, double, long, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            FuncProxy<int, string, double, long, CancellationToken, Task> action = new FuncProxy<int, string, double, long, CancellationToken, Task>(
+                (arg1, arg2, arg3, arg4, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAsyncAction
+            ReliableAsyncAction<int, string, double, long> reliableAsyncAction = new ReliableAsyncAction<int, string, double, long>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAsyncAction.Retrying         += retryHandler    .Invoke;
+                reliableAsyncAction.Failed           += failedHandler   .Invoke;
+                reliableAsyncAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAsyncAction, 42, "foo", 3.14D, 1000L, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T5.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
@@ -519,6 +521,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncAction<int, string, double, long, ushort>, int, string, double, long, ushort, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            FuncProxy<int, string, double, long, ushort, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, CancellationToken, Task>(
+                (arg1, arg2, arg3, arg4, arg5, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAsyncAction
+            ReliableAsyncAction<int, string, double, long, ushort> reliableAsyncAction = new ReliableAsyncAction<int, string, double, long, ushort>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAsyncAction.Retrying         += retryHandler    .Invoke;
+                reliableAsyncAction.Failed           += failedHandler   .Invoke;
+                reliableAsyncAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAsyncAction, 42, "foo", 3.14D, 1000L, (ushort)1, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T6.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, arg6, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, arg6, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, arg6, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, arg6, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
@@ -519,6 +521,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncAction<int, string, double, long, ushort, byte>, int, string, double, long, ushort, byte, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAsyncAction
+            ReliableAsyncAction<int, string, double, long, ushort, byte> reliableAsyncAction = new ReliableAsyncAction<int, string, double, long, ushort, byte>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAsyncAction.Retrying         += retryHandler    .Invoke;
+                reliableAsyncAction.Failed           += failedHandler   .Invoke;
+                reliableAsyncAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAsyncAction, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.T8.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay ((r, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => r.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
@@ -519,6 +521,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task> action = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAsyncAction
+            ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint> reliableAsyncAction = new ReliableAsyncAction<int, string, double, long, ushort, byte, TimeSpan, uint>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAsyncAction.Retrying         += retryHandler    .Invoke;
+                reliableAsyncAction.Failed           += failedHandler   .Invoke;
+                reliableAsyncAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAsyncAction, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), 112U, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/ReliableAsyncAction.Test.cs
@@ -197,6 +197,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action(invokeAsync, addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay (invokeAsync, addEventHandlers);
@@ -235,6 +236,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r, t) => r.TryInvokeAsync(t).Wait(), addEventHandlers);
                     Invoke_Canceled_Action((r, t) => r.TryInvokeAsync(t).Wait(), addEventHandlers, useSynchronousAction: false);
                     Invoke_Canceled_Action((r, t) => r.TryInvokeAsync(t).Wait(), addEventHandlers, useSynchronousAction: true );
                     Invoke_Canceled_Delay ((r, t) => r.TryInvokeAsync(t).Wait(), addEventHandlers);
@@ -515,6 +517,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncAction, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            FuncProxy<CancellationToken, Task> action = new FuncProxy<CancellationToken, Task>(
+                (token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create ReliableAsyncAction
+            ReliableAsyncAction reliableAsyncAction = new ReliableAsyncAction(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableAsyncAction.Retrying         += retryHandler    .Invoke;
+                reliableAsyncAction.Failed           += failedHandler   .Invoke;
+                reliableAsyncAction.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableAsyncAction, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/Reliably.Async.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Reliably.Async.Test.cs
@@ -40,11 +40,13 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -77,11 +79,13 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         [TestMethod]
@@ -114,14 +118,15 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -154,14 +159,15 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         [TestMethod]
@@ -196,11 +202,13 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -235,11 +243,13 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         [TestMethod]
@@ -274,14 +284,15 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -316,14 +327,15 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         #endregion
@@ -359,12 +371,15 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -396,12 +411,15 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         [TestMethod]
@@ -435,14 +453,15 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -476,14 +495,15 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         [TestMethod]
@@ -517,12 +537,15 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -556,12 +579,15 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         [TestMethod]
@@ -597,14 +623,15 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -640,14 +667,15 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         #endregion

--- a/src/Sweetener.Reliability.Test/Action/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Action/Reliably.Test.cs
@@ -27,11 +27,12 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
         [TestMethod]
@@ -51,11 +52,12 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
         [TestMethod]
@@ -75,14 +77,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, t, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
+            Invoke_Action_Success          (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
             Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -102,14 +104,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       invoke      = (a, t, n, e, d)    => Reliably.Invoke(a, t, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
+            Invoke_Action_Success          (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
             Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         [TestMethod]
@@ -133,11 +135,12 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
         [TestMethod]
@@ -161,11 +164,12 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
         [TestMethod]
@@ -189,14 +193,14 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
+            Invoke_Action_Success          (invoke     , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (invoke     , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
             Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -220,14 +224,14 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
+            Invoke_Action_Success          (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (invoke     , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
             Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         #endregion
@@ -252,11 +256,12 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
         [TestMethod]
@@ -277,11 +282,12 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
         [TestMethod]
@@ -302,14 +308,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -330,14 +336,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         [TestMethod]
@@ -368,11 +374,12 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
         [TestMethod]
@@ -403,11 +410,12 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
         [TestMethod]
@@ -438,14 +446,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -476,14 +484,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         #endregion
@@ -507,12 +515,14 @@ namespace Sweetener.Reliability.Test
             Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) => Reliably.TryInvoke(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
         [TestMethod]
@@ -532,12 +542,14 @@ namespace Sweetener.Reliability.Test
             Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, bool> tryInvoke = (a, t, n, e, d) => Reliably.TryInvoke(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
         [TestMethod]
@@ -559,14 +571,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -588,14 +600,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         [TestMethod]
@@ -619,12 +631,14 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
         [TestMethod]
@@ -648,12 +662,14 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
         [TestMethod]
@@ -679,14 +695,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -712,14 +728,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         #endregion
@@ -743,12 +759,14 @@ namespace Sweetener.Reliability.Test
             Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
         [TestMethod]
@@ -768,12 +786,14 @@ namespace Sweetener.Reliability.Test
             Func  <Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Task<bool>> tryInvoke = (a, t, n, e, d)    => Reliably.TryInvokeAsync(a, n, e, d.Invoke);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
         [TestMethod]
@@ -795,14 +815,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -824,14 +844,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         [TestMethod]
@@ -861,12 +881,14 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
         }
 
         [TestMethod]
@@ -896,12 +918,14 @@ namespace Sweetener.Reliability.Test
             };
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
         }
 
         [TestMethod]
@@ -933,14 +957,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, TimeSpan>(i => t), (d, t) => d.Invoking += Expect.Asc());
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, TimeSpan>(i => t),  d     => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -972,14 +996,14 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<int, Exception, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t), (d, t) => d.Invoking += Expect.ExceptionAsc(t));
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<int, Exception, TimeSpan>((i, e) => t),  d     => d.Invoking += Expect.Nothing<int, Exception>());
         }
 
         #endregion

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/Action.Extensions.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/Action.Extensions.Test.t4
@@ -116,6 +116,7 @@ namespace Sweetener.Reliability.Test
                 if (interruptable)
                 {
 #>
+            WithRetry<#= suffix #>_Canceled        (actionFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke);
             WithRetry<#= suffix #>_Canceled_Action (actionFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.<#= useComplexHandler ? "ExceptionAsc(e)" : "Asc()" #>);
             WithRetry<#= suffix #>_Canceled_Delay  (actionFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke, observeActionDelay, (d, e) => d.Invoking += Expect.<#= useComplexHandler ? "ExceptionAsc(e)" : "Asc()" #>);
 <#

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/ReliableAction.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/ReliableAction.Test.t4
@@ -225,6 +225,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invoke, addEventHandlers);
                     Invoke_Canceled_Action(invoke, addEventHandlers);
                     Invoke_Canceled_Delay (invoke, addEventHandlers);
                 }
@@ -273,6 +274,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       (invokeAsync, addEventHandlers);
 <#
         if (async)
         {
@@ -320,6 +322,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r<#= optionalComma #><#= arguments #>, t) => r.TryInvoke(<#= arguments #><#= optionalComma #>t), addEventHandlers);
                     Invoke_Canceled_Action((r<#= optionalComma #><#= arguments #>, t) => r.TryInvoke(<#= arguments #><#= optionalComma #>t), addEventHandlers);
                     Invoke_Canceled_Delay ((r<#= optionalComma #><#= arguments #>, t) => r.TryInvoke(<#= arguments #><#= optionalComma #>t), addEventHandlers);
                 }
@@ -367,6 +370,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled       ((r<#= optionalComma #><#= arguments #>, t) => r.TryInvokeAsync(<#= arguments #><#= optionalComma #>t).Wait(), addEventHandlers);
 <#
         if (async)
         {
@@ -715,6 +719,57 @@ namespace Sweetener.Reliability.Test
                 Assert.AreEqual(2, retryHandler    .Calls);
                 Assert.AreEqual(0, failedHandler   .Calls);
                 Assert.AreEqual(1, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<Reliable<#= optionalAsync #>Action<#= typeArguments #><#= optionalComma #><#= typeArgumentsNoBrackets #>, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused no-op user-defined action
+            <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #> action = new <#= inputActionKind #>Proxy<#= tokenInputActionTypeArguments #>(
+                (<#= arguments #><#= optionalComma #>token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<Exception, bool>          exceptionHandler  = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, Exception, TimeSpan> delayHandler      = new FuncProxy<int, Exception, TimeSpan>((i, e) => TimeSpan.Zero);
+
+            ActionProxy<int, Exception>         retryHandler     = new ActionProxy<int, Exception>();
+            ActionProxy<Exception>              failedHandler    = new ActionProxy<Exception>();
+            ActionProxy<Exception>              exhaustedHandler = new ActionProxy<Exception>();
+
+            // Create Reliable<#= optionalAsync #>Action
+            Reliable<#= optionalAsync #>Action<#= typeArguments #> reliable<#= optionalAsync #>Action = new Reliable<#= optionalAsync #>Action<#= typeArguments #>(
+                action.Invoke,
+                Retries.Infinite,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliable<#= optionalAsync #>Action.Retrying         += retryHandler    .Invoke;
+                reliable<#= optionalAsync #>Action.Failed           += failedHandler   .Invoke;
+                reliable<#= optionalAsync #>Action.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliable<#= optionalAsync #>Action<#= optionalComma #><#= argumentValues #>, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, action          .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
             }
         }
 

--- a/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
+++ b/src/Sweetener.Reliability.Test/Action/TextTemplating/Reliably.Test.t4
@@ -32,11 +32,11 @@ namespace Sweetener.Reliability.Test
             string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
             string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
-            foreach (bool interruptable in new bool[2] { false, true })
+            foreach (bool passToken in new bool[2] { false, true })
             {
-                string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
-                string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
-                string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+                string optionalTokenObj    = passToken ? ", CancellationToken.None" : string.Empty;
+                string optionalTokenArg    = passToken ? ", t"                      : string.Empty;
+                string optionalTokenSuffix = passToken ? "_Interruptable"           : string.Empty;
 
                 foreach (bool useComplexDelayHandler in new bool[2] { false, true })
                 {
@@ -83,18 +83,18 @@ namespace Sweetener.Reliability.Test
 #>
             Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => invoke(a, t, n, e, d), x);
 
-            Invoke_Action_Success         (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Action_Failure         (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Action_EventualSuccess (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_EventualFailure (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_RetriesExhausted(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Success          (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_Failure          (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_EventualSuccess  (invoke     , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_EventualFailure  (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_RetriesExhausted (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
 <#
-                    if (interruptable)
+                    if (passToken)
                     {
 #>
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
             Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled         (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
 <#
                     }
 #>
@@ -121,11 +121,11 @@ namespace Sweetener.Reliability.Test
         string optionalStateArg       = stateful ? ", state"          : string.Empty;
         string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
-        foreach (bool interruptable in new bool[2] { false, true })
+        foreach (bool passToken in new bool[2] { false, true })
         {
-            string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
-            string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
-            string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+            string optionalTokenObj    = passToken ? ", CancellationToken.None" : string.Empty;
+            string optionalTokenArg    = passToken ? ", t"                      : string.Empty;
+            string optionalTokenSuffix = passToken ? "_Interruptable"           : string.Empty;
 
             foreach (bool useComplexDelayHandler in new bool[2] { false, true })
             {
@@ -211,18 +211,25 @@ namespace Sweetener.Reliability.Test
             Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => invoke(a, t, n, e, d).Wait();
             Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => invoke(a, t, n, e, d), x).Wait();
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Action_Failure         (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_EventualFailure (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_RetriesExhausted(assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_Failure          (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_EventualFailure  (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_RetriesExhausted (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
 <#
-                if (interruptable)
+                if (passToken)
                 {
 #>
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+<#
+                }
 
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+                if (async)
+                {
+#>
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
 <#
                 }
 #>
@@ -249,11 +256,11 @@ namespace Sweetener.Reliability.Test
             string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
             string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
-            foreach (bool interruptable in new bool[2] { false, true })
+            foreach (bool passToken in new bool[2] { false, true })
             {
-                string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
-                string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
-                string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+                string optionalTokenObj    = passToken ? ", CancellationToken.None" : string.Empty;
+                string optionalTokenArg    = passToken ? ", t"                      : string.Empty;
+                string optionalTokenSuffix = passToken ? "_Interruptable"           : string.Empty;
 
                 foreach (bool useComplexDelayHandler in new bool[2] { false, true })
                 {
@@ -300,27 +307,20 @@ namespace Sweetener.Reliability.Test
 #>
             Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d));
             Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d));
-<#
-                    if (interruptable)
-                    {
-#>
             Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsException(() => tryInvoke(a, t, n, e, d), x);
-<#
-                    }
-#>
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
 <#
-                    if (interruptable)
+                    if (passToken)
                     {
 #>
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
 <#
                     }
 #>
@@ -347,11 +347,11 @@ namespace Sweetener.Reliability.Test
         string optionalStateArg       = stateful ? ", state"          : string.Empty;
         string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
-        foreach (bool interruptable in new bool[2] { false, true })
+        foreach (bool passToken in new bool[2] { false, true })
         {
-            string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
-            string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
-            string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+            string optionalTokenObj    = passToken ? ", CancellationToken.None" : string.Empty;
+            string optionalTokenArg    = passToken ? ", t"                      : string.Empty;
+            string optionalTokenSuffix = passToken ? "_Interruptable"           : string.Empty;
 
             foreach (bool useComplexDelayHandler in new bool[2] { false, true })
             {
@@ -436,27 +436,27 @@ namespace Sweetener.Reliability.Test
 #>
             Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>>       assertSuccess = (a, t, n, e, d)    => Assert.IsTrue (tryInvoke(a, t, n, e, d).Result);
             Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertFailure = (a, t, n, e, d, x) => Assert.IsFalse(tryInvoke(a, t, n, e, d).Result);
+            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+
+            Invoke_Action_Success          (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_Failure          (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Action_EventualSuccess  (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_EventualFailure  (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_RetriesExhausted (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_Delegate(assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
 <#
-                if (interruptable)
+                if (passToken)
                 {
 #>
-            Action<Action, CancellationToken, int, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type> assertError   = (a, t, n, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(a, t, n, e, d), x).Wait();
+            Invoke_Action_Canceled_Delay   (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled         (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
 <#
                 }
-#>
 
-            Invoke_Action_Success         (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Action_Failure         (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Action_EventualSuccess (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_EventualFailure (assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_RetriesExhausted(assertFailure, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-<#
-                if (interruptable)
+                if (async)
                 {
 #>
-
-            Invoke_Action_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Action_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Action_Canceled_NoTask  (assertError  , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d     => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
 <#
                 }
 #>

--- a/src/Sweetener.Reliability.Test/Expectations/Expect.cs
+++ b/src/Sweetener.Reliability.Test/Expectations/Expect.cs
@@ -140,6 +140,9 @@ namespace Sweetener.Reliability.Test
 
         #region Nothing
 
+        public static Action<CallContext> Nothing()
+            => context => Assert.Fail();
+
         public static Action<T1, CallContext> Nothing<T1>()
             => (arg, context) => Assert.Fail();
 

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T1.Test.cs
@@ -225,6 +225,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT1_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
@@ -272,6 +273,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT1_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
@@ -325,6 +327,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT1_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
@@ -378,6 +381,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT1_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T2.Test.cs
@@ -224,6 +224,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT2_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
@@ -271,6 +272,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT2_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
@@ -324,6 +326,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT2_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
@@ -377,6 +380,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT2_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T3.Test.cs
@@ -224,6 +224,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT3_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
@@ -271,6 +272,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT3_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
@@ -324,6 +326,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT3_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
@@ -377,6 +380,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT3_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T4.Test.cs
@@ -224,6 +224,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT4_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
@@ -271,6 +272,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT4_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
@@ -324,6 +326,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT4_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
@@ -377,6 +380,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT4_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T5.Test.cs
@@ -224,6 +224,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT5_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
@@ -271,6 +272,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT5_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
@@ -324,6 +326,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT5_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
@@ -377,6 +380,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT5_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T6.Test.cs
@@ -224,6 +224,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT6_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
@@ -271,6 +272,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT6_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
@@ -324,6 +326,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT6_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
@@ -377,6 +380,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT6_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T7.Test.cs
@@ -224,6 +224,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT7_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
@@ -271,6 +272,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT7_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
@@ -324,6 +326,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT7_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
@@ -377,6 +380,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT7_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T8.Test.cs
@@ -224,6 +224,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT8_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
@@ -271,6 +272,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT8_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
@@ -324,6 +326,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT8_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
@@ -377,6 +380,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT8_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 

--- a/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/AsyncFunc.Extensions.T9.Test.cs
@@ -224,6 +224,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT9_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
@@ -271,6 +272,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT9_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
@@ -324,6 +326,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT9_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
@@ -377,6 +380,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT9_Canceled      (funcFactory, delayHandlerFactory, withAsyncRetry, invoke);
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withAsyncRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T1.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T1.Test.Base.cs
@@ -447,6 +447,49 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT1_Canceled
+
+        internal void WithRetryT1_Canceled<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
+            Func<Func<CancellationToken, int>, TFuncProxy> funcFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TFunc, int, ResultHandler<int>, ExceptionHandler, TDelayPolicy, TFunc> withRetry,
+            Func<TFunc, CancellationToken, int> invoke)
+            where TFunc             : Delegate
+            where TDelayPolicy      : Delegate
+            where TFuncProxy        : DelegateProxy<TFunc>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            TFuncProxy func = funcFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<int, ResultKind> resultHandler    = new FuncProxy<int, ResultKind>(ResultPolicy.Default<int>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable function
+            TFunc reliableFunc = withRetry(
+                func.Proxy,
+                Retries.Infinite,
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Begin the invocation
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT1_Canceled_Func
 
         internal void WithRetryT1_Canceled_Func<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
@@ -464,7 +507,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether it's canceled
+            // Create a user-defined function that will throw an exception depending on whether it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t =>
             {
@@ -533,7 +576,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create an "unsuccessful" user-defined func that continues to fail with transient exceptions until it's canceled
+            // Create an "unsuccessful" user-defined function that continues to fail with transient exceptions until it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t => flakyFunc());
 

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T1.Test.cs
@@ -200,6 +200,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT1_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
@@ -238,6 +239,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT1_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
@@ -282,6 +284,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT1_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
@@ -326,6 +329,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT1_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT1_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT1_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT1_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T2.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T2.Test.Base.cs
@@ -447,6 +447,49 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT2_Canceled
+
+        internal void WithRetryT2_Canceled<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
+            Func<Func<CancellationToken, int>, TFuncProxy> funcFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TFunc, int, ResultHandler<int>, ExceptionHandler, TDelayPolicy, TFunc> withRetry,
+            Func<TFunc, int, CancellationToken, int> invoke)
+            where TFunc             : Delegate
+            where TDelayPolicy      : Delegate
+            where TFuncProxy        : DelegateProxy<TFunc>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            TFuncProxy func = funcFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<int, ResultKind> resultHandler    = new FuncProxy<int, ResultKind>(ResultPolicy.Default<int>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable function
+            TFunc reliableFunc = withRetry(
+                func.Proxy,
+                Retries.Infinite,
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Begin the invocation
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT2_Canceled_Func
 
         internal void WithRetryT2_Canceled_Func<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
@@ -464,7 +507,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether it's canceled
+            // Create a user-defined function that will throw an exception depending on whether it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t =>
             {
@@ -533,7 +576,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create an "unsuccessful" user-defined func that continues to fail with transient exceptions until it's canceled
+            // Create an "unsuccessful" user-defined function that continues to fail with transient exceptions until it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t => flakyFunc());
 

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T2.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT2_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT2_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
@@ -281,6 +283,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT2_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
@@ -325,6 +328,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT2_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT2_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT2_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT2_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T3.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT3_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT3_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
@@ -281,6 +283,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT3_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
@@ -325,6 +328,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT3_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT3_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT3_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT3_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T4.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T4.Test.Base.cs
@@ -447,6 +447,49 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT4_Canceled
+
+        internal void WithRetryT4_Canceled<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
+            Func<Func<CancellationToken, int>, TFuncProxy> funcFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TFunc, int, ResultHandler<int>, ExceptionHandler, TDelayPolicy, TFunc> withRetry,
+            Func<TFunc, int, string, double, CancellationToken, int> invoke)
+            where TFunc             : Delegate
+            where TDelayPolicy      : Delegate
+            where TFuncProxy        : DelegateProxy<TFunc>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            TFuncProxy func = funcFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<int, ResultKind> resultHandler    = new FuncProxy<int, ResultKind>(ResultPolicy.Default<int>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable function
+            TFunc reliableFunc = withRetry(
+                func.Proxy,
+                Retries.Infinite,
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Begin the invocation
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT4_Canceled_Func
 
         internal void WithRetryT4_Canceled_Func<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
@@ -464,7 +507,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether it's canceled
+            // Create a user-defined function that will throw an exception depending on whether it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t =>
             {
@@ -533,7 +576,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create an "unsuccessful" user-defined func that continues to fail with transient exceptions until it's canceled
+            // Create an "unsuccessful" user-defined function that continues to fail with transient exceptions until it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t => flakyFunc());
 

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T4.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT4_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT4_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
@@ -281,6 +283,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT4_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
@@ -325,6 +328,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT4_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT4_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT4_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT4_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T5.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T5.Test.Base.cs
@@ -447,6 +447,49 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT5_Canceled
+
+        internal void WithRetryT5_Canceled<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
+            Func<Func<CancellationToken, int>, TFuncProxy> funcFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TFunc, int, ResultHandler<int>, ExceptionHandler, TDelayPolicy, TFunc> withRetry,
+            Func<TFunc, int, string, double, long, CancellationToken, int> invoke)
+            where TFunc             : Delegate
+            where TDelayPolicy      : Delegate
+            where TFuncProxy        : DelegateProxy<TFunc>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            TFuncProxy func = funcFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<int, ResultKind> resultHandler    = new FuncProxy<int, ResultKind>(ResultPolicy.Default<int>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable function
+            TFunc reliableFunc = withRetry(
+                func.Proxy,
+                Retries.Infinite,
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Begin the invocation
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT5_Canceled_Func
 
         internal void WithRetryT5_Canceled_Func<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
@@ -464,7 +507,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether it's canceled
+            // Create a user-defined function that will throw an exception depending on whether it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t =>
             {
@@ -533,7 +576,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create an "unsuccessful" user-defined func that continues to fail with transient exceptions until it's canceled
+            // Create an "unsuccessful" user-defined function that continues to fail with transient exceptions until it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t => flakyFunc());
 

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T5.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT5_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT5_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
@@ -281,6 +283,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT5_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
@@ -325,6 +328,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT5_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT5_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT5_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT5_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T6.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T6.Test.Base.cs
@@ -447,6 +447,49 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT6_Canceled
+
+        internal void WithRetryT6_Canceled<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
+            Func<Func<CancellationToken, int>, TFuncProxy> funcFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TFunc, int, ResultHandler<int>, ExceptionHandler, TDelayPolicy, TFunc> withRetry,
+            Func<TFunc, int, string, double, long, ushort, CancellationToken, int> invoke)
+            where TFunc             : Delegate
+            where TDelayPolicy      : Delegate
+            where TFuncProxy        : DelegateProxy<TFunc>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            TFuncProxy func = funcFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<int, ResultKind> resultHandler    = new FuncProxy<int, ResultKind>(ResultPolicy.Default<int>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable function
+            TFunc reliableFunc = withRetry(
+                func.Proxy,
+                Retries.Infinite,
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Begin the invocation
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT6_Canceled_Func
 
         internal void WithRetryT6_Canceled_Func<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
@@ -464,7 +507,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether it's canceled
+            // Create a user-defined function that will throw an exception depending on whether it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t =>
             {
@@ -533,7 +576,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create an "unsuccessful" user-defined func that continues to fail with transient exceptions until it's canceled
+            // Create an "unsuccessful" user-defined function that continues to fail with transient exceptions until it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t => flakyFunc());
 

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T6.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT6_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT6_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
@@ -281,6 +283,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT6_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
@@ -325,6 +328,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT6_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT6_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT6_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT6_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T7.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T7.Test.Base.cs
@@ -447,6 +447,49 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT7_Canceled
+
+        internal void WithRetryT7_Canceled<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
+            Func<Func<CancellationToken, int>, TFuncProxy> funcFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TFunc, int, ResultHandler<int>, ExceptionHandler, TDelayPolicy, TFunc> withRetry,
+            Func<TFunc, int, string, double, long, ushort, byte, CancellationToken, int> invoke)
+            where TFunc             : Delegate
+            where TDelayPolicy      : Delegate
+            where TFuncProxy        : DelegateProxy<TFunc>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            TFuncProxy func = funcFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<int, ResultKind> resultHandler    = new FuncProxy<int, ResultKind>(ResultPolicy.Default<int>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable function
+            TFunc reliableFunc = withRetry(
+                func.Proxy,
+                Retries.Infinite,
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Begin the invocation
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT7_Canceled_Func
 
         internal void WithRetryT7_Canceled_Func<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
@@ -464,7 +507,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether it's canceled
+            // Create a user-defined function that will throw an exception depending on whether it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t =>
             {
@@ -533,7 +576,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create an "unsuccessful" user-defined func that continues to fail with transient exceptions until it's canceled
+            // Create an "unsuccessful" user-defined function that continues to fail with transient exceptions until it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t => flakyFunc());
 

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T7.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT7_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT7_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
@@ -281,6 +283,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT7_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
@@ -325,6 +328,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT7_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT7_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT7_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT7_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T8.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T8.Test.Base.cs
@@ -447,6 +447,49 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT8_Canceled
+
+        internal void WithRetryT8_Canceled<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
+            Func<Func<CancellationToken, int>, TFuncProxy> funcFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TFunc, int, ResultHandler<int>, ExceptionHandler, TDelayPolicy, TFunc> withRetry,
+            Func<TFunc, int, string, double, long, ushort, byte, TimeSpan, CancellationToken, int> invoke)
+            where TFunc             : Delegate
+            where TDelayPolicy      : Delegate
+            where TFuncProxy        : DelegateProxy<TFunc>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            TFuncProxy func = funcFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<int, ResultKind> resultHandler    = new FuncProxy<int, ResultKind>(ResultPolicy.Default<int>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable function
+            TFunc reliableFunc = withRetry(
+                func.Proxy,
+                Retries.Infinite,
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Begin the invocation
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT8_Canceled_Func
 
         internal void WithRetryT8_Canceled_Func<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
@@ -464,7 +507,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether it's canceled
+            // Create a user-defined function that will throw an exception depending on whether it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t =>
             {
@@ -533,7 +576,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create an "unsuccessful" user-defined func that continues to fail with transient exceptions until it's canceled
+            // Create an "unsuccessful" user-defined function that continues to fail with transient exceptions until it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t => flakyFunc());
 

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T8.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT8_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT8_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
@@ -281,6 +283,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT8_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
@@ -325,6 +328,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT8_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT8_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT8_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT8_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T9.Test.Base.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T9.Test.Base.cs
@@ -447,6 +447,49 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetryT9_Canceled
+
+        internal void WithRetryT9_Canceled<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
+            Func<Func<CancellationToken, int>, TFuncProxy> funcFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TFunc, int, ResultHandler<int>, ExceptionHandler, TDelayPolicy, TFunc> withRetry,
+            Func<TFunc, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, int> invoke)
+            where TFunc             : Delegate
+            where TDelayPolicy      : Delegate
+            where TFuncProxy        : DelegateProxy<TFunc>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            TFuncProxy func = funcFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<int, ResultKind> resultHandler    = new FuncProxy<int, ResultKind>(ResultPolicy.Default<int>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable function
+            TFunc reliableFunc = withRetry(
+                func.Proxy,
+                Retries.Infinite,
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Begin the invocation
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), 112U, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetryT9_Canceled_Func
 
         internal void WithRetryT9_Canceled_Func<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
@@ -464,7 +507,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether it's canceled
+            // Create a user-defined function that will throw an exception depending on whether it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t =>
             {
@@ -533,7 +576,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create an "unsuccessful" user-defined func that continues to fail with transient exceptions until it's canceled
+            // Create an "unsuccessful" user-defined function that continues to fail with transient exceptions until it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t => flakyFunc());
 

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.T9.Test.cs
@@ -199,6 +199,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
 
             // Cancel
+            WithRetryT9_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: false);
         }
@@ -237,6 +238,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
 
             // Cancel
+            WithRetryT9_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.OnlyExceptionAsc<int>(e), passResultHandler: false);
         }
@@ -281,6 +283,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
 
             // Cancel
+            WithRetryT9_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.Asc(), passResultHandler: true);
         }
@@ -325,6 +328,7 @@ namespace Sweetener.Reliability.Test
             WithRetryT9_RetriesExhausted_Exception(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
 
             // Cancel
+            WithRetryT9_Canceled      (funcFactory, delayHandlerFactory, withRetry, invoke);
             WithRetryT9_Canceled_Func (funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
             WithRetryT9_Canceled_Delay(funcFactory, delayHandlerFactory, withRetry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.AlternatingAsc(r, e), passResultHandler: true);
         }

--- a/src/Sweetener.Reliability.Test/Func/Func.Extensions.Test.Base.tt
+++ b/src/Sweetener.Reliability.Test/Func/Func.Extensions.Test.Base.tt
@@ -472,6 +472,49 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region WithRetry<#= suffix #>_Canceled
+
+        internal void WithRetry<#= suffix #>_Canceled<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
+            Func<Func<CancellationToken, int>, TFuncProxy> funcFactory,
+            Func<TimeSpan, TDelayPolicyProxy> delayHandlerFactory,
+            Func<TFunc, int, ResultHandler<int>, ExceptionHandler, TDelayPolicy, TFunc> withRetry,
+            Func<TFunc<#= optionalComma #><#= typeArguments #>, CancellationToken, int> invoke)
+            where TFunc             : Delegate
+            where TDelayPolicy      : Delegate
+            where TFuncProxy        : DelegateProxy<TFunc>
+            where TDelayPolicyProxy : DelegateProxy<TDelayPolicy>
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            TFuncProxy func = funcFactory(t => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<int, ResultKind> resultHandler    = new FuncProxy<int, ResultKind>(ResultPolicy.Default<int>().Invoke);
+            FuncProxy<Exception, bool> exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            TDelayPolicyProxy delayHandler = delayHandlerFactory(TimeSpan.Zero);
+
+            // Create the reliable function
+            TFunc reliableFunc = withRetry(
+                func.Proxy,
+                Retries.Infinite,
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler.Proxy);
+
+            // Begin the invocation
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc<#= optionalComma #><#= argumentValues #>, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+        }
+
+        #endregion
+
         #region WithRetry<#= suffix #>_Canceled_Func
 
         internal void WithRetry<#= suffix #>_Canceled_Func<TFunc, TDelayPolicy, TFuncProxy, TDelayPolicyProxy>(
@@ -489,7 +532,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether it's canceled
+            // Create a user-defined function that will throw an exception depending on whether it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t =>
             {
@@ -558,7 +601,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create an "unsuccessful" user-defined func that continues to fail with transient exceptions until it's canceled
+            // Create an "unsuccessful" user-defined function that continues to fail with transient exceptions until it's canceled
             Func<int> flakyFunc = passResultHandler ? FlakyFunc.Create<int, IOException>(418) : () => throw new IOException();
             TFuncProxy func = funcFactory(t => flakyFunc());
 

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T1.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T1.Test.cs
@@ -332,6 +332,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, t) => f.InvokeAsync(t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, t) => f.InvokeAsync(t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, t) => f.InvokeAsync(t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, t) => f.InvokeAsync(t).Wait(), addEventHandlers);
@@ -401,6 +402,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, t) => f.TryInvokeAsync(t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, t) => f.TryInvokeAsync(t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, t) => f.TryInvokeAsync(t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, t) => f.TryInvokeAsync(t).Wait(), addEventHandlers);
@@ -900,13 +902,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncFunc<string>, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<CancellationToken, Task<string>> func = new FuncProxy<CancellationToken, Task<string>>(
+                (token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableAsyncFunc
+            ReliableAsyncFunc<string> reliableFunc = new ReliableAsyncFunc<string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<string>, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<CancellationToken, Task<string>> func = useSynchronousFunc
@@ -967,10 +1023,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -988,7 +1044,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<Task<string>> func = new FuncProxy<Task<string>>(async () => await Task.FromResult(flakyFunc()));
 
@@ -1036,10 +1092,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T2.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T2.Test.cs
@@ -334,6 +334,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg, t) => f.InvokeAsync(arg, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg, t) => f.InvokeAsync(arg, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg, t) => f.InvokeAsync(arg, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg, t) => f.InvokeAsync(arg, t).Wait(), addEventHandlers);
@@ -403,6 +404,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg, t) => f.TryInvokeAsync(arg, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg, t) => f.TryInvokeAsync(arg, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg, t) => f.TryInvokeAsync(arg, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg, t) => f.TryInvokeAsync(arg, t).Wait(), addEventHandlers);
@@ -905,13 +907,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncFunc<int, string>, int, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, CancellationToken, Task<string>> func = new FuncProxy<int, CancellationToken, Task<string>>(
+                (arg, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableAsyncFunc
+            ReliableAsyncFunc<int, string> reliableFunc = new ReliableAsyncFunc<int, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string>, int, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, CancellationToken, Task<string>> func = useSynchronousFunc
@@ -972,10 +1028,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -993,7 +1049,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, Task<string>> func = new FuncProxy<int, Task<string>>(async (arg) => await Task.FromResult(flakyFunc()));
 
@@ -1041,10 +1097,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T4.Test.cs
@@ -334,6 +334,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
@@ -403,6 +404,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, t) => f.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, t) => f.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
@@ -905,13 +907,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncFunc<int, string, double, string>, int, string, double, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, CancellationToken, Task<string>>(
+                (arg1, arg2, arg3, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableAsyncFunc
+            ReliableAsyncFunc<int, string, double, string> reliableFunc = new ReliableAsyncFunc<int, string, double, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, string>, int, string, double, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, CancellationToken, Task<string>> func = useSynchronousFunc
@@ -972,10 +1028,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -993,7 +1049,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, Task<string>> func = new FuncProxy<int, string, double, Task<string>>(async (arg1, arg2, arg3) => await Task.FromResult(flakyFunc()));
 
@@ -1041,10 +1097,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T5.Test.cs
@@ -334,6 +334,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
@@ -403,6 +404,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
@@ -905,13 +907,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncFunc<int, string, double, long, string>, int, string, double, long, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, long, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, CancellationToken, Task<string>>(
+                (arg1, arg2, arg3, arg4, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableAsyncFunc
+            ReliableAsyncFunc<int, string, double, long, string> reliableFunc = new ReliableAsyncFunc<int, string, double, long, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, string>, int, string, double, long, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, CancellationToken, Task<string>> func = useSynchronousFunc
@@ -972,10 +1028,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -993,7 +1049,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, Task<string>> func = new FuncProxy<int, string, double, long, Task<string>>(async (arg1, arg2, arg3, arg4) => await Task.FromResult(flakyFunc()));
 
@@ -1041,10 +1097,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T6.Test.cs
@@ -334,6 +334,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
@@ -403,6 +404,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
@@ -905,13 +907,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncFunc<int, string, double, long, ushort, string>, int, string, double, long, ushort, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, long, ushort, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, CancellationToken, Task<string>>(
+                (arg1, arg2, arg3, arg4, arg5, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableAsyncFunc
+            ReliableAsyncFunc<int, string, double, long, ushort, string> reliableFunc = new ReliableAsyncFunc<int, string, double, long, ushort, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, string>, int, string, double, long, ushort, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, CancellationToken, Task<string>> func = useSynchronousFunc
@@ -972,10 +1028,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -993,7 +1049,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, Task<string>> func = new FuncProxy<int, string, double, long, ushort, Task<string>>(async (arg1, arg2, arg3, arg4, arg5) => await Task.FromResult(flakyFunc()));
 
@@ -1041,10 +1097,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T7.Test.cs
@@ -334,6 +334,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
@@ -403,6 +404,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
@@ -905,13 +907,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, string>, int, string, double, long, ushort, byte, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task<string>>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableAsyncFunc
+            ReliableAsyncFunc<int, string, double, long, ushort, byte, string> reliableFunc = new ReliableAsyncFunc<int, string, double, long, ushort, byte, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, string>, int, string, double, long, ushort, byte, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, CancellationToken, Task<string>> func = useSynchronousFunc
@@ -972,10 +1028,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -993,7 +1049,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, byte, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6) => await Task.FromResult(flakyFunc()));
 
@@ -1041,10 +1097,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T8.Test.cs
@@ -334,6 +334,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
@@ -403,6 +404,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
@@ -905,13 +907,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableAsyncFunc
+            ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string> reliableFunc = new ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, string>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, Task<string>> func = useSynchronousFunc
@@ -972,10 +1028,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -993,7 +1049,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => await Task.FromResult(flakyFunc()));
 
@@ -1041,10 +1097,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableAsyncFunc.T9.Test.cs
@@ -334,6 +334,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
@@ -403,6 +404,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers, useSynchronousFunc: false);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers, useSynchronousFunc: true );
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
@@ -905,13 +907,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableAsyncFunc
+            ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string> reliableFunc = new ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), 112U, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableAsyncFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke, bool addEventHandlers, bool useSynchronousFunc)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             // Note: We need to separately check the use of asynchronous and synchronous methods when checking cancellation
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, Task<string>> func = useSynchronousFunc
@@ -972,10 +1028,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), 112U, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -993,7 +1049,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, Task<string>>(async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => await Task.FromResult(flakyFunc()));
 
@@ -1041,10 +1097,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), 112U, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T3.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T3.Test.cs
@@ -341,6 +341,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, t) => f.Invoke(arg1, arg2, t), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, t) => f.Invoke(arg1, arg2, t), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, t) => f.Invoke(arg1, arg2, t), addEventHandlers);
                 }
@@ -378,6 +379,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, t) => f.InvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, t) => f.InvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, t) => f.InvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                 }
@@ -437,6 +439,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, t) => f.TryInvoke(arg1, arg2, t, out string _), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, t) => f.TryInvoke(arg1, arg2, t, out string _), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, t) => f.TryInvoke(arg1, arg2, t, out string _), addEventHandlers);
                 }
@@ -505,6 +508,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, t) => f.TryInvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, t) => f.TryInvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, t) => f.TryInvokeAsync(arg1, arg2, t).Wait(), addEventHandlers);
                 }
@@ -1006,13 +1010,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableFunc<int, string, string>, int, string, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, CancellationToken, string> func = new FuncProxy<int, string, CancellationToken, string>(
+                (arg1, arg2, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableFunc
+            ReliableFunc<int, string, string> reliableFunc = new ReliableFunc<int, string, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableFunc<int, string, string>, int, string, CancellationToken> invoke, bool addEventHandlers)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, CancellationToken, string> func = new FuncProxy<int, string, CancellationToken, string>(
                 (arg1, arg2, token) =>
@@ -1065,10 +1123,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -1086,7 +1144,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, string> func = new FuncProxy<int, string, string>((arg1, arg2) => flakyFunc());
 
@@ -1134,10 +1192,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T4.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T4.Test.cs
@@ -341,6 +341,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, t) => f.Invoke(arg1, arg2, arg3, t), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.Invoke(arg1, arg2, arg3, t), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, t) => f.Invoke(arg1, arg2, arg3, t), addEventHandlers);
                 }
@@ -378,6 +379,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, t) => f.InvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                 }
@@ -437,6 +439,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, t) => f.TryInvoke(arg1, arg2, arg3, t, out string _), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.TryInvoke(arg1, arg2, arg3, t, out string _), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, t) => f.TryInvoke(arg1, arg2, arg3, t, out string _), addEventHandlers);
                 }
@@ -505,6 +508,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, t) => f.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, t) => f.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, t) => f.TryInvokeAsync(arg1, arg2, arg3, t).Wait(), addEventHandlers);
                 }
@@ -1006,13 +1010,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableFunc<int, string, double, string>, int, string, double, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, CancellationToken, string> func = new FuncProxy<int, string, double, CancellationToken, string>(
+                (arg1, arg2, arg3, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableFunc
+            ReliableFunc<int, string, double, string> reliableFunc = new ReliableFunc<int, string, double, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableFunc<int, string, double, string>, int, string, double, CancellationToken> invoke, bool addEventHandlers)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, CancellationToken, string> func = new FuncProxy<int, string, double, CancellationToken, string>(
                 (arg1, arg2, arg3, token) =>
@@ -1065,10 +1123,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -1086,7 +1144,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, string> func = new FuncProxy<int, string, double, string>((arg1, arg2, arg3) => flakyFunc());
 
@@ -1134,10 +1192,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T5.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T5.Test.cs
@@ -341,6 +341,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, t) => f.Invoke(arg1, arg2, arg3, arg4, t), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.Invoke(arg1, arg2, arg3, arg4, t), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, t) => f.Invoke(arg1, arg2, arg3, arg4, t), addEventHandlers);
                 }
@@ -378,6 +379,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                 }
@@ -437,6 +439,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, t) => f.TryInvoke(arg1, arg2, arg3, arg4, t, out string _), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.TryInvoke(arg1, arg2, arg3, arg4, t, out string _), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, t) => f.TryInvoke(arg1, arg2, arg3, arg4, t, out string _), addEventHandlers);
                 }
@@ -505,6 +508,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, t).Wait(), addEventHandlers);
                 }
@@ -1006,13 +1010,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableFunc<int, string, double, long, string>, int, string, double, long, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, long, CancellationToken, string> func = new FuncProxy<int, string, double, long, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableFunc
+            ReliableFunc<int, string, double, long, string> reliableFunc = new ReliableFunc<int, string, double, long, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableFunc<int, string, double, long, string>, int, string, double, long, CancellationToken> invoke, bool addEventHandlers)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, CancellationToken, string> func = new FuncProxy<int, string, double, long, CancellationToken, string>(
                 (arg1, arg2, arg3, arg4, token) =>
@@ -1065,10 +1123,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -1086,7 +1144,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, string> func = new FuncProxy<int, string, double, long, string>((arg1, arg2, arg3, arg4) => flakyFunc());
 
@@ -1134,10 +1192,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T6.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T6.Test.cs
@@ -341,6 +341,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, t), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, t), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, t), addEventHandlers);
                 }
@@ -378,6 +379,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                 }
@@ -437,6 +439,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, t, out string _), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, t, out string _), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, t, out string _), addEventHandlers);
                 }
@@ -505,6 +508,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, t).Wait(), addEventHandlers);
                 }
@@ -1006,13 +1010,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableFunc<int, string, double, long, ushort, string>, int, string, double, long, ushort, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, long, ushort, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableFunc
+            ReliableFunc<int, string, double, long, ushort, string> reliableFunc = new ReliableFunc<int, string, double, long, ushort, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableFunc<int, string, double, long, ushort, string>, int, string, double, long, ushort, CancellationToken> invoke, bool addEventHandlers)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, CancellationToken, string>(
                 (arg1, arg2, arg3, arg4, arg5, token) =>
@@ -1065,10 +1123,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -1086,7 +1144,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, string> func = new FuncProxy<int, string, double, long, ushort, string>((arg1, arg2, arg3, arg4, arg5) => flakyFunc());
 
@@ -1134,10 +1192,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T7.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T7.Test.cs
@@ -341,6 +341,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, arg6, t), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, arg6, t), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, arg6, t), addEventHandlers);
                 }
@@ -378,6 +379,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                 }
@@ -437,6 +439,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, t, out string _), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, t, out string _), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, t, out string _), addEventHandlers);
                 }
@@ -505,6 +508,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, t).Wait(), addEventHandlers);
                 }
@@ -1006,13 +1010,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableFunc<int, string, double, long, ushort, byte, string>, int, string, double, long, ushort, byte, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, long, ushort, byte, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableFunc
+            ReliableFunc<int, string, double, long, ushort, byte, string> reliableFunc = new ReliableFunc<int, string, double, long, ushort, byte, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableFunc<int, string, double, long, ushort, byte, string>, int, string, double, long, ushort, byte, CancellationToken> invoke, bool addEventHandlers)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, byte, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, CancellationToken, string>(
                 (arg1, arg2, arg3, arg4, arg5, arg6, token) =>
@@ -1065,10 +1123,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -1086,7 +1144,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, byte, string> func = new FuncProxy<int, string, double, long, ushort, byte, string>((arg1, arg2, arg3, arg4, arg5, arg6) => flakyFunc());
 
@@ -1134,10 +1192,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T8.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T8.Test.cs
@@ -341,6 +341,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t), addEventHandlers);
                 }
@@ -378,6 +379,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                 }
@@ -437,6 +439,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t, out string _), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t, out string _), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t, out string _), addEventHandlers);
                 }
@@ -505,6 +508,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, t).Wait(), addEventHandlers);
                 }
@@ -1006,13 +1010,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableFunc<int, string, double, long, ushort, byte, TimeSpan, string>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableFunc
+            ReliableFunc<int, string, double, long, ushort, byte, TimeSpan, string> reliableFunc = new ReliableFunc<int, string, double, long, ushort, byte, TimeSpan, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableFunc<int, string, double, long, ushort, byte, TimeSpan, string>, int, string, double, long, ushort, byte, TimeSpan, CancellationToken> invoke, bool addEventHandlers)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, CancellationToken, string>(
                 (arg1, arg2, arg3, arg4, arg5, arg6, arg7, token) =>
@@ -1065,10 +1123,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -1086,7 +1144,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7) => flakyFunc());
 
@@ -1134,10 +1192,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/ReliableFunc.T9.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/ReliableFunc.T9.Test.cs
@@ -341,6 +341,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.Invoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t), addEventHandlers);
                 }
@@ -378,6 +379,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.InvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                 }
@@ -437,6 +439,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t, out string _), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t, out string _), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.TryInvoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t, out string _), addEventHandlers);
                 }
@@ -505,6 +508,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Func ((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                     Invoke_Canceled_Delay((f, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t) => f.TryInvokeAsync(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, t).Wait(), addEventHandlers);
                 }
@@ -1006,13 +1010,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<ReliableFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, string>(
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create ReliableFunc
+            ReliableFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string> reliableFunc = new ReliableFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), 112U, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<ReliableFunc<int, string, double, long, ushort, byte, TimeSpan, uint, string>, int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken> invoke, bool addEventHandlers)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, CancellationToken, string>(
                 (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, token) =>
@@ -1065,10 +1123,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), 112U, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -1086,7 +1144,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, string> func = new FuncProxy<int, string, double, long, ushort, byte, TimeSpan, uint, string>((arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => flakyFunc());
 
@@ -1134,10 +1192,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc, 42, "foo", 3.14D, 1000L, (ushort)1, (byte)255, TimeSpan.FromDays(30), 112U, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/Reliably.Async.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Reliably.Async.Test.cs
@@ -47,6 +47,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -86,6 +90,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -131,6 +139,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -176,6 +188,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -216,8 +232,11 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -258,8 +277,11 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -306,8 +328,11 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -354,8 +379,11 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -397,6 +425,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -438,6 +470,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -485,6 +521,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -532,6 +572,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -574,8 +618,11 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -618,8 +665,11 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -668,8 +718,11 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -718,8 +771,11 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         #endregion
@@ -755,15 +811,20 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -795,15 +856,20 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -836,20 +902,25 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -882,20 +953,25 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -930,16 +1006,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -974,16 +1053,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -1019,21 +1101,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -1069,21 +1154,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -1117,15 +1205,20 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -1159,15 +1252,20 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -1202,20 +1300,25 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -1250,20 +1353,25 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -1300,16 +1408,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -1346,16 +1457,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -1393,21 +1507,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -1445,21 +1562,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         #endregion

--- a/src/Sweetener.Reliability.Test/Func/Reliably.Async.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Reliably.Async.Test.cs
@@ -795,7 +795,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
             Func<Task<string>> nullTaskFunc = () => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -840,7 +840,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync        (testFunc, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
 
             Func<Task<string>> nullTaskFunc = () => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<string>(nullTaskFunc, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync<string>(nullTaskFunc, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -886,7 +886,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
             Func<Task<string>> nullTaskFunc = () => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -937,7 +937,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
 
             Func<Task<string>> nullTaskFunc = () => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -987,7 +987,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
             Func<Task<string>> nullTaskFunc = () => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1034,7 +1034,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync        (testFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
 
             Func<Task<string>> nullTaskFunc = () => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<string>(nullTaskFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync<string>(nullTaskFunc, CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1082,7 +1082,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
             Func<Task<string>> nullTaskFunc = () => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1135,7 +1135,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
 
             Func<Task<string>> nullTaskFunc = () => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1187,7 +1187,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
             Func<object, Task<string>> nullTaskFunc = s => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, new object(), 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1234,7 +1234,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync                (testFunc, new object(), 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
 
             Func<object, Task<string>> nullTaskFunc = s => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<object, string>(nullTaskFunc, new object(), 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync<object, string>(nullTaskFunc, new object(), 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1282,7 +1282,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
             Func<object, Task<string>> nullTaskFunc = s => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1335,7 +1335,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
 
             Func<object, Task<string>> nullTaskFunc = s => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, new object(), 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1387,7 +1387,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
             Func<object, Task<string>> nullTaskFunc = s => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1436,7 +1436,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync                (testFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
 
             Func<object, Task<string>> nullTaskFunc = s => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<object, string>(nullTaskFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync<object, string>(nullTaskFunc, new object(), CancellationToken.None, 10, ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1486,7 +1486,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (DelayHandler)null)).ConfigureAwait(false);
 
             Func<object, Task<string>> nullTaskFunc = s => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, DelayPolicy.None)).ConfigureAwait(false);
 
 #nullable enable
 
@@ -1541,7 +1541,7 @@ namespace Sweetener.Reliability.Test
             await Assert.ThrowsExceptionAsync<ArgumentNullException      >(() => Reliably.TryInvokeAsync(testFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (ComplexDelayHandler<string>)null)).ConfigureAwait(false);
 
             Func<object, Task<string>> nullTaskFunc = s => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync(nullTaskFunc, new object(), CancellationToken.None, 10, ResultPolicy.Default<string>(), ExceptionPolicy.Transient, (i, r, e) => TimeSpan.Zero)).ConfigureAwait(false);
 
 #nullable enable
 

--- a/src/Sweetener.Reliability.Test/Func/Reliably.Test.cs
+++ b/src/Sweetener.Reliability.Test/Func/Reliably.Test.cs
@@ -36,6 +36,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
         }
 
         [TestMethod]
@@ -64,6 +67,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
         }
 
         [TestMethod]
@@ -98,6 +104,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
         }
 
         [TestMethod]
@@ -132,6 +141,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
         }
 
         [TestMethod]
@@ -161,8 +173,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -192,8 +206,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -229,8 +245,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -266,8 +284,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -300,6 +320,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
         }
 
         [TestMethod]
@@ -332,6 +355,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
         }
 
         [TestMethod]
@@ -370,6 +396,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
         }
 
         [TestMethod]
@@ -408,6 +437,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
         }
 
         [TestMethod]
@@ -441,8 +473,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -476,8 +510,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -517,8 +553,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -558,8 +596,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         #endregion
@@ -592,6 +632,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
         }
 
         [TestMethod]
@@ -620,6 +663,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
         }
 
         [TestMethod]
@@ -654,6 +700,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
         }
 
         [TestMethod]
@@ -688,6 +737,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
         }
 
         [TestMethod]
@@ -717,8 +769,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -748,8 +802,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -785,8 +841,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -822,8 +880,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -862,6 +922,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
         }
 
         [TestMethod]
@@ -900,6 +963,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
         }
 
         [TestMethod]
@@ -944,6 +1010,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
         }
 
         [TestMethod]
@@ -988,6 +1057,9 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
         }
 
         [TestMethod]
@@ -1027,8 +1099,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -1068,8 +1142,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -1115,8 +1191,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -1162,8 +1240,10 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         #endregion
@@ -1187,15 +1267,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
             {
@@ -1220,15 +1304,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
             {
@@ -1254,20 +1342,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
             {
@@ -1293,20 +1385,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
             {
@@ -1334,16 +1430,18 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
             {
@@ -1371,16 +1469,18 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
             {
@@ -1409,21 +1509,23 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
             {
@@ -1452,21 +1554,23 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
             {
@@ -1491,15 +1595,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
             {
@@ -1525,15 +1633,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
             {
@@ -1560,20 +1672,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
             {
@@ -1600,20 +1716,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
             {
@@ -1642,16 +1762,18 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
             {
@@ -1680,16 +1802,18 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
             {
@@ -1719,21 +1843,23 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, TimeSpan> d, out string x)
             {
@@ -1763,21 +1889,23 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
 
             static bool TryInvoke(Func<string> f, CancellationToken t, int n, ResultHandler<string> r, ExceptionHandler e, Func<int, string, Exception?, TimeSpan> d, out string x)
             {
@@ -1808,15 +1936,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
         }
 
         [TestMethod]
@@ -1837,15 +1969,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
         }
 
         [TestMethod]
@@ -1867,20 +2003,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
         }
 
         [TestMethod]
@@ -1902,20 +2042,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
         }
 
         [TestMethod]
@@ -1939,16 +2083,18 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -1972,16 +2118,18 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -2006,21 +2154,23 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -2045,21 +2195,23 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -2090,15 +2242,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
         }
 
         [TestMethod]
@@ -2129,15 +2285,19 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
         }
 
         [TestMethod]
@@ -2169,20 +2329,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
         }
 
         [TestMethod]
@@ -2214,20 +2378,24 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
+            Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
         }
 
         [TestMethod]
@@ -2261,16 +2429,18 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -2304,16 +2474,18 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), false);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.OnlyExceptionAsc<string>(t), false);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         [TestMethod]
@@ -2348,21 +2520,23 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc());
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, TimeSpan>(i => t), (d, r, t) => d.Invoking += Expect.Asc(), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, TimeSpan>(i => t),  d        => d.Invoking += Expect.Nothing<int>());
         }
 
         [TestMethod]
@@ -2397,21 +2571,23 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<int, string, Exception?, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>(), true);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t));
 
             // Failure (Exception)
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t), (d, r, t) => d.Invoking += Expect.AlternatingAsc(r, t), true);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<int, string, Exception?, TimeSpan>((i, r, e) => t),  d        => d.Invoking += Expect.Nothing<int, string, Exception?>());
         }
 
         #endregion

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/Func.Extensions.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/Func.Extensions.Test.t4
@@ -149,6 +149,7 @@ namespace Sweetener.Reliability.Test
 #>
 
             // Cancel
+            WithRetry<#= suffix #>_Canceled      (funcFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke);
             WithRetry<#= suffix #>_Canceled_Func (funcFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.<#= delayHandlerExpectation #>, passResultHandler: <#= passResultHandler.ToString().ToLowerInvariant() #>);
             WithRetry<#= suffix #>_Canceled_Delay(funcFactory, delayHandlerFactory, with<#= optionalAsync #>Retry, invoke, observeFuncDelay, (d, r, e) => d.Invoking += Expect.<#= delayHandlerExpectation #>, passResultHandler: <#= passResultHandler.ToString().ToLowerInvariant() #>);
 <#

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/ReliableFunc.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/ReliableFunc.Test.t4
@@ -294,6 +294,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f<#= optionalComma #><#= arguments #>, t) => f.Invoke(<#= arguments #><#= optionalComma #>t), addEventHandlers);
                     Invoke_Canceled_Func ((f<#= optionalComma #><#= arguments #>, t) => f.Invoke(<#= arguments #><#= optionalComma #>t), addEventHandlers);
                     Invoke_Canceled_Delay((f<#= optionalComma #><#= arguments #>, t) => f.Invoke(<#= arguments #><#= optionalComma #>t), addEventHandlers);
                 }
@@ -349,6 +350,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f<#= optionalComma #><#= arguments #>, t) => f.InvokeAsync(<#= arguments #><#= optionalComma #>t).Wait(), addEventHandlers);
 <#
         if (async)
         {
@@ -426,6 +428,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f<#= optionalComma #><#= arguments #>, t) => f.TryInvoke(<#= arguments #><#= optionalComma #>t, out string _), addEventHandlers);
                     Invoke_Canceled_Func ((f<#= optionalComma #><#= arguments #>, t) => f.TryInvoke(<#= arguments #><#= optionalComma #>t, out string _), addEventHandlers);
                     Invoke_Canceled_Delay((f<#= optionalComma #><#= arguments #>, t) => f.TryInvoke(<#= arguments #><#= optionalComma #>t, out string _), addEventHandlers);
                 }
@@ -512,6 +515,7 @@ namespace Sweetener.Reliability.Test
 
                 if (passToken)
                 {
+                    Invoke_Canceled      ((f<#= optionalComma #><#= arguments #>, t) => f.TryInvokeAsync(<#= arguments #><#= optionalComma #>t).Wait(), addEventHandlers);
 <#
         if (async)
         {
@@ -1113,13 +1117,67 @@ namespace Sweetener.Reliability.Test
 
         #endregion
 
+        #region Invoke_Canceled
+
+        private void Invoke_Canceled(Action<Reliable<#= optionalAsync #>Func<<#= typeArguments #>><#= optionalComma #><#= inputTypeArguments #>, CancellationToken> invoke, bool addEventHandlers)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            // Create an unused user-defined function
+            FuncProxy<#= tokenInputFuncTypeArguments #> func = new FuncProxy<#= tokenInputFuncTypeArguments #>(
+                (<#= arguments #><#= optionalComma #>token) => throw new InvalidOperationException());
+
+            // Declare the various proxies for the input delegates and event handlers
+            FuncProxy<string, ResultKind>                 resultHandler    = new FuncProxy<string, ResultKind>(ResultPolicy.Default<string>().Invoke);
+            FuncProxy<Exception, bool>                    exceptionHandler = new FuncProxy<Exception, bool>(ExceptionPolicy.Transient.Invoke);
+            FuncProxy<int, string?, Exception?, TimeSpan> delayHandler     = new FuncProxy<int, string?, Exception?, TimeSpan>((i, r, e) => TimeSpan.Zero);
+
+            ActionProxy<int, string?, Exception?> retryHandler     = new ActionProxy<int, string?, Exception?>();
+            ActionProxy<string?, Exception?>      failedHandler    = new ActionProxy<string?, Exception?>();
+            ActionProxy<string?, Exception?>      exhaustedHandler = new ActionProxy<string?, Exception?>();
+
+            // Create Reliable<#= optionalAsync #>Func
+            Reliable<#= optionalAsync #>Func<<#= typeArguments #>> reliableFunc = new Reliable<#= optionalAsync #>Func<<#= typeArguments #>>(
+                func.Invoke,
+                Retries.Infinite, // Exception, Result, Exception, ...
+                resultHandler   .Invoke,
+                exceptionHandler.Invoke,
+                delayHandler    .Invoke);
+
+            if (addEventHandlers)
+            {
+                reliableFunc.Retrying         += retryHandler    .Invoke;
+                reliableFunc.Failed           += failedHandler   .Invoke;
+                reliableFunc.RetriesExhausted += exhaustedHandler.Invoke;
+            }
+
+            // Invoke, retry, and cancel
+            Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc<#= optionalComma #><#= argumentValues #>, tokenSource.Token), allowedDerivedTypes: true);
+
+            // Validate the number of calls
+            Assert.AreEqual(0, func            .Calls);
+            Assert.AreEqual(0, resultHandler   .Calls);
+            Assert.AreEqual(0, exceptionHandler.Calls);
+            Assert.AreEqual(0, delayHandler    .Calls);
+
+            if (addEventHandlers)
+            {
+                Assert.AreEqual(0, retryHandler    .Calls);
+                Assert.AreEqual(0, failedHandler   .Calls);
+                Assert.AreEqual(0, exhaustedHandler.Calls);
+            }
+        }
+
+        #endregion
+
         #region Invoke_Canceled_Func
 
         private void Invoke_Canceled_Func(Action<Reliable<#= optionalAsync #>Func<<#= typeArguments #>><#= optionalComma #><#= inputTypeArguments #>, CancellationToken> invoke, bool addEventHandlers<#= async ? ", bool useSynchronousFunc" : string.Empty #>)
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
 <#
         if (async)
@@ -1198,10 +1256,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc<#= optionalComma #><#= argumentValues #>, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(1, exceptionHandler .Calls);
-            Assert.AreEqual(2, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(1, exceptionHandler.Calls);
+            Assert.AreEqual(2, delayHandler    .Calls);
 
             if (addEventHandlers)
             {
@@ -1219,7 +1277,7 @@ namespace Sweetener.Reliability.Test
         {
             using CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            // Create a user-defined action that will throw an exception depending on whether its canceled
+            // Create a user-defined function that will throw an exception depending on whether its canceled
             Func<string> flakyFunc = FlakyFunc.Create<string, IOException>("Retry");
             FuncProxy<#= inputFuncTypeArguments #> func = new FuncProxy<#= inputFuncTypeArguments #>(<#= GetExpressionDelegate(parameterCount, "flakyFunc()", async) #>);
 
@@ -1280,10 +1338,10 @@ namespace Sweetener.Reliability.Test
             Assert.That.ThrowsException<OperationCanceledException>(() => invoke(reliableFunc<#= optionalComma #><#= argumentValues #>, tokenSource.Token), allowedDerivedTypes: true);
 
             // Validate the number of calls
-            Assert.AreEqual(3, func             .Calls);
-            Assert.AreEqual(1, resultHandler    .Calls);
-            Assert.AreEqual(2, exceptionHandler .Calls);
-            Assert.AreEqual(3, delayHandler     .Calls);
+            Assert.AreEqual(3, func            .Calls);
+            Assert.AreEqual(1, resultHandler   .Calls);
+            Assert.AreEqual(2, exceptionHandler.Calls);
+            Assert.AreEqual(3, delayHandler    .Calls);
 
             if (addEventHandlers)
             {

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/Reliably.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/Reliably.Test.t4
@@ -517,7 +517,7 @@ namespace Sweetener.Reliability.Test
                     {
 #>
             <#= inputFuncType #> nullTaskFunc = <#= stateful ? "s" : "()" #> => null;
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.InvokeAsync<#= optionalCtorTypeArgs #>(nullTaskFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => Reliably.TryInvokeAsync<#= optionalCtorTypeArgs #>(nullTaskFunc<#= optionalStateObj #><#= optionalTokenObj #>, 10<#= optionalResultPolicyObj #>, ExceptionPolicy.Transient, <#= noDelay #>)).ConfigureAwait(false);
 
 <#
                     }

--- a/src/Sweetener.Reliability.Test/Func/TextTemplating/Reliably.Test.t4
+++ b/src/Sweetener.Reliability.Test/Func/TextTemplating/Reliably.Test.t4
@@ -33,11 +33,11 @@ namespace Sweetener.Reliability.Test
             string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
             string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
-            foreach (bool interruptable in new bool[2] { false, true })
+            foreach (bool passToken in new bool[2] { false, true })
             {
-                string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
-                string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
-                string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+                string optionalTokenObj    = passToken ? ", CancellationToken.None" : string.Empty;
+                string optionalTokenArg    = passToken ? ", t"                      : string.Empty;
+                string optionalTokenSuffix = passToken ? "_Interruptable"           : string.Empty;
 
                 foreach (bool includeResultPolicy in new bool[2] { false, true })
                 {
@@ -121,13 +121,15 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
 <#
-                        if (interruptable)
+                        if (passToken)
                         {
 #>
-
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
 <#
                         }
 #>
@@ -156,11 +158,11 @@ namespace Sweetener.Reliability.Test
         string optionalStateArg       = stateful ? ", state"          : string.Empty;
         string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
-        foreach (bool interruptable in new bool[2] { false, true })
+        foreach (bool passToken in new bool[2] { false, true })
         {
-            string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
-            string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
-            string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+            string optionalTokenObj    = passToken ? ", CancellationToken.None" : string.Empty;
+            string optionalTokenArg    = passToken ? ", t"                      : string.Empty;
+            string optionalTokenSuffix = passToken ? "_Interruptable"           : string.Empty;
 
             foreach (bool includeResultPolicy in new bool[2] { false, true })
             {
@@ -290,13 +292,22 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
             Invoke_Func_EventualFailure_Exception (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
             Invoke_Func_RetriesExhausted_Exception(assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
 <#
-                    if (interruptable)
+                    if (passToken)
                     {
 #>
+            Invoke_Func_Canceled_Delay            (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Canceled                  (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+<#
+                    }
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+                    if (async)
+                    {
+#>
+            Invoke_Func_Canceled_NoTask           (assertError , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
 <#
                     }
 #>
@@ -324,11 +335,11 @@ namespace Sweetener.Reliability.Test
             string optionalStateObj       = stateful ? ", new object()"   : string.Empty;
             string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
-            foreach (bool interruptable in new bool[2] { false, true })
+            foreach (bool passToken in new bool[2] { false, true })
             {
-                string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
-                string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
-                string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+                string optionalTokenObj    = passToken ? ", CancellationToken.None" : string.Empty;
+                string optionalTokenArg    = passToken ? ", t"                      : string.Empty;
+                string optionalTokenSuffix = passToken ? "_Interruptable"           : string.Empty;
 
                 foreach (bool includeResultPolicy in new bool[2] { false, true })
                 {
@@ -374,27 +385,20 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue (TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(x      , a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => { Assert.IsFalse(TryInvoke(f, t, n, r, e, d, out string a)); Assert.AreEqual(default, a); };
-<#
-                        if (interruptable)
-                        {
-#>
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsException(() => TryInvoke(f, t, n, r, e, d, out string _), x);
-<#
-                        }
-#>
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>(), <#= passResultPolicy #>);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>(), <#= passResultPolicy #>);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
 <#
                         if (includeResultPolicy)
                         {
 #>
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
 <#
                         }
 #>
@@ -403,13 +407,15 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
 <#
-                        if (interruptable)
+                        if (passToken)
                         {
 #>
-
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
 <#
                         }
 #>
@@ -457,11 +463,11 @@ namespace Sweetener.Reliability.Test
         string optionalStateArg       = stateful ? ", state"          : string.Empty;
         string optionalStatefulSuffix = stateful ? "_Stateful"        : string.Empty;
 
-        foreach (bool interruptable in new bool[2] { false, true })
+        foreach (bool passToken in new bool[2] { false, true })
         {
-            string optionalTokenObj    = interruptable ? ", CancellationToken.None" : string.Empty;
-            string optionalTokenArg    = interruptable ? ", t"                      : string.Empty;
-            string optionalTokenSuffix = interruptable ? "_Interruptable"           : string.Empty;
+            string optionalTokenObj    = passToken ? ", CancellationToken.None" : string.Empty;
+            string optionalTokenArg    = passToken ? ", t"                      : string.Empty;
+            string optionalTokenSuffix = passToken ? "_Interruptable"           : string.Empty;
 
             foreach (bool includeResultPolicy in new bool[2] { false, true })
             {
@@ -571,27 +577,20 @@ namespace Sweetener.Reliability.Test
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> assertSuccess          = (f, t, n, r, e, d, x) => { Assert.IsTrue(tryInvoke(f, t, n, r, e, d).Result.TryGetValue(out string? actual)); Assert.AreEqual(x, actual); };
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, string> assertFailureResult    = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type>   assertFailureException = (f, t, n, r, e, d, x) => Assert.IsFalse(tryInvoke(f, t, n, r, e, d).Result.HasValue);
-<#
-                    if (interruptable)
-                    {
-#>
             Action<Func<string>, CancellationToken, int, ResultHandler<string>, ExceptionHandler, Func<<#= delayInputTypeParam #>, TimeSpan>, Type>   assertError            = (f, t, n, r, e, d, x) => Assert.That.ThrowsExceptionAsync(() => tryInvoke(f, t, n, r, e, d), x).Wait();
-<#
-                    }
-#>
 
             // Success
-            Invoke_Func_Success                   (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>(), <#= passResultPolicy #>);
-            Invoke_Func_EventualSuccess           (assertSuccess, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Success                   (assertSuccess         , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>(), <#= passResultPolicy #>);
+            Invoke_Func_EventualSuccess           (assertSuccess         , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
 <#
                     if (includeResultPolicy)
                     {
 #>
 
             // Failure (Result)
-            Invoke_Func_Failure_Result            (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
-            Invoke_Func_EventualFailure_Result    (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
-            Invoke_Func_RetriesExhausted_Result   (assertFailureResult, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Func_Failure_Result            (assertFailureResult   , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+            Invoke_Func_EventualFailure_Result    (assertFailureResult   , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
+            Invoke_Func_RetriesExhausted_Result   (assertFailureResult   , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>);
 <#
                     }
 #>
@@ -600,13 +599,22 @@ namespace Sweetener.Reliability.Test
             Invoke_Func_Failure_Exception         (assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
             Invoke_Func_EventualFailure_Exception (assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
             Invoke_Func_RetriesExhausted_Exception(assertFailureException, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+
+            // Cancellation
+            Invoke_Func_Canceled_Delegate         (assertError           , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
 <#
-                    if (interruptable)
+                    if (passToken)
                     {
 #>
+            Invoke_Func_Canceled_Delay            (assertError           , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+            Invoke_Func_Canceled                  (assertError           , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
+<#
+                    }
 
-            Invoke_Func_Canceled_Delegate(assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
-            Invoke_Func_Canceled_Delay   (assertError, t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t), (d, r, t) => d.Invoking += Expect.<#= delayCallExpectation #>, <#= passResultPolicy #>);
+                    if (async)
+                    {
+#>
+            Invoke_Func_Canceled_NoTask           (assertError           , t => new FuncProxy<<#= delayInputTypeParam #>, TimeSpan>(<#= delayInputArgs #> => t),  d        => d.Invoking += Expect.Nothing<<#= delayInputTypeParam #>>());
 <#
                     }
 #>

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T1.cs
@@ -149,9 +149,13 @@ namespace Sweetener.Reliability
                     action(arg, cancellationToken);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T1.cs
@@ -136,6 +136,9 @@ namespace Sweetener.Reliability
 
             return (arg, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T2.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T2.cs
@@ -153,9 +153,13 @@ namespace Sweetener.Reliability
                     action(arg1, arg2, cancellationToken);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T2.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T2.cs
@@ -140,6 +140,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T3.cs
@@ -144,6 +144,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T3.cs
@@ -157,9 +157,13 @@ namespace Sweetener.Reliability
                     action(arg1, arg2, arg3, cancellationToken);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T4.cs
@@ -161,9 +161,13 @@ namespace Sweetener.Reliability
                     action(arg1, arg2, arg3, arg4, cancellationToken);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T4.cs
@@ -148,6 +148,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T5.cs
@@ -165,9 +165,13 @@ namespace Sweetener.Reliability
                     action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T5.cs
@@ -152,6 +152,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T6.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T6.cs
@@ -156,6 +156,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T6.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T6.cs
@@ -169,9 +169,13 @@ namespace Sweetener.Reliability
                     action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T7.cs
@@ -173,9 +173,13 @@ namespace Sweetener.Reliability
                     action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T7.cs
@@ -160,6 +160,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T8.cs
@@ -177,9 +177,13 @@ namespace Sweetener.Reliability
                     action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Action/Action.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.T8.cs
@@ -164,6 +164,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/Action.Extensions.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.cs
@@ -148,9 +148,13 @@ namespace Sweetener.Reliability
                     action(cancellationToken);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Action/Action.Extensions.cs
+++ b/src/Sweetener.Reliability/Action/Action.Extensions.cs
@@ -135,6 +135,9 @@ namespace Sweetener.Reliability
 
             return (cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T1.cs
@@ -160,6 +160,9 @@ namespace Sweetener.Reliability
 
             return async (arg, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T1.cs
@@ -71,12 +71,11 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg);
+                    Task t = action(arg);
                     if (t == null)
                         goto Invalid;
 
@@ -166,22 +165,24 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg, cancellationToken);
+                    Task t = action(arg, cancellationToken);
                     if (t == null)
                         goto Invalid;
 
                     await t.ConfigureAwait(false);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T2.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T2.cs
@@ -164,6 +164,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T2.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T2.cs
@@ -73,12 +73,11 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2);
+                    Task t = action(arg1, arg2);
                     if (t == null)
                         goto Invalid;
 
@@ -170,22 +169,24 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, cancellationToken);
+                    Task t = action(arg1, arg2, cancellationToken);
                     if (t == null)
                         goto Invalid;
 
                     await t.ConfigureAwait(false);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T3.cs
@@ -168,6 +168,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T3.cs
@@ -75,12 +75,11 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3);
+                    Task t = action(arg1, arg2, arg3);
                     if (t == null)
                         goto Invalid;
 
@@ -174,22 +173,24 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, cancellationToken);
+                    Task t = action(arg1, arg2, arg3, cancellationToken);
                     if (t == null)
                         goto Invalid;
 
                     await t.ConfigureAwait(false);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T4.cs
@@ -77,12 +77,11 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, arg4);
+                    Task t = action(arg1, arg2, arg3, arg4);
                     if (t == null)
                         goto Invalid;
 
@@ -178,22 +177,24 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, arg4, cancellationToken);
+                    Task t = action(arg1, arg2, arg3, arg4, cancellationToken);
                     if (t == null)
                         goto Invalid;
 
                     await t.ConfigureAwait(false);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T4.cs
@@ -172,6 +172,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T5.cs
@@ -79,12 +79,11 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, arg4, arg5);
+                    Task t = action(arg1, arg2, arg3, arg4, arg5);
                     if (t == null)
                         goto Invalid;
 
@@ -182,22 +181,24 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
+                    Task t = action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
                     if (t == null)
                         goto Invalid;
 
                     await t.ConfigureAwait(false);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T5.cs
@@ -176,6 +176,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T6.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T6.cs
@@ -180,6 +180,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T6.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T6.cs
@@ -81,12 +81,11 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, arg4, arg5, arg6);
+                    Task t = action(arg1, arg2, arg3, arg4, arg5, arg6);
                     if (t == null)
                         goto Invalid;
 
@@ -186,22 +185,24 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
+                    Task t = action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
                     if (t == null)
                         goto Invalid;
 
                     await t.ConfigureAwait(false);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T7.cs
@@ -184,6 +184,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T7.cs
@@ -83,12 +83,11 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+                    Task t = action(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
                     if (t == null)
                         goto Invalid;
 
@@ -190,22 +189,24 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
+                    Task t = action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
                     if (t == null)
                         goto Invalid;
 
                     await t.ConfigureAwait(false);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T8.cs
@@ -85,12 +85,11 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+                    Task t = action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
                     if (t == null)
                         goto Invalid;
 
@@ -194,22 +193,24 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
+                    Task t = action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
                     if (t == null)
                         goto Invalid;
 
                     await t.ConfigureAwait(false);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.T8.cs
@@ -188,6 +188,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.cs
@@ -159,6 +159,9 @@ namespace Sweetener.Reliability
 
             return async (cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/AsyncAction.Extensions.cs
+++ b/src/Sweetener.Reliability/Action/AsyncAction.Extensions.cs
@@ -72,12 +72,11 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action();
+                    Task t = action();
                     if (t == null)
                         goto Invalid;
 
@@ -165,22 +164,24 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-                Task? t = null;
                 attempt++;
 
                 try
                 {
-                    t = action(cancellationToken);
+                    Task t = action(cancellationToken);
                     if (t == null)
                         goto Invalid;
 
                     await t.ConfigureAwait(false);
                     return;
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Action/ReliableAction.T1.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T1.cs
@@ -125,9 +125,13 @@ namespace Sweetener.Reliability
             {
                 _action(arg, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -175,9 +179,13 @@ namespace Sweetener.Reliability
                 _action(arg, cancellationToken);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -210,6 +218,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T arg, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -225,11 +234,12 @@ namespace Sweetener.Reliability
                 _action(arg, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     return false;
 
@@ -265,6 +275,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -280,11 +291,12 @@ namespace Sweetener.Reliability
                 _action(arg, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAction.T1.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T1.cs
@@ -113,6 +113,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public void Invoke(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -159,6 +162,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -206,6 +212,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -258,6 +267,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Action/ReliableAction.T1.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T1.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -218,7 +219,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T arg, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -275,7 +276,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAction.T2.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T2.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -225,7 +226,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -284,7 +285,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAction.T2.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T2.cs
@@ -116,6 +116,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public void Invoke(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -164,6 +167,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -213,6 +219,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -267,6 +276,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Action/ReliableAction.T2.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T2.cs
@@ -128,9 +128,13 @@ namespace Sweetener.Reliability
             {
                 _action(arg1, arg2, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -180,9 +184,13 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, cancellationToken);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -217,6 +225,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -232,11 +241,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     return false;
 
@@ -274,6 +284,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -289,11 +300,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAction.T3.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T3.cs
@@ -131,9 +131,13 @@ namespace Sweetener.Reliability
             {
                 _action(arg1, arg2, arg3, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -185,9 +189,13 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, cancellationToken);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -224,6 +232,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -239,11 +248,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     return false;
 
@@ -283,6 +293,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -298,11 +309,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAction.T3.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T3.cs
@@ -119,6 +119,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public void Invoke(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -169,6 +172,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -220,6 +226,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -276,6 +285,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Action/ReliableAction.T3.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T3.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -232,7 +233,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -293,7 +294,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAction.T4.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T4.cs
@@ -122,6 +122,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -174,6 +177,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -227,6 +233,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -285,6 +294,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Action/ReliableAction.T4.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T4.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -239,7 +240,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -302,7 +303,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAction.T4.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T4.cs
@@ -134,9 +134,13 @@ namespace Sweetener.Reliability
             {
                 _action(arg1, arg2, arg3, arg4, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -190,9 +194,13 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, cancellationToken);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -231,6 +239,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -246,11 +255,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     return false;
 
@@ -292,6 +302,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -307,11 +318,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAction.T5.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T5.cs
@@ -137,9 +137,13 @@ namespace Sweetener.Reliability
             {
                 _action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -195,9 +199,13 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -238,6 +246,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -253,11 +262,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     return false;
 
@@ -301,6 +311,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -316,11 +327,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAction.T5.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T5.cs
@@ -125,6 +125,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -179,6 +182,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -234,6 +240,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -294,6 +303,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Action/ReliableAction.T5.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T5.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -246,7 +247,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -311,7 +312,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAction.T6.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T6.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -253,7 +254,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -320,7 +321,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAction.T6.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T6.cs
@@ -140,9 +140,13 @@ namespace Sweetener.Reliability
             {
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -200,9 +204,13 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -245,6 +253,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -260,11 +269,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     return false;
 
@@ -310,6 +320,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -325,11 +336,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAction.T6.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T6.cs
@@ -128,6 +128,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -184,6 +187,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -241,6 +247,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -303,6 +312,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Action/ReliableAction.T7.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T7.cs
@@ -143,9 +143,13 @@ namespace Sweetener.Reliability
             {
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -205,9 +209,13 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -252,6 +260,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -267,11 +276,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     return false;
 
@@ -319,6 +329,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -334,11 +345,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAction.T7.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T7.cs
@@ -131,6 +131,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -189,6 +192,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -248,6 +254,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -312,6 +321,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Action/ReliableAction.T7.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T7.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -260,7 +261,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -329,7 +330,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAction.T8.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T8.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -267,7 +268,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -338,7 +339,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAction.T8.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T8.cs
@@ -134,6 +134,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -194,6 +197,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -255,6 +261,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -321,6 +330,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Action/ReliableAction.T8.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.T8.cs
@@ -146,9 +146,13 @@ namespace Sweetener.Reliability
             {
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -210,9 +214,13 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -259,6 +267,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -274,11 +283,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     return false;
 
@@ -328,6 +338,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -343,11 +354,12 @@ namespace Sweetener.Reliability
                 _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAction.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -211,7 +212,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -266,7 +267,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAction.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.cs
@@ -110,6 +110,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public void Invoke(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -154,6 +157,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -199,6 +205,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -249,6 +258,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Action/ReliableAction.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAction.cs
@@ -122,9 +122,13 @@ namespace Sweetener.Reliability
             {
                 _action(cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -170,9 +174,13 @@ namespace Sweetener.Reliability
                 _action(cancellationToken);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -203,6 +211,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -218,11 +227,12 @@ namespace Sweetener.Reliability
                 _action(cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     return false;
 
@@ -256,6 +266,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -271,11 +282,12 @@ namespace Sweetener.Reliability
                 _action(cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T1.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T1.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -188,7 +189,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T1.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T1.cs
@@ -124,26 +124,27 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg, cancellationToken);
+                Task t = _action(arg, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -187,32 +188,32 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg, cancellationToken);
+                Task t = _action(arg, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T1.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T1.cs
@@ -121,6 +121,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -186,6 +189,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T2.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T2.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -193,7 +194,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T2.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T2.cs
@@ -124,6 +124,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -191,6 +194,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T2.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T2.cs
@@ -127,26 +127,27 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, cancellationToken);
+                Task t = _action(arg1, arg2, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -192,32 +193,32 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, cancellationToken);
+                Task t = _action(arg1, arg2, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T3.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T3.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -198,7 +199,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T3.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T3.cs
@@ -127,6 +127,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -196,6 +199,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T3.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T3.cs
@@ -130,26 +130,27 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -197,32 +198,32 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T4.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T4.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -203,7 +204,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T4.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T4.cs
@@ -133,26 +133,27 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, arg4, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, arg4, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -202,32 +203,32 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, arg4, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, arg4, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T4.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T4.cs
@@ -130,6 +130,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -201,6 +204,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T5.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T5.cs
@@ -136,26 +136,27 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -207,32 +208,32 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, arg4, arg5, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T5.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T5.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -208,7 +209,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T5.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T5.cs
@@ -133,6 +133,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -206,6 +209,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T6.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T6.cs
@@ -139,26 +139,27 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -212,32 +213,32 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T6.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T6.cs
@@ -136,6 +136,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -211,6 +214,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T6.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T6.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -213,7 +214,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T7.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T7.cs
@@ -142,26 +142,27 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -217,32 +218,32 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T7.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T7.cs
@@ -139,6 +139,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -216,6 +219,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T7.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T7.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -218,7 +219,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T8.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T8.cs
@@ -145,26 +145,27 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -222,32 +223,32 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
+                Task t = _action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T8.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T8.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -223,7 +224,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.T8.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.T8.cs
@@ -142,6 +142,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -221,6 +224,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.cs
@@ -121,26 +121,27 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(cancellationToken);
+                Task t = _action(cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -182,32 +183,32 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
             attempt++;
 
             try
             {
-                t = _action(cancellationToken);
+                Task t = _action(cancellationToken);
                 if (t == null)
                     goto Invalid;
 
                 await t.ConfigureAwait(false);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.cs
@@ -118,6 +118,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -181,6 +184,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Action/ReliableAsyncAction.cs
+++ b/src/Sweetener.Reliability/Action/ReliableAsyncAction.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncAction.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -183,7 +184,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/Reliably.Async.cs
+++ b/src/Sweetener.Reliability/Action/Reliably.Async.cs
@@ -103,6 +103,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -120,7 +123,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
                 if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
@@ -233,6 +236,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -250,7 +256,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
                 if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
@@ -369,6 +375,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -387,7 +396,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
                 if (isCanceled)
                     throw;
 
@@ -513,6 +522,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task? t;
             int attempt = 0;
 
@@ -531,7 +543,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
                 if (isCanceled)
                     throw;
 

--- a/src/Sweetener.Reliability/Action/Reliably.cs
+++ b/src/Sweetener.Reliability/Action/Reliably.cs
@@ -101,6 +101,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -112,7 +115,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
@@ -219,6 +222,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -230,7 +236,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
@@ -335,6 +341,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -346,7 +355,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
@@ -455,6 +464,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -466,7 +478,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
@@ -581,6 +593,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -593,7 +608,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
+                if (e is OperationCanceledException)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
@@ -715,6 +730,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -727,7 +745,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
+                if (e is OperationCanceledException)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
@@ -845,6 +863,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -857,7 +878,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
+                if (e is OperationCanceledException)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
@@ -979,6 +1000,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -991,7 +1015,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
+                if (e is OperationCanceledException)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))

--- a/src/Sweetener.Reliability/Action/Reliably.cs
+++ b/src/Sweetener.Reliability/Action/Reliably.cs
@@ -113,9 +113,13 @@ namespace Sweetener.Reliability
             {
                 action();
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
@@ -234,9 +238,13 @@ namespace Sweetener.Reliability
             {
                 action(state);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
@@ -353,9 +361,13 @@ namespace Sweetener.Reliability
             {
                 action();
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
@@ -476,9 +488,13 @@ namespace Sweetener.Reliability
             {
                 action(state);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
@@ -578,6 +594,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static bool TryInvoke(Action action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
@@ -606,11 +623,12 @@ namespace Sweetener.Reliability
                 action();
                 return true;
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     return false;
 
@@ -715,6 +733,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static bool TryInvoke<TState>(Action<TState> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
@@ -743,11 +762,12 @@ namespace Sweetener.Reliability
                 action(state);
                 return true;
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     return false;
 
@@ -848,6 +868,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static async Task<bool> TryInvokeAsync(Action action, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
@@ -876,11 +897,12 @@ namespace Sweetener.Reliability
                 action();
                 return true;
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     return false;
 
@@ -985,6 +1007,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static async Task<bool> TryInvokeAsync<TState>(Action<TState> action, TState state, CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
@@ -1013,11 +1036,12 @@ namespace Sweetener.Reliability
                 action(state);
                 return true;
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/TextTemplating/Action.Extensions.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/Action.Extensions.t4
@@ -98,6 +98,16 @@ namespace Sweetener.Reliability
 
             return <#= async ? "async " : string.Empty #>(<#= arguments #><#= interruptable ? optionalComma + "cancellationToken" : string.Empty #>) =>
             {
+<#
+            if (interruptable)
+            {
+#>
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
+<#
+            }
+#>
                 int attempt = 0;
 
             Attempt:

--- a/src/Sweetener.Reliability/Action/TextTemplating/Action.Extensions.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/Action.Extensions.t4
@@ -40,9 +40,8 @@ namespace Sweetener.Reliability
 <#
         foreach (bool interruptable in new bool[] { false, true })
         {
-            string inputActionType           = (async ? "Func" : "Action") + Enclose(GetActionTypeParameters(parameterCount, async, interruptable), BracketType.AngleBrackets);
-            string optionalCancellationCheck = interruptable ? (async ? "isCanceled" : "e.IsCancellation(cancellationToken)") + " || " : string.Empty;
-            string asyncOperationSuffx       = async ? ".ConfigureAwait(false)" : ".Wait(" + (interruptable ? "cancellationToken" : string.Empty) + ")";
+            string inputActionType     = (async ? "Func" : "Action") + Enclose(GetActionTypeParameters(parameterCount, async, interruptable), BracketType.AngleBrackets);
+            string asyncOperationSuffx = async ? ".ConfigureAwait(false)" : ".Wait(" + (interruptable ? "cancellationToken" : string.Empty) + ")";
 #>
         #region <#= inputActionType #>
 
@@ -111,14 +110,6 @@ namespace Sweetener.Reliability
                 int attempt = 0;
 
             Attempt:
-<#
-            if (async)
-            {
-#>
-                Task? t = null;
-<#
-            }
-#>
                 attempt++;
 
                 try
@@ -127,7 +118,7 @@ namespace Sweetener.Reliability
             if (async)
             {
 #>
-                    t = action(<#= arguments #><#= interruptable ? optionalComma + "cancellationToken" : string.Empty #>);
+                    Task t = action(<#= arguments #><#= interruptable ? optionalComma + "cancellationToken" : string.Empty #>);
                     if (t == null)
                         goto Invalid;
 
@@ -143,17 +134,20 @@ namespace Sweetener.Reliability
 #>
                     return;
                 }
+<#
+            if (interruptable)
+            {
+#>
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
+<#
+            }
+#>
                 catch (Exception e)
                 {
-<#
-        if (async && interruptable)
-        {
-#>
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-<#
-        }
-#>
-                    if (<#= optionalCancellationCheck #>!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     <#= async ? "await " : string.Empty #>Task.Delay(delayHandler(attempt, e)<#= interruptable ? ", cancellationToken" : string.Empty #>)<#= asyncOperationSuffx #>;

--- a/src/Sweetener.Reliability/Action/TextTemplating/ReliableAction.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/ReliableAction.t4
@@ -131,9 +131,13 @@ namespace Sweetener.Reliability
             {
                 _action(<#= arguments #><#= optionalComma #>cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry<#= optionalAsync #>(attempt, e, cancellationToken))
+                if (!CanRetry<#= optionalAsync #>(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -208,25 +212,9 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-<#
-        if (async)
-        {
-#>
-            Task? t;
-<#
-        }
-#>
             int attempt = 0;
 
         Attempt:
-<#
-        if (async)
-        {
-#>
-            t = null;
-<#
-        }
-#>
             attempt++;
 
             try
@@ -235,7 +223,7 @@ namespace Sweetener.Reliability
         if (async)
         {
 #>
-                t = _action(<#= arguments #><#= optionalComma #>cancellationToken);
+                Task t = _action(<#= arguments #><#= optionalComma #>cancellationToken);
                 if (t == null)
                     goto Invalid;
 
@@ -251,17 +239,13 @@ namespace Sweetener.Reliability
 #>
                 return;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-<#
-        if (async)
-        {
-#>
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-<#
-        }
-#>
-                if (<#= async ? "isCanceled" : "e.IsCancellation(cancellationToken)" #> || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -312,6 +296,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -327,11 +312,12 @@ namespace Sweetener.Reliability
                 _action(<#= arguments #><#= optionalComma #>cancellationToken);
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     return false;
 
@@ -394,30 +380,15 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<bool> TryInvokeAsync(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-<#
-        if (async)
-        {
-#>
-            Task? t;
-<#
-        }
-#>
             int attempt = 0;
 
         Attempt:
-<#
-        if (async)
-        {
-#>
-            t = null;
-<#
-        }
-#>
             attempt++;
 
             try
@@ -426,7 +397,7 @@ namespace Sweetener.Reliability
         if (async)
         {
 #>
-                t = _action(<#= arguments #><#= optionalComma #>cancellationToken);
+                Task t = _action(<#= arguments #><#= optionalComma #>cancellationToken);
                 if (t == null)
                     goto Invalid;
 
@@ -442,11 +413,12 @@ namespace Sweetener.Reliability
 #>
                 return true;
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     return false;
 

--- a/src/Sweetener.Reliability/Action/TextTemplating/ReliableAction.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/ReliableAction.t4
@@ -119,6 +119,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public void Invoke(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -202,6 +205,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task InvokeAsync(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
 <#
         if (async)
         {
@@ -308,6 +314,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -387,6 +396,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<bool> TryInvokeAsync(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
 <#
         if (async)
         {

--- a/src/Sweetener.Reliability/Action/TextTemplating/ReliableAction.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/ReliableAction.t4
@@ -18,6 +18,7 @@
 #>
 // Generated from <#= GetTemplateFileName() #>
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -296,7 +297,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -380,7 +381,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<bool> TryInvokeAsync(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Action/TextTemplating/Reliably.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/Reliably.t4
@@ -13,8 +13,6 @@ namespace Sweetener.Reliability
     static partial class Reliably
     {
 <#
-    string cancellationCheck = async ? "isCanceled" : "e.IsCancellation(cancellationToken)";
-
     if (!async)
     {
 #>
@@ -65,6 +63,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -76,7 +77,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
@@ -139,6 +140,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -180,11 +184,11 @@ namespace Sweetener.Reliability
         if (async)
         {
 #>
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
 <#
         }
 #>
-                if (<#= cancellationCheck #> || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (<#= async ? "isCanceled" : "e is OperationCanceledException" #> || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
@@ -258,6 +262,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -270,7 +277,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
+                if (e is OperationCanceledException)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
@@ -337,6 +344,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
 <#
         if (async)
         {
@@ -386,11 +396,11 @@ namespace Sweetener.Reliability
         if (async)
         {
 #>
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
 <#
         }
 #>
-                if (<#= cancellationCheck #>)
+                if (<#= async ? "isCanceled" : "e is OperationCanceledException" #>)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))

--- a/src/Sweetener.Reliability/Action/TextTemplating/Reliably.t4
+++ b/src/Sweetener.Reliability/Action/TextTemplating/Reliably.t4
@@ -75,9 +75,13 @@ namespace Sweetener.Reliability
             {
                 action(<#= stateful ? "state" : string.Empty #>);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, e), cancellationToken).Wait();
@@ -146,14 +150,6 @@ namespace Sweetener.Reliability
             int attempt = 0;
 
         Attempt:
-<#
-        if (async)
-        {
-#>
-            Task? t = null;
-<#
-        }
-#>
             attempt++;
 
             try
@@ -162,7 +158,7 @@ namespace Sweetener.Reliability
         if (async)
         {
 #>
-                t = action(<#= stateful ? "state" : string.Empty #>);
+                Task t = action(<#= stateful ? "state" : string.Empty #>);
                 if (t == null)
                     goto Invalid;
 
@@ -178,17 +174,13 @@ namespace Sweetener.Reliability
         }
 #>
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-<#
-        if (async)
-        {
-#>
-                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
-<#
-        }
-#>
-                if (<#= async ? "isCanceled" : "e is OperationCanceledException" #> || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, e), cancellationToken).ConfigureAwait(false);
@@ -247,6 +239,7 @@ namespace Sweetener.Reliability
 <#
             PrintReliablyTryInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true);
 #>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static bool TryInvoke<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
@@ -275,11 +268,12 @@ namespace Sweetener.Reliability
                 action(<#= stateful ? "state" : string.Empty #>);
                 return true;
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     return false;
 
@@ -329,6 +323,7 @@ namespace Sweetener.Reliability
 <#
         PrintReliablyTryInvokeActionXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true);
 #>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static async Task<bool> TryInvokeAsync<#= optionalTypeParam #>(<#= inputActionType #> action, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ExceptionHandler exceptionHandler, ComplexDelayHandler delayHandler)
         {
@@ -347,25 +342,9 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-<#
-        if (async)
-        {
-#>
-            Task? t;
-<#
-        }
-#>
             int attempt = 0;
 
         Attempt:
-<#
-        if (async)
-        {
-#>
-            t = null;
-<#
-        }
-#>
             attempt++;
 
             try
@@ -374,7 +353,7 @@ namespace Sweetener.Reliability
         if (async)
         {
 #>
-                t = action(<#= stateful ? "state" : string.Empty #>);
+                Task t = action(<#= stateful ? "state" : string.Empty #>);
                 if (t == null)
                     goto Invalid;
 
@@ -390,19 +369,12 @@ namespace Sweetener.Reliability
 #>
                 return true;
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-<#
-        if (async)
-        {
-#>
-                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
-<#
-        }
-#>
-                if (<#= async ? "isCanceled" : "e is OperationCanceledException" #>)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     return false;
 

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T1.cs
@@ -132,11 +132,10 @@ namespace Sweetener.Reliability
 
             return async () =>
             {
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -296,11 +295,10 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -311,10 +309,13 @@ namespace Sweetener.Reliability
 
                     await t.ConfigureAwait(false);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T1.cs
@@ -293,6 +293,9 @@ namespace Sweetener.Reliability
 
             return async (cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 Task<TResult>? t;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T2.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T2.cs
@@ -298,6 +298,9 @@ namespace Sweetener.Reliability
 
             return async (arg, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 Task<TResult>? t;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T2.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T2.cs
@@ -133,11 +133,10 @@ namespace Sweetener.Reliability
 
             return async (arg) =>
             {
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -301,11 +300,10 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -316,10 +314,13 @@ namespace Sweetener.Reliability
 
                     await t.ConfigureAwait(false);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T3.cs
@@ -306,6 +306,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 Task<TResult>? t;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T3.cs
@@ -137,11 +137,10 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2) =>
             {
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -309,11 +308,10 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -324,10 +322,13 @@ namespace Sweetener.Reliability
 
                     await t.ConfigureAwait(false);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T4.cs
@@ -314,6 +314,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 Task<TResult>? t;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T4.cs
@@ -141,11 +141,10 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3) =>
             {
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -317,11 +316,10 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -332,10 +330,13 @@ namespace Sweetener.Reliability
 
                     await t.ConfigureAwait(false);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T5.cs
@@ -322,6 +322,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 Task<TResult>? t;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T5.cs
@@ -145,11 +145,10 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4) =>
             {
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -325,11 +324,10 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -340,10 +338,13 @@ namespace Sweetener.Reliability
 
                     await t.ConfigureAwait(false);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T6.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T6.cs
@@ -330,6 +330,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 Task<TResult>? t;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T7.cs
@@ -153,11 +153,10 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6) =>
             {
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -341,11 +340,10 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -356,10 +354,13 @@ namespace Sweetener.Reliability
 
                     await t.ConfigureAwait(false);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T7.cs
@@ -338,6 +338,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 Task<TResult>? t;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T8.cs
@@ -157,11 +157,10 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
             {
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -349,11 +348,10 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -364,10 +362,13 @@ namespace Sweetener.Reliability
 
                     await t.ConfigureAwait(false);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T8.cs
@@ -346,6 +346,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 Task<TResult>? t;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T9.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T9.cs
@@ -354,6 +354,9 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 Task<TResult>? t;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T9.cs
+++ b/src/Sweetener.Reliability/Func/AsyncFunc.Extensions.T9.cs
@@ -161,11 +161,10 @@ namespace Sweetener.Reliability
 
             return async (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
             {
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -357,11 +356,10 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                Task<TResult>? t;
                 int attempt = 0;
 
             Attempt:
-                t = null;
+                Task<TResult> t;
                 attempt++;
 
                 try
@@ -372,10 +370,13 @@ namespace Sweetener.Reliability
 
                     await t.ConfigureAwait(false);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                    if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T1.cs
@@ -252,6 +252,9 @@ namespace Sweetener.Reliability
 
             return (cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 TResult result;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T1.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T1.cs
@@ -116,10 +116,10 @@ namespace Sweetener.Reliability
 
             return () =>
             {
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
@@ -255,19 +255,23 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
                 {
                     result = func(cancellationToken);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T2.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T2.cs
@@ -257,6 +257,9 @@ namespace Sweetener.Reliability
 
             return (arg, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 TResult result;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T3.cs
@@ -265,6 +265,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 TResult result;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T3.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T3.cs
@@ -121,10 +121,10 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2) =>
             {
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
@@ -268,19 +268,23 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
                 {
                     result = func(arg1, arg2, cancellationToken);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T4.cs
@@ -125,10 +125,10 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3) =>
             {
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
@@ -276,19 +276,23 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
                 {
                     result = func(arg1, arg2, arg3, cancellationToken);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T4.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T4.cs
@@ -273,6 +273,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 TResult result;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T5.cs
@@ -281,6 +281,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 TResult result;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T5.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T5.cs
@@ -129,10 +129,10 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4) =>
             {
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
@@ -284,19 +284,23 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
                 {
                     result = func(arg1, arg2, arg3, arg4, cancellationToken);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T6.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T6.cs
@@ -133,10 +133,10 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5) =>
             {
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
@@ -292,19 +292,23 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
                 {
                     result = func(arg1, arg2, arg3, arg4, arg5, cancellationToken);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T6.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T6.cs
@@ -289,6 +289,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 TResult result;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T7.cs
@@ -137,10 +137,10 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, arg6) =>
             {
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
@@ -300,19 +300,23 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
                 {
                     result = func(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T7.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T7.cs
@@ -297,6 +297,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 TResult result;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T8.cs
@@ -141,10 +141,10 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
             {
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
@@ -308,19 +308,23 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
                 {
                     result = func(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T8.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T8.cs
@@ -305,6 +305,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 TResult result;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T9.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T9.cs
@@ -145,10 +145,10 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
             {
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
@@ -316,19 +316,23 @@ namespace Sweetener.Reliability
                 // Check for cancellation before invoking
                 cancellationToken.ThrowIfCancellationRequested();
 
-                TResult result;
                 int attempt = 0;
 
             Attempt:
+                TResult result;
                 attempt++;
 
                 try
                 {
                     result = func(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
                 }
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait(cancellationToken);

--- a/src/Sweetener.Reliability/Func/Func.Extensions.T9.cs
+++ b/src/Sweetener.Reliability/Func/Func.Extensions.T9.cs
@@ -313,6 +313,9 @@ namespace Sweetener.Reliability
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken) =>
             {
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
                 TResult result;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T1.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T1.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncFunc.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -276,7 +277,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T1.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T1.cs
@@ -207,6 +207,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -273,6 +276,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T1.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T1.cs
@@ -210,11 +210,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -225,10 +224,13 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -274,16 +276,16 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -294,11 +296,12 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T2.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T2.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncFunc.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -281,7 +282,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T2.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T2.cs
@@ -210,6 +210,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -278,6 +281,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T3.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T3.cs
@@ -213,6 +213,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -283,6 +286,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T3.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T3.cs
@@ -216,11 +216,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -231,10 +230,13 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -284,16 +286,16 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -304,11 +306,12 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T3.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T3.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncFunc.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -286,7 +287,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T4.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T4.cs
@@ -216,6 +216,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -288,6 +291,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T4.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T4.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncFunc.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -291,7 +292,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T4.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T4.cs
@@ -219,11 +219,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -234,10 +233,13 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -289,16 +291,16 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -309,11 +311,12 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T5.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T5.cs
@@ -219,6 +219,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -293,6 +296,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T5.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T5.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncFunc.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -296,7 +297,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T5.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T5.cs
@@ -222,11 +222,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -237,10 +236,13 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -294,16 +296,16 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -314,11 +316,12 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T6.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T6.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncFunc.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -301,7 +302,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T6.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T6.cs
@@ -225,11 +225,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -240,10 +239,13 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -299,16 +301,16 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -319,11 +321,12 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T6.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T6.cs
@@ -222,6 +222,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -298,6 +301,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T7.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T7.cs
@@ -228,11 +228,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -243,10 +242,13 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -304,16 +306,16 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -324,11 +326,12 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T7.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T7.cs
@@ -225,6 +225,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -303,6 +306,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T7.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T7.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncFunc.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -306,7 +307,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T8.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T8.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncFunc.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -311,7 +312,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T8.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T8.cs
@@ -231,11 +231,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -246,10 +245,13 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-                if (isCanceled || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -309,16 +311,16 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -329,11 +331,12 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T8.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T8.cs
@@ -228,6 +228,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -308,6 +311,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T9.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T9.cs
@@ -231,6 +231,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -313,6 +316,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T9.cs
+++ b/src/Sweetener.Reliability/Func/ReliableAsyncFunc.T9.cs
@@ -1,5 +1,6 @@
 // Generated from ReliableAsyncFunc.tt
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -316,7 +317,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T1.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T1.cs
@@ -320,7 +320,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -386,7 +386,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T1.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T1.cs
@@ -209,9 +209,13 @@ namespace Sweetener.Reliability
             {
                 result = _func(cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -256,19 +260,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = _func(cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -312,6 +320,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -326,11 +335,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     goto Fail;
 
@@ -376,6 +386,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -391,11 +402,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T1.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T1.cs
@@ -196,6 +196,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public TResult Invoke(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -250,6 +253,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -308,6 +314,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -369,6 +378,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T2.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T2.cs
@@ -327,7 +327,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T arg, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -395,7 +395,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T2.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T2.cs
@@ -212,9 +212,13 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -261,19 +265,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = _func(arg, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -319,6 +327,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T arg, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -333,11 +342,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     goto Fail;
 
@@ -385,6 +395,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -400,11 +411,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T2.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T2.cs
@@ -199,6 +199,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public TResult Invoke(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -255,6 +258,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -315,6 +321,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T arg, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -378,6 +387,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T arg, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T3.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T3.cs
@@ -215,9 +215,13 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -266,19 +270,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = _func(arg1, arg2, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -326,6 +334,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -340,11 +349,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     goto Fail;
 
@@ -394,6 +404,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -409,11 +420,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T3.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T3.cs
@@ -202,6 +202,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public TResult Invoke(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -260,6 +263,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -322,6 +328,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -387,6 +396,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T3.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T3.cs
@@ -334,7 +334,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -404,7 +404,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T4.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T4.cs
@@ -205,6 +205,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -265,6 +268,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -329,6 +335,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -396,6 +405,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T4.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T4.cs
@@ -218,9 +218,13 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -271,19 +275,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = _func(arg1, arg2, arg3, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -333,6 +341,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -347,11 +356,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     goto Fail;
 
@@ -403,6 +413,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -418,11 +429,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T4.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T4.cs
@@ -341,7 +341,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -413,7 +413,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T5.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T5.cs
@@ -221,9 +221,13 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -276,19 +280,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = _func(arg1, arg2, arg3, arg4, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -340,6 +348,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -354,11 +363,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     goto Fail;
 
@@ -412,6 +422,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -427,11 +438,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T5.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T5.cs
@@ -208,6 +208,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -270,6 +273,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -336,6 +342,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -405,6 +414,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T5.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T5.cs
@@ -348,7 +348,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -422,7 +422,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T6.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T6.cs
@@ -355,7 +355,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -431,7 +431,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T6.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T6.cs
@@ -224,9 +224,13 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -281,19 +285,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -347,6 +355,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -361,11 +370,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     goto Fail;
 
@@ -421,6 +431,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -436,11 +447,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T6.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T6.cs
@@ -211,6 +211,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -275,6 +278,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -343,6 +349,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -414,6 +423,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T7.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T7.cs
@@ -362,7 +362,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -440,7 +440,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T7.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T7.cs
@@ -227,9 +227,13 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -286,19 +290,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -354,6 +362,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -368,11 +377,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     goto Fail;
 
@@ -430,6 +440,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -445,11 +456,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T7.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T7.cs
@@ -214,6 +214,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -280,6 +283,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -350,6 +356,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -423,6 +432,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T8.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T8.cs
@@ -369,7 +369,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -449,7 +449,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T8.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T8.cs
@@ -217,6 +217,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -285,6 +288,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -357,6 +363,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -432,6 +441,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T8.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T8.cs
@@ -230,9 +230,13 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -291,19 +295,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -361,6 +369,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -375,11 +384,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     goto Fail;
 
@@ -439,6 +449,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -454,11 +465,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, arg7, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T9.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T9.cs
@@ -376,7 +376,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -458,7 +458,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T9.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T9.cs
@@ -220,6 +220,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -290,6 +293,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -364,6 +370,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -441,6 +450,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:

--- a/src/Sweetener.Reliability/Func/ReliableFunc.T9.cs
+++ b/src/Sweetener.Reliability/Func/ReliableFunc.T9.cs
@@ -233,9 +233,13 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -296,19 +300,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -368,6 +376,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -382,11 +391,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     goto Fail;
 
@@ -448,6 +458,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
@@ -463,11 +474,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/Reliably.Async.cs
+++ b/src/Sweetener.Reliability/Func/Reliably.Async.cs
@@ -227,11 +227,11 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
+            
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -242,10 +242,13 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
-                if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
@@ -497,11 +500,11 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
+            
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -512,10 +515,13 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
-                if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
@@ -734,6 +740,7 @@ namespace Sweetener.Reliability
         /// <exception cref="ObjectDisposedException">
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static async Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<Task<TResult>> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
         {
@@ -755,11 +762,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -770,12 +776,12 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
-                if (isCanceled)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     goto Fail;
 
@@ -1017,6 +1023,7 @@ namespace Sweetener.Reliability
         /// <exception cref="ObjectDisposedException">
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static async Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, Task<TResult>> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
         {
@@ -1038,11 +1045,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            Task<TResult>? t;
             int attempt = 0;
 
         Attempt:
-            t = null;
+            Task<TResult> t;
             attempt++;
 
             try
@@ -1053,12 +1059,12 @@ namespace Sweetener.Reliability
 
                 await t.ConfigureAwait(false);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
-                if (isCanceled)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/Reliably.Async.cs
+++ b/src/Sweetener.Reliability/Func/Reliably.Async.cs
@@ -224,6 +224,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -241,7 +244,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
                 if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
@@ -491,6 +494,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -508,7 +514,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
                 if (isCanceled || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
@@ -746,6 +752,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -763,7 +772,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
                 if (isCanceled)
                     throw;
 
@@ -1026,6 +1035,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             Task<TResult>? t;
             int attempt = 0;
 
@@ -1043,7 +1055,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
                 if (isCanceled)
                     throw;
 

--- a/src/Sweetener.Reliability/Func/Reliably.cs
+++ b/src/Sweetener.Reliability/Func/Reliably.cs
@@ -204,6 +204,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -216,7 +219,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
@@ -441,6 +444,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -453,7 +459,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
@@ -686,6 +692,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -698,7 +707,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
@@ -943,6 +952,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -955,7 +967,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
@@ -1224,6 +1236,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -1235,7 +1250,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
+                if (e is OperationCanceledException)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
@@ -1530,6 +1545,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -1541,7 +1559,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
+                if (e is OperationCanceledException)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
@@ -1788,6 +1806,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -1800,7 +1821,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
+                if (e is OperationCanceledException)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
@@ -2058,6 +2079,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -2070,7 +2094,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
+                if (e is OperationCanceledException)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))

--- a/src/Sweetener.Reliability/Func/Reliably.cs
+++ b/src/Sweetener.Reliability/Func/Reliably.cs
@@ -207,19 +207,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = func();
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
@@ -447,19 +451,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = func(state);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
@@ -695,19 +703,24 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
+            
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = func();
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
@@ -955,19 +968,24 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
+            
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = func(state);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
@@ -1218,6 +1236,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static bool TryInvoke<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
         {
@@ -1248,11 +1267,12 @@ namespace Sweetener.Reliability
             {
                 result = func();
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     goto Fail;
 
@@ -1527,6 +1547,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static bool TryInvoke<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
         {
@@ -1557,11 +1578,12 @@ namespace Sweetener.Reliability
             {
                 result = func(state);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     goto Fail;
 
@@ -1788,6 +1810,7 @@ namespace Sweetener.Reliability
         /// <exception cref="ObjectDisposedException">
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static async Task<Optional<TResult>> TryInvokeAsync<TResult>(Func<TResult> func, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
         {
@@ -1819,11 +1842,12 @@ namespace Sweetener.Reliability
             {
                 result = func();
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     goto Fail;
 
@@ -2061,6 +2085,7 @@ namespace Sweetener.Reliability
         /// <exception cref="ObjectDisposedException">
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static async Task<Optional<TResult>> TryInvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
         {
@@ -2092,11 +2117,12 @@ namespace Sweetener.Reliability
             {
                 result = func(state);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/TextTemplating/Func.Extensions.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/Func.Extensions.t4
@@ -152,6 +152,16 @@ namespace Sweetener.Reliability
 
             return <#= async ? "async " : string.Empty #>(<#= arguments #><#= optionalToken #>) =>
             {
+<#
+            if (interruptable)
+            {
+#>
+                // Check for cancellation before invoking
+                cancellationToken.ThrowIfCancellationRequested();
+
+<#
+            }
+#>
                 <#= async ? "Task<TResult>? t" : "TResult result" #>;
                 int attempt = 0;
 

--- a/src/Sweetener.Reliability/Func/TextTemplating/Func.Extensions.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/Func.Extensions.t4
@@ -41,10 +41,9 @@ namespace Sweetener.Reliability
 <#
         foreach (bool interruptable in new bool[] { false, true })
         {
-            string inputTypeParameters       = GetFuncTypeParameters(parameterCount, async, interruptable);
-            string optionalToken             = interruptable ? optionalComma + "cancellationToken" : string.Empty;
-            string optionalCancellationCheck = interruptable ? (async ? "isCanceled" : "e.IsCancellation(cancellationToken)") + " || " : string.Empty;
-            string asyncOperationSuffx       = async ? ".ConfigureAwait(false)" : ".Wait(" + (interruptable ? "cancellationToken" : string.Empty) + ")";
+            string inputTypeParameters = GetFuncTypeParameters(parameterCount, async, interruptable);
+            string optionalToken       = interruptable ? optionalComma + "cancellationToken" : string.Empty;
+            string asyncOperationSuffx = async ? ".ConfigureAwait(false)" : ".Wait(" + (interruptable ? "cancellationToken" : string.Empty) + ")";
 #>
         #region Func<<#= inputTypeParameters #>>
 
@@ -162,18 +161,10 @@ namespace Sweetener.Reliability
 <#
             }
 #>
-                <#= async ? "Task<TResult>? t" : "TResult result" #>;
                 int attempt = 0;
 
             Attempt:
-<#
-            if (async)
-            {
-#>
-                t = null;
-<#
-            }
-#>
+                <#= async ? "Task<TResult> t" : "TResult result" #>;
                 attempt++;
 
                 try
@@ -197,17 +188,20 @@ namespace Sweetener.Reliability
             }
 #>
                 }
-                catch (Exception e)
-                {
 <#
-            if (async && interruptable)
+            if (interruptable)
             {
 #>
-                    bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
 <#
             }
 #>
-                    if (<#= optionalCancellationCheck #>!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                catch (Exception e)
+                {
+                    if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                         throw;
 
                     <#= async ? "await " : string.Empty #>Task.Delay(delayHandler(attempt, default, e)<#= interruptable ? ", cancellationToken" : string.Empty #>)<#= asyncOperationSuffx #>;

--- a/src/Sweetener.Reliability/Func/TextTemplating/ReliableFunc.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/ReliableFunc.t4
@@ -192,9 +192,13 @@ namespace Sweetener.Reliability
             {
                 result = _func(<#= arguments #><#= optionalComma #>cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !CanRetry(attempt, e, cancellationToken))
+                if (!CanRetry(attempt, e, cancellationToken))
                     throw;
 
                 goto Attempt;
@@ -278,18 +282,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            <#= async ? "Task<TResult>? t" : "TResult result" #>;
             int attempt = 0;
 
         Attempt:
-<#
-        if (async)
-        {
-#>
-            t = null;
-<#
-        }
-#>
+            <#= async ? "Task<TResult> t" : "TResult result" #>;
             attempt++;
 
             try
@@ -313,17 +309,13 @@ namespace Sweetener.Reliability
         }
 #>
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-<#
-        if (async)
-        {
-#>
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
-<#
-        }
-#>
-                if (<#= async ? "isCanceled" : "e.IsCancellation(cancellationToken)" #> || !await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
+                if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     throw;
 
                 goto Attempt;
@@ -395,6 +387,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public bool TryInvoke(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -409,11 +402,12 @@ namespace Sweetener.Reliability
             {
                 result = _func(<#= arguments #><#= optionalComma #>cancellationToken);
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!CanRetry(attempt, e, cancellationToken))
                     goto Fail;
 
@@ -488,36 +482,16 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
         public async Task<Optional<TResult>> TryInvokeAsync(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-<#
-        if (async)
-        {
-#>
-            Task<TResult>? t;
-<#
-        }
-#>
             int attempt = 0;
 
         Attempt:
-<#
-        if (async)
-        {
-#>
-            t = null;
-<#
-        }
-        else
-        {
-#>
-            TResult result;
-<#
-        }
-#>
+            <#= async ? "Task<TResult> t" : "TResult result" #>;
             attempt++;
 
             try
@@ -541,11 +515,12 @@ namespace Sweetener.Reliability
         }
 #>
             }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
-                    throw;
-
                 if (!await CanRetryAsync(attempt, e, cancellationToken).ConfigureAwait(false))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/TextTemplating/ReliableFunc.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/ReliableFunc.t4
@@ -179,6 +179,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public TResult Invoke(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -272,6 +275,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<TResult> InvokeAsync(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             <#= async ? "Task<TResult>? t" : "TResult result" #>;
             int attempt = 0;
 
@@ -391,6 +397,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public bool TryInvoke(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -481,6 +490,9 @@ namespace Sweetener.Reliability
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
         public async Task<Optional<TResult>> TryInvokeAsync(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
 <#
         if (async)
         {

--- a/src/Sweetener.Reliability/Func/TextTemplating/ReliableFunc.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/ReliableFunc.t4
@@ -15,14 +15,7 @@
 #>
 // Generated from <#= GetTemplateFileName() #>
 using System;
-<#
-        if (!async)
-        {
-#>
 using System.Diagnostics.CodeAnalysis;
-<#
-        }
-#>
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -387,7 +380,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public bool TryInvoke(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken, [MaybeNullWhen(false)] out TResult result)
         {
             // Check for cancellation before invoking
@@ -482,7 +475,7 @@ namespace Sweetener.Reliability
         /// The underlying <see cref="CancellationTokenSource" /> has already been disposed.
         /// </exception>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler.")]
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions must be caught so they can be tested by the exception handler")]
         public async Task<Optional<TResult>> TryInvokeAsync(<#= parameters #><#= optionalComma #>CancellationToken cancellationToken)
         {
             // Check for cancellation before invoking

--- a/src/Sweetener.Reliability/Func/TextTemplating/Reliably.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/Reliably.t4
@@ -96,19 +96,23 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            TResult result;
             int attempt = 0;
 
         Attempt:
+            TResult result;
             attempt++;
 
             try
             {
                 result = func(<#= stateful ? "state" : string.Empty #>);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
@@ -209,18 +213,11 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-            <#= async ? "Task<TResult>? t" : "TResult result" #>;
+            
             int attempt = 0;
 
         Attempt:
-<#
-        if (async)
-        {
-#>
-            t = null;
-<#
-        }
-#>
+            <#= async ? "Task<TResult> t" : "TResult result" #>;
             attempt++;
 
             try
@@ -244,17 +241,13 @@ namespace Sweetener.Reliability
         }
 #>
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-<#
-        if (async)
-        {
-#>
-                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
-<#
-        }
-#>
-                if (<#= async ? "isCanceled" : "e is OperationCanceledException" #> || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
@@ -353,6 +346,7 @@ namespace Sweetener.Reliability
 <#
             PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: false, hasToken: true, hasResultHandler: true);
 #>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static bool TryInvoke<#= typeParam #>(Func<#= typeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler, out TResult result)
         {
@@ -383,11 +377,12 @@ namespace Sweetener.Reliability
             {
                 result = func(<#= stateful ? "state" : string.Empty #>);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     goto Fail;
 
@@ -479,6 +474,7 @@ namespace Sweetener.Reliability
 <#
         PrintReliablyTryInvokeFuncXmlDoc(indent: 2, stateful, isAsync: true, hasToken: true, hasResultHandler: true);
 #>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types"       , Justification = "All exceptions must be caught so they can be tested by the exception handler"   )]
         [SuppressMessage("Design", "CA1068:CancellationToken parameters must come last", Justification = "Token is not used for canceling operation, and API mirrors TaskFactory.StartNew")]
         public static async Task<Optional<TResult>> TryInvokeAsync<#= typeParam #>(Func<#= funcTypeParam #> func, <#= optionalStateParam #>CancellationToken cancellationToken, int maxRetries, ResultHandler<TResult> resultHandler, ExceptionHandler exceptionHandler, ComplexDelayHandler<TResult> delayHandler)
         {
@@ -500,31 +496,10 @@ namespace Sweetener.Reliability
             // Check for cancellation before invoking
             cancellationToken.ThrowIfCancellationRequested();
 
-<#
-        if (async)
-        {
-#>
-            Task<TResult>? t;
-<#
-        }
-#>
             int attempt = 0;
 
         Attempt:
-<#
-        if (async)
-        {
-#>
-            t = null;
-<#
-        }
-        else
-        {
-#>
-            TResult result;
-<#
-        }
-#>
+            <#= async ? "Task<TResult> t" : "TResult result" #>;
             attempt++;
 
             try
@@ -548,19 +523,12 @@ namespace Sweetener.Reliability
         }
 #>
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-<#
-        if (async)
-        {
-#>
-                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
-<#
-        }
-#>
-                if (<#= async ? "isCanceled" : "e is OperationCanceledException" #>)
-                    throw;
-
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     goto Fail;
 

--- a/src/Sweetener.Reliability/Func/TextTemplating/Reliably.t4
+++ b/src/Sweetener.Reliability/Func/TextTemplating/Reliably.t4
@@ -13,8 +13,7 @@ namespace Sweetener.Reliability
     static partial class Reliably
     {
 <#
-    string resultType        = async ? "Task<TResult>" : "TResult";
-    string cancellationCheck = async ? "isCanceled"    : "e.IsCancellation(cancellationToken)";
+    string resultType = async ? "Task<TResult>" : "TResult";
 
     if (!async)
     {
@@ -94,6 +93,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             TResult result;
             int attempt = 0;
 
@@ -106,7 +108,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken) || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (e is OperationCanceledException || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 Task.Delay(delayHandler(attempt, default, e), cancellationToken).Wait();
@@ -204,6 +206,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             <#= async ? "Task<TResult>? t" : "TResult result" #>;
             int attempt = 0;
 
@@ -245,11 +250,11 @@ namespace Sweetener.Reliability
         if (async)
         {
 #>
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
 <#
         }
 #>
-                if (<#= cancellationCheck #> || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
+                if (<#= async ? "isCanceled" : "e is OperationCanceledException" #> || !exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
                     throw;
 
                 await Task.Delay(delayHandler(attempt, default, e), cancellationToken).ConfigureAwait(false);
@@ -366,6 +371,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
             int attempt = 0;
 
         Attempt:
@@ -377,7 +385,7 @@ namespace Sweetener.Reliability
             }
             catch (Exception e)
             {
-                if (e.IsCancellation(cancellationToken))
+                if (e is OperationCanceledException)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))
@@ -489,6 +497,9 @@ namespace Sweetener.Reliability
             if (delayHandler == null)
                 throw new ArgumentNullException(nameof(delayHandler));
 
+            // Check for cancellation before invoking
+            cancellationToken.ThrowIfCancellationRequested();
+
 <#
         if (async)
         {
@@ -543,11 +554,11 @@ namespace Sweetener.Reliability
         if (async)
         {
 #>
-                bool isCanceled = t != null ? t.IsCanceled : e.IsCancellation(cancellationToken);
+                bool isCanceled = t != null ? t.IsCanceled : e is OperationCanceledException;
 <#
         }
 #>
-                if (<#= cancellationCheck #>)
+                if (<#= async ? "isCanceled" : "e is OperationCanceledException" #>)
                     throw;
 
                 if (!exceptionHandler(e) || (maxRetries != Retries.Infinite && attempt > maxRetries))


### PR DESCRIPTION
- Check for cancellation before invoking delegate for the first time
- Change cancellation check
    - Stop using `Task.IsCanceled`
    - Always check if `OperationCanceledException` is thrown
    - For APIs that pass the token to the delegate, check that the exception's token matches
- Add new test cases