### PR TITLE
Refactor Optional<T>

### DIFF
--- a/src/Sweetener/Resources/Exceptions.resx
+++ b/src/Sweetener/Resources/Exceptions.resx
@@ -123,7 +123,7 @@
   <data name="EmptyEnumeratorMessage" xml:space="preserve">
     <value>Enumerator does not iterate over any elements.</value>
   </data>
-  <data name="UndefinedOptionalValueMessage" xml:space="preserve">
+  <data name="MissingOptionalValueMessage" xml:space="preserve">
     <value>Optional object must have a value.</value>
   </data>
 </root>

--- a/src/Sweetener/SR.cs
+++ b/src/Sweetener/SR.cs
@@ -12,7 +12,7 @@ namespace Sweetener
 
         public static string EmptyEnumeratorMessage => ExceptionResourceManager.GetString(nameof(EmptyEnumeratorMessage), CultureInfo.CurrentUICulture);
 
-        public static string UndefinedOptionalValueMessage => ExceptionResourceManager.GetString(nameof(UndefinedOptionalValueMessage), CultureInfo.CurrentUICulture);
+        public static string MissingOptionalValueMessage => ExceptionResourceManager.GetString(nameof(MissingOptionalValueMessage), CultureInfo.CurrentUICulture);
 
         private static readonly ResourceManager ExceptionResourceManager = new ResourceManager("Sweetener.Resources.Exceptions", typeof(SR).Assembly);
     }


### PR DESCRIPTION
- Create a `static` utility class called `Optional` for methods `Equals` and `Compare`, like `Nullable`
- Replace `Undefined` with the more common phrase `None`
- Add methods `None` and `Some` to `Optional`
- Update `DebuggerDisplay` to differentiate between objects with and without a value