### PR TITLE
Add DateTime and TimeSpan Extensions

### DIFF
--- a/src/Sweetener.Test/Extensions/DateTime.Extensions.Test.cs
+++ b/src/Sweetener.Test/Extensions/DateTime.Extensions.Test.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Sweetener.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Test
+{
+    [TestClass]
+    public class DateTimeExtensionsTest
+    {
+        [TestMethod]
+        public void Truncate()
+        {
+            // Invalid Negative Input
+            Assert.ThrowsException<ArgumentNegativeException>(() => DateTime.UtcNow.Truncate(TimeSpan.FromSeconds(-5)));
+
+            // TimeSpan.Zero graularity, DateTime.MinValue, or trying to truncate a value that's already at
+            // the desired granularity result in the identity function
+            Assert.AreEqual(DateTime.MaxValue, DateTime.MaxValue.Truncate(TimeSpan.Zero));
+            Assert.AreEqual(DateTime.MinValue, DateTime.MinValue.Truncate(TimeSpan.FromMinutes(3)));
+            Assert.AreEqual(new DateTime(1413, 12, 11, 10, 9, 8), new DateTime(1413, 12, 11, 10, 9, 8).Truncate(TimeSpan.FromSeconds(1)));
+
+            // Set to DateTime.MinValue when truncation would result in a smaller value
+            Assert.AreEqual(DateTime.MinValue, DateTime.MinValue.AddHours(3).Truncate(TimeSpan.FromHours(5)));
+
+            // A few normal cases using the different DateTimeKind values
+            // (1) Truncate to the nearest hour with kind UTC
+            DateTime date = new DateTime(2020, 7, 22, 10, 9, 8, DateTimeKind.Utc);
+            Assert.AreEqual(new DateTime(2020, 7, 22, 10, 0, 0, DateTimeKind.Utc), date.Truncate(TimeSpan.FromHours(1)));
+
+            // (2) Truncate to the nearest 5 minute interval with kind 'local'
+            date = new DateTime(2000, 1, 1, 15, 14, 13, DateTimeKind.Local);
+            Assert.AreEqual(new DateTime(2000, 1, 1, 15, 10, 0, DateTimeKind.Local), date.Truncate(TimeSpan.FromMinutes(5)));
+
+            // (3) Truncate to the nearest day for an 'unspecified' kind
+            date = new DateTime(1970, 4, 4, 1, 2, 3, DateTimeKind.Unspecified);
+            Assert.AreEqual(new DateTime(1970, 4, 4, 0, 0, 0, DateTimeKind.Unspecified), date.Truncate(TimeSpan.FromDays(1)));
+        }
+    }
+}

--- a/src/Sweetener.Test/Extensions/TimeSpan.Extensions.Test.cs
+++ b/src/Sweetener.Test/Extensions/TimeSpan.Extensions.Test.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using Sweetener.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Test
+{
+    [TestClass]
+    public class TimeSpanExtensionsTest
+    {
+        [TestMethod]
+        public void AddDays()
+        {
+            Assert.ThrowsException<ArgumentException>(() => TimeSpan.Zero    .AddDays(double.NaN             ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddDays(double.MinValue        ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddDays(double.MaxValue        ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddDays(double.PositiveInfinity));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddDays(double.NegativeInfinity));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MaxValue.AddDays( 1                      ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MinValue.AddDays(-1                      ));
+
+            Assert.AreEqual(TimeSpan.MaxValue, TimeSpan.MaxValue.AddDays(0));
+            Assert.AreEqual(new TimeSpan( 2,  14,  3,  4,  5), new TimeSpan( 1,  2,  3,  4,  5).AddDays( 1.5 ));
+            Assert.AreEqual(new TimeSpan(-1,   2,  3,  4,  5), new TimeSpan( 1,  2,  3,  4,  5).AddDays(-2.0 ));
+            Assert.AreEqual(new TimeSpan( 9,   4, -3, -4, -5), new TimeSpan(-1, -2, -3, -4, -5).AddDays(10.25));
+            Assert.AreEqual(new TimeSpan(-6, -14, -3, -4, -5), new TimeSpan(-1, -2, -3, -4, -5).AddDays(-5.5 ));
+        }
+
+        [TestMethod]
+        public void AddHours()
+        {
+            Assert.ThrowsException<ArgumentException>(() => TimeSpan.Zero    .AddHours(double.NaN             ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddHours(double.MinValue        ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddHours(double.MaxValue        ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddHours(double.PositiveInfinity));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddHours(double.NegativeInfinity));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MaxValue.AddHours( 1                      ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MinValue.AddHours(-1                      ));
+
+            Assert.AreEqual(TimeSpan.MaxValue, TimeSpan.MaxValue.AddHours(0));
+            Assert.AreEqual(new TimeSpan( 1,  3,  33,  4,  5), new TimeSpan( 1,  2,  3,  4,  5).AddHours( 1.5 ));
+            Assert.AreEqual(new TimeSpan( 1,  0,   3,  4,  5), new TimeSpan( 1,  2,  3,  4,  5).AddHours(-2.0 ));
+            Assert.AreEqual(new TimeSpan(-1,  8,  12, -4, -5), new TimeSpan(-1, -2, -3, -4, -5).AddHours(10.25));
+            Assert.AreEqual(new TimeSpan(-1, -7, -33, -4, -5), new TimeSpan(-1, -2, -3, -4, -5).AddHours(-5.5 ));
+        }
+
+        [TestMethod]
+        public void AddMinutes()
+        {
+            Assert.ThrowsException<ArgumentException>(() => TimeSpan.Zero    .AddMinutes(double.NaN             ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddMinutes(double.MinValue        ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddMinutes(double.MaxValue        ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddMinutes(double.PositiveInfinity));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddMinutes(double.NegativeInfinity));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MaxValue.AddMinutes( 1                      ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MinValue.AddMinutes(-1                      ));
+
+            Assert.AreEqual(TimeSpan.MaxValue, TimeSpan.MaxValue.AddMinutes(0));
+            Assert.AreEqual(new TimeSpan( 1,  2,  4,  34,  5), new TimeSpan( 1,  2,  3,  4,  5).AddMinutes( 1.5 ));
+            Assert.AreEqual(new TimeSpan( 1,  2,  1,   4,  5), new TimeSpan( 1,  2,  3,  4,  5).AddMinutes(-2.0 ));
+            Assert.AreEqual(new TimeSpan(-1, -2,  7,  11, -5), new TimeSpan(-1, -2, -3, -4, -5).AddMinutes(10.25));
+            Assert.AreEqual(new TimeSpan(-1, -2, -8, -34, -5), new TimeSpan(-1, -2, -3, -4, -5).AddMinutes(-5.5 ));
+        }
+
+        [TestMethod]
+        public void AddSeconds()
+        {
+            Assert.ThrowsException<ArgumentException>(() => TimeSpan.Zero    .AddSeconds(double.NaN             ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddSeconds(double.MinValue        ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddSeconds(double.MaxValue        ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddSeconds(double.PositiveInfinity));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddSeconds(double.NegativeInfinity));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MaxValue.AddSeconds( 1                      ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MinValue.AddSeconds(-1                      ));
+
+            Assert.AreEqual(TimeSpan.MaxValue, TimeSpan.MaxValue.AddSeconds(0));
+            Assert.AreEqual(new TimeSpan( 1,  2,  3,  5,  505), new TimeSpan( 1,  2,  3,  4,  5).AddSeconds( 1.5 ));
+            Assert.AreEqual(new TimeSpan( 1,  2,  3,  2,    5), new TimeSpan( 1,  2,  3,  4,  5).AddSeconds(-2.0 ));
+            Assert.AreEqual(new TimeSpan(-1, -2, -3,  6,  245), new TimeSpan(-1, -2, -3, -4, -5).AddSeconds(10.25));
+            Assert.AreEqual(new TimeSpan(-1, -2, -3, -9, -505), new TimeSpan(-1, -2, -3, -4, -5).AddSeconds(-5.5 ));
+        }
+
+        [TestMethod]
+        public void AddMilliseconds()
+        {
+            Assert.ThrowsException<ArgumentException>(() => TimeSpan.Zero    .AddMilliseconds(double.NaN             ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddMilliseconds(double.MinValue        ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddMilliseconds(double.MaxValue        ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddMilliseconds(double.PositiveInfinity));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.Zero    .AddMilliseconds(double.NegativeInfinity));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MaxValue.AddMilliseconds( 1                      ));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MinValue.AddMilliseconds(-1                      ));
+
+            Assert.AreEqual(TimeSpan.MaxValue, TimeSpan.MaxValue.AddMilliseconds(0));
+            Assert.AreEqual(new TimeSpan( 1,  2,  3,  4,   6).AddTicks( TimeSpan.TicksPerMillisecond / 2), new TimeSpan( 1,  2,  3,  4,  5).AddMilliseconds( 1.5 ));
+            Assert.AreEqual(new TimeSpan( 1,  2,  3,  4,   3)                                            , new TimeSpan( 1,  2,  3,  4,  5).AddMilliseconds(-2.0 ));
+            Assert.AreEqual(new TimeSpan(-1, -2, -3, -4,   5).AddTicks( TimeSpan.TicksPerMillisecond / 4), new TimeSpan(-1, -2, -3, -4, -5).AddMilliseconds(10.25));
+            Assert.AreEqual(new TimeSpan(-1, -2, -3, -4, -10).AddTicks(-TimeSpan.TicksPerMillisecond / 2), new TimeSpan(-1, -2, -3, -4, -5).AddMilliseconds(-5.5 ));
+        }
+
+        [TestMethod]
+        public void AddTicks()
+        {
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MaxValue.AddTicks( 1));
+            Assert.ThrowsException<OverflowException>(() => TimeSpan.MinValue.AddTicks(-1));
+
+            Assert.AreEqual(TimeSpan.MaxValue, TimeSpan.MaxValue.AddTicks(0));
+            Assert.AreEqual(new TimeSpan( 12360), new TimeSpan( 12345).AddTicks(  15));
+            Assert.AreEqual(new TimeSpan( 12325), new TimeSpan( 12345).AddTicks( -20));
+            Assert.AreEqual(new TimeSpan(-11320), new TimeSpan(-12345).AddTicks(1025));
+            Assert.AreEqual(new TimeSpan(-12400), new TimeSpan(-12345).AddTicks( -55));
+        }
+
+        [TestMethod]
+        public void Truncate()
+        {
+            // Invalid Negative Input
+            Assert.ThrowsException<ArgumentNegativeException>(() => TimeSpan.FromHours(7).Truncate(TimeSpan.FromMinutes(-3)));
+
+            // TimeSpan.Zero graularity, a TimeSpan.Zero value, or trying to truncate a value that's already at
+            // the desired granularity result in the identity function
+            Assert.AreEqual(TimeSpan.MaxValue    , TimeSpan.MaxValue    .Truncate(TimeSpan.Zero        ));
+            Assert.AreEqual(TimeSpan.Zero        , TimeSpan.Zero        .Truncate(TimeSpan.FromHours(2)));
+            Assert.AreEqual(TimeSpan.FromDays(10), TimeSpan.FromDays(10).Truncate(TimeSpan.FromDays (5)));
+
+            // Set to TimeSpan.Zero when truncation would result in a smaller value
+            Assert.AreEqual(TimeSpan.Zero, TimeSpan.Zero.Add(TimeSpan.FromMinutes(15)).Truncate(TimeSpan.FromHours(1)));
+
+            // Positive scenario
+            TimeSpan positive = new TimeSpan(7, 6, 5, 4, 3);
+            Assert.AreEqual(new TimeSpan(7, 6, 5, 0, 0), positive.Truncate(new TimeSpan(0, 2, 30)));
+
+            // Negative scenario (value moves towards TimeSpan.Zero)
+            TimeSpan negative = new TimeSpan(1, 2, 3, 4, 5).Negate();
+            Assert.AreEqual(new TimeSpan(1, 2, 0, 0, 0).Negate(), negative.Truncate(TimeSpan.FromHours(1)));
+        }
+    }
+}

--- a/src/Sweetener/Exceptions/ArgumentNegativeException.cs
+++ b/src/Sweetener/Exceptions/ArgumentNegativeException.cs
@@ -13,30 +13,10 @@ namespace Sweetener
         /// Initializes a new instance of the <see cref="ArgumentNegativeException"/> class.
         /// </summary>
         /// <remarks>
-        /// <para>
         /// This constructor initializes the <see cref="Exception.Message"/> property of
         /// the new instance to a system-supplied message that describes the error,
         /// such as "Nonnegative number required." This message takes into account the current
         /// system culture.
-        /// </para>
-        /// <para>
-        /// The following table shows the initial property values for an instance of
-        /// <see cref="ArgumentNegativeException"/>.
-        /// </para>
-        /// <list type="table">
-        /// <listheader>
-        /// <term>Property</term>
-        /// <term>Value</term>
-        /// </listheader>
-        /// <item>
-        /// <term><see cref="Exception.InnerException"/></term>
-        /// <term><see langword="null" /></term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Exception.Message"/></term>
-        /// <term>The localized error message string.</term>
-        /// </item>
-        /// </list>
         /// </remarks>
         public ArgumentNegativeException()
             : this(paramName: null)
@@ -57,28 +37,6 @@ namespace Sweetener
         /// of the new instance using the <paramref name="paramName"/> parameter. The content of
         /// <paramref name="paramName"/> is intended to be understood by humans.
         /// </para>
-        /// <para>
-        /// The following table shows the initial property values for an instance of
-        /// <see cref="ArgumentNegativeException"/>.
-        /// </para>
-        /// <list type="table">
-        /// <listheader>
-        /// <term>Property</term>
-        /// <term>Value</term>
-        /// </listheader>
-        /// <item>
-        /// <term><see cref="Exception.InnerException"/></term>
-        /// <term><see langword="null" /></term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Exception.Message"/></term>
-        /// <term>The empty string ("").</term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="ArgumentException.ParamName"/></term>
-        /// <term>The parameter name string.</term>
-        /// </item>
-        /// </list>
         /// </remarks>
         /// <param name="paramName">The name of the parameter that causes this exception.</param>
         public ArgumentNegativeException(string? paramName)
@@ -115,28 +73,6 @@ namespace Sweetener
         /// of the new instance using the <paramref name="paramName"/> parameter. The content of
         /// <paramref name="paramName"/> is intended to be understood by humans.
         /// </para>
-        /// <para>
-        /// The following table shows the initial property values for an instance of
-        /// <see cref="ArgumentNegativeException"/>.
-        /// </para>
-        /// <list type="table">
-        /// <listheader>
-        /// <term>Property</term>
-        /// <term>Value</term>
-        /// </listheader>
-        /// <item>
-        /// <term><see cref="Exception.InnerException"/></term>
-        /// <term><see langword="null" /></term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Exception.Message"/></term>
-        /// <term>The error message string.</term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="ArgumentException.ParamName"/></term>
-        /// <term>The parameter name string.</term>
-        /// </item>
-        /// </list>
         /// </remarks>
         /// <param name="paramName">The name of the parameter that caused the exception.</param>
         /// <param name="message">The message that describes the error.</param>
@@ -168,32 +104,6 @@ namespace Sweetener
         /// representation is appended to the message string held in the
         /// <see cref="Exception.Message"/> property.
         /// </para>
-        /// <para>
-        /// The following table shows the initial property values for an instance of
-        /// <see cref="ArgumentNegativeException"/>.
-        /// </para>
-        /// <list type="table">
-        /// <listheader>
-        /// <term>Property</term>
-        /// <term>Value</term>
-        /// </listheader>
-        /// <item>
-        /// <term><see cref="ArgumentOutOfRangeException.ActualValue"/></term>
-        /// <term>The argument value.</term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Exception.InnerException"/></term>
-        /// <term><see langword="null" /></term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Exception.Message"/></term>
-        /// <term>The error message string.</term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="ArgumentException.ParamName"/></term>
-        /// <term>The parameter name string.</term>
-        /// </item>
-        /// </list>
         /// </remarks>
         /// <param name="paramName">The name of the parameter that caused the exception.</param>
         /// <param name="actualValue">The value of the argument that causes this exception.</param>

--- a/src/Sweetener/Extensions/DateTime.Extensions.cs
+++ b/src/Sweetener/Extensions/DateTime.Extensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Sweetener.Extensions
+{
+    /// <summary>
+    /// Provides a set of additional methods for <see cref="DateTime"/> structures.
+    /// </summary>
+    public static class DateTimeExtensions
+    {
+        /// <summary>
+        /// Returns a new <see cref="DateTime"/> whose value has been truncated to the specified <paramref name="granularity"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="DateTime"/> instance to truncate.</param>
+        /// <param name="granularity">
+        /// A <see cref="TimeSpan"/> that represents the desired granularity for the <paramref name="value"/>.
+        /// </param>
+        /// <returns>
+        /// An object whose value has been truncated to the <paramref name="granularity"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNegativeException"><paramref name="value"/> cannot be negative.</exception>
+        public static DateTime Truncate(this DateTime value, TimeSpan granularity)
+        {
+            if (granularity < TimeSpan.Zero)
+                throw new ArgumentNegativeException(nameof(granularity));
+
+            return granularity == TimeSpan.Zero ? value : new DateTime(value.Ticks - (value.Ticks % granularity.Ticks), value.Kind);
+        }
+    }
+}

--- a/src/Sweetener/Extensions/TimeSpan.Extensions.cs
+++ b/src/Sweetener/Extensions/TimeSpan.Extensions.cs
@@ -1,0 +1,186 @@
+﻿using System;
+
+namespace Sweetener.Extensions
+{
+    /// <summary>
+    /// Provides a set of additional methods for <see cref="TimeSpan"/> structures.
+    /// </summary>
+    public static class TimeSpanExtensions
+    {
+        /// <summary>
+        /// Returns a new <see cref="TimeSpan"/> that adds the specified number of days to the <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> instance.</param>
+        /// <param name="days">
+        /// A number of whole and fractional days. The <paramref name="days"/> parameter can be negative or positive.
+        /// </param>
+        /// <returns>
+        /// An object whose time is the sum of the <paramref name="value"/> and the specified number of <paramref name="days"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="days"/> is equal to <see cref="double.NaN"/>.</exception>
+        /// <exception cref="OverflowException">
+        /// <para>
+        /// <paramref name="days"/> is <see cref="double.PositiveInfinity"/>.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// <paramref name="days"/> is <see cref="double.NegativeInfinity"/>.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The resulting <see cref="TimeSpan"/> is less than <see cref="TimeSpan.MinValue"/> or
+        /// greater than <see cref="TimeSpan.MaxValue"/>.
+        /// </para>
+        /// </exception>
+        public static TimeSpan AddDays(this TimeSpan value, double days)
+            => value.Add(TimeSpan.FromDays(days));
+
+        /// <summary>
+        /// Returns a new <see cref="TimeSpan"/> that adds the specified number of hours to the <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> instance.</param>
+        /// <param name="hours">
+        /// A number of whole and fractional hours. The <paramref name="hours"/> parameter can be negative or positive.
+        /// </param>
+        /// <returns>
+        /// An object whose time is the sum of the <paramref name="value"/> and the specified number of <paramref name="hours"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="hours"/> is equal to <see cref="double.NaN"/>.</exception>
+        /// <exception cref="OverflowException">
+        /// <para>
+        /// <paramref name="hours"/> is <see cref="double.PositiveInfinity"/>.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// <paramref name="hours"/> is <see cref="double.NegativeInfinity"/>.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The resulting <see cref="TimeSpan"/> is less than <see cref="TimeSpan.MinValue"/> or
+        /// greater than <see cref="TimeSpan.MaxValue"/>.
+        /// </para>
+        /// </exception>
+        public static TimeSpan AddHours(this TimeSpan value, double hours)
+            => value.Add(TimeSpan.FromHours(hours));
+
+        /// <summary>
+        /// Returns a new <see cref="TimeSpan"/> that adds the specified number of minutes to the <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> instance.</param>
+        /// <param name="minutes">
+        /// A number of whole and fractional minutes. The <paramref name="minutes"/> parameter can be negative or positive.
+        /// </param>
+        /// <returns>
+        /// An object whose time is the sum of the <paramref name="value"/> and the specified number of <paramref name="minutes"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="minutes"/> is equal to <see cref="double.NaN"/>.</exception>
+        /// <exception cref="OverflowException">
+        /// <para>
+        /// <paramref name="minutes"/> is <see cref="double.PositiveInfinity"/>.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// <paramref name="minutes"/> is <see cref="double.NegativeInfinity"/>.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The resulting <see cref="TimeSpan"/> is less than <see cref="TimeSpan.MinValue"/> or
+        /// greater than <see cref="TimeSpan.MaxValue"/>.
+        /// </para>
+        /// </exception>
+        public static TimeSpan AddMinutes(this TimeSpan value, double minutes)
+            => value.Add(TimeSpan.FromMinutes(minutes));
+
+        /// <summary>
+        /// Returns a new <see cref="TimeSpan"/> that adds the specified number of seconds to the <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> instance.</param>
+        /// <param name="seconds">
+        /// A number of whole and fractional seconds. The <paramref name="seconds"/> parameter can be negative or positive.
+        /// </param>
+        /// <returns>
+        /// An object whose time is the sum of the <paramref name="value"/> and the specified number of <paramref name="seconds"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="seconds"/> is equal to <see cref="double.NaN"/>.</exception>
+        /// <exception cref="OverflowException">
+        /// <para>
+        /// <paramref name="seconds"/> is <see cref="double.PositiveInfinity"/>.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// <paramref name="seconds"/> is <see cref="double.NegativeInfinity"/>.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The resulting <see cref="TimeSpan"/> is less than <see cref="TimeSpan.MinValue"/> or
+        /// greater than <see cref="TimeSpan.MaxValue"/>.
+        /// </para>
+        /// </exception>
+        public static TimeSpan AddSeconds(this TimeSpan value, double seconds)
+            => value.Add(TimeSpan.FromSeconds(seconds));
+
+        /// <summary>
+        /// Returns a new <see cref="TimeSpan"/> that adds the specified number of milliseconds to the <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> instance.</param>
+        /// <param name="milliseconds">
+        /// A number of whole and fractional milliseconds. The <paramref name="milliseconds"/> parameter can be negative or positive.
+        /// </param>
+        /// <returns>
+        /// An object whose time is the sum of the <paramref name="value"/> and the specified number of <paramref name="milliseconds"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="milliseconds"/> is equal to <see cref="double.NaN"/>.</exception>
+        /// <exception cref="OverflowException">
+        /// <para>
+        /// <paramref name="milliseconds"/> is <see cref="double.PositiveInfinity"/>.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// <paramref name="milliseconds"/> is <see cref="double.NegativeInfinity"/>.
+        /// </para>
+        /// <para>-or-</para>
+        /// <para>
+        /// The resulting <see cref="TimeSpan"/> is less than <see cref="TimeSpan.MinValue"/> or
+        /// greater than <see cref="TimeSpan.MaxValue"/>.
+        /// </para>
+        /// </exception>
+        public static TimeSpan AddMilliseconds(this TimeSpan value, double milliseconds)
+            => value.Add(TimeSpan.FromMilliseconds(milliseconds));
+
+        /// <summary>
+        /// Returns a new <see cref="TimeSpan"/> that adds the specified number of ticks to the <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> instance.</param>
+        /// <param name="ticks">
+        /// A time period expressed in 100-nanosecond units. The <paramref name="ticks"/> parameter can be negative or positive.
+        /// </param>
+        /// <returns>
+        /// An object whose time is the sum of the <paramref name="value"/> and the specified number of <paramref name="ticks"/>.
+        /// </returns>
+        /// <exception cref="OverflowException">
+        /// The resulting <see cref="TimeSpan"/> is less than <see cref="TimeSpan.MinValue"/> or
+        /// greater than <see cref="TimeSpan.MaxValue"/>.
+        /// </exception>
+        public static TimeSpan AddTicks(this TimeSpan value, long ticks)
+            => value.Add(new TimeSpan(ticks));
+
+        /// <summary>
+        /// Returns a new <see cref="TimeSpan"/> whose value has been truncated to the specified <paramref name="granularity"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> instance to truncate.</param>
+        /// <param name="granularity">
+        /// A <see cref="TimeSpan"/> that represents the desired granularity for the <paramref name="value"/>.
+        /// </param>
+        /// <returns>
+        /// An object whose value has been truncated to the <paramref name="granularity"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNegativeException"><paramref name="value"/> cannot be negative.</exception>
+        public static TimeSpan Truncate(this TimeSpan value, TimeSpan granularity)
+        {
+            if (granularity < TimeSpan.Zero)
+                throw new ArgumentNegativeException(nameof(granularity));
+
+            return granularity == TimeSpan.Zero ? value : new TimeSpan(value.Ticks - (value.Ticks % granularity.Ticks));
+        }
+    }
+}


### PR DESCRIPTION
- Add `Truncate` extension method for `DateTime` and `TimeSpan`
- Add various "Add*" extension methods for `TimeSpan`
- Remove tables from `ArgumentNegativeException` XML doc to avoid formatting problems in Visual Studio