### PR TITLE
Add MultiTask Utilities

### DIFF
--- a/src/Sweetener.Test/Sweetener.Test.csproj
+++ b/src/Sweetener.Test/Sweetener.Test.csproj
@@ -4,4 +4,25 @@
     <ProjectReference Include="..\Sweetener\Sweetener.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <!-- Generated Files -->
+  <ItemGroup>
+    <Compile Update="Threading\Tasks\MultiTask.Test.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>MultiTask.Test.tt</DependentUpon>
+      <DesignTime>True</DesignTime>
+    </Compile>
+  </ItemGroup>
+
+  <!-- Text Templating Files -->
+  <ItemGroup>
+    <None Update="Threading\Tasks\MultiTask.Test.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>MultiTask.Test.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/Sweetener.Test/Threading/Tasks/MultiTask.Test.cs
+++ b/src/Sweetener.Test/Threading/Tasks/MultiTask.Test.cs
@@ -1,0 +1,456 @@
+﻿// Copyright © William Sugarman.
+// Licensed under the MIT License.
+
+// Do not modify this file. It was automatically generated from MultiTask.Test.tt
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Threading.Tasks.Test
+{
+    [TestClass]
+    public class MultiTaskTest
+    {
+        [TestMethod]
+        public async Task WhenAllT2()
+        {
+            // Exceptions
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    (Task<int>)null!,
+                    Task.FromResult("Hello World"))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    (Task<string>)null!)).ConfigureAwait(false);
+
+            // Success
+            (int value1, string value2) = await MultiTask.WhenAll(
+                Task.FromResult(42),
+                Task.FromResult("Hello World")).ConfigureAwait(false);
+
+            Assert.AreEqual(42           , value1);
+            Assert.AreEqual("Hello World", value2);
+        }
+
+        [TestMethod]
+        public async Task WhenAllT3()
+        {
+            // Exceptions
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    (Task<int>)null!,
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    (Task<string>)null!,
+                    Task.FromResult(TimeSpan.FromHours(3)))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    (Task<TimeSpan>)null!)).ConfigureAwait(false);
+
+            // Success
+            (int value1, string value2, TimeSpan value3) = await MultiTask.WhenAll(
+                Task.FromResult(42),
+                Task.FromResult("Hello World"),
+                Task.FromResult(TimeSpan.FromHours(3))).ConfigureAwait(false);
+
+            Assert.AreEqual(42                   , value1);
+            Assert.AreEqual("Hello World"        , value2);
+            Assert.AreEqual(TimeSpan.FromHours(3), value3);
+        }
+
+        [TestMethod]
+        public async Task WhenAllT4()
+        {
+            // Exceptions
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    (Task<int>)null!,
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    (Task<string>)null!,
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    (Task<TimeSpan>)null!,
+                    Task.FromResult(3.14d))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    (Task<double>)null!)).ConfigureAwait(false);
+
+            // Success
+            (int value1, string value2, TimeSpan value3, double value4) = await MultiTask.WhenAll(
+                Task.FromResult(42),
+                Task.FromResult("Hello World"),
+                Task.FromResult(TimeSpan.FromHours(3)),
+                Task.FromResult(3.14d)).ConfigureAwait(false);
+
+            Assert.AreEqual(42                   , value1);
+            Assert.AreEqual("Hello World"        , value2);
+            Assert.AreEqual(TimeSpan.FromHours(3), value3);
+            Assert.AreEqual(3.14d                , value4);
+        }
+
+        [TestMethod]
+        public async Task WhenAllT5()
+        {
+            // Exceptions
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    (Task<int>)null!,
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    (Task<string>)null!,
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    (Task<TimeSpan>)null!,
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    (Task<double>)null!,
+                    Task.FromResult(100L))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    (Task<long>)null!)).ConfigureAwait(false);
+
+            // Success
+            (int value1, string value2, TimeSpan value3, double value4, long value5) = await MultiTask.WhenAll(
+                Task.FromResult(42),
+                Task.FromResult("Hello World"),
+                Task.FromResult(TimeSpan.FromHours(3)),
+                Task.FromResult(3.14d),
+                Task.FromResult(100L)).ConfigureAwait(false);
+
+            Assert.AreEqual(42                   , value1);
+            Assert.AreEqual("Hello World"        , value2);
+            Assert.AreEqual(TimeSpan.FromHours(3), value3);
+            Assert.AreEqual(3.14d                , value4);
+            Assert.AreEqual(100L                 , value5);
+        }
+
+        [TestMethod]
+        public async Task WhenAllT6()
+        {
+            // Exceptions
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    (Task<int>)null!,
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    (Task<string>)null!,
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    (Task<TimeSpan>)null!,
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    (Task<double>)null!,
+                    Task.FromResult(100L),
+                    Task.FromResult('a'))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    (Task<long>)null!,
+                    Task.FromResult('a'))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    (Task<char>)null!)).ConfigureAwait(false);
+
+            // Success
+            (int value1, string value2, TimeSpan value3, double value4, long value5, char value6) = await MultiTask.WhenAll(
+                Task.FromResult(42),
+                Task.FromResult("Hello World"),
+                Task.FromResult(TimeSpan.FromHours(3)),
+                Task.FromResult(3.14d),
+                Task.FromResult(100L),
+                Task.FromResult('a')).ConfigureAwait(false);
+
+            Assert.AreEqual(42                   , value1);
+            Assert.AreEqual("Hello World"        , value2);
+            Assert.AreEqual(TimeSpan.FromHours(3), value3);
+            Assert.AreEqual(3.14d                , value4);
+            Assert.AreEqual(100L                 , value5);
+            Assert.AreEqual('a'                  , value6);
+        }
+
+        [TestMethod]
+        public async Task WhenAllT7()
+        {
+            // Exceptions
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    (Task<int>)null!,
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    (Task<string>)null!,
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    (Task<TimeSpan>)null!,
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    (Task<double>)null!,
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    (Task<long>)null!,
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    (Task<char>)null!,
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    (Task<Guid>)null!)).ConfigureAwait(false);
+
+            // Success
+            (int value1, string value2, TimeSpan value3, double value4, long value5, char value6, Guid value7) = await MultiTask.WhenAll(
+                Task.FromResult(42),
+                Task.FromResult("Hello World"),
+                Task.FromResult(TimeSpan.FromHours(3)),
+                Task.FromResult(3.14d),
+                Task.FromResult(100L),
+                Task.FromResult('a'),
+                Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af"))).ConfigureAwait(false);
+
+            Assert.AreEqual(42                                                , value1);
+            Assert.AreEqual("Hello World"                                     , value2);
+            Assert.AreEqual(TimeSpan.FromHours(3)                             , value3);
+            Assert.AreEqual(3.14d                                             , value4);
+            Assert.AreEqual(100L                                              , value5);
+            Assert.AreEqual('a'                                               , value6);
+            Assert.AreEqual(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af"), value7);
+        }
+
+        [TestMethod]
+        public async Task WhenAllT8()
+        {
+            // Exceptions
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    (Task<int>)null!,
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")),
+                    Task.FromResult((sbyte)-3))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    (Task<string>)null!,
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")),
+                    Task.FromResult((sbyte)-3))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    (Task<TimeSpan>)null!,
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")),
+                    Task.FromResult((sbyte)-3))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    (Task<double>)null!,
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")),
+                    Task.FromResult((sbyte)-3))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    (Task<long>)null!,
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")),
+                    Task.FromResult((sbyte)-3))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    (Task<char>)null!,
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")),
+                    Task.FromResult((sbyte)-3))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    (Task<Guid>)null!,
+                    Task.FromResult((sbyte)-3))).ConfigureAwait(false);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+                    Task.FromResult(42),
+                    Task.FromResult("Hello World"),
+                    Task.FromResult(TimeSpan.FromHours(3)),
+                    Task.FromResult(3.14d),
+                    Task.FromResult(100L),
+                    Task.FromResult('a'),
+                    Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")),
+                    (Task<sbyte>)null!)).ConfigureAwait(false);
+
+            // Success
+            (int value1, string value2, TimeSpan value3, double value4, long value5, char value6, Guid value7, sbyte value8) = await MultiTask.WhenAll(
+                Task.FromResult(42),
+                Task.FromResult("Hello World"),
+                Task.FromResult(TimeSpan.FromHours(3)),
+                Task.FromResult(3.14d),
+                Task.FromResult(100L),
+                Task.FromResult('a'),
+                Task.FromResult(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af")),
+                Task.FromResult((sbyte)-3)).ConfigureAwait(false);
+
+            Assert.AreEqual(42                                                , value1);
+            Assert.AreEqual("Hello World"                                     , value2);
+            Assert.AreEqual(TimeSpan.FromHours(3)                             , value3);
+            Assert.AreEqual(3.14d                                             , value4);
+            Assert.AreEqual(100L                                              , value5);
+            Assert.AreEqual('a'                                               , value6);
+            Assert.AreEqual(Guid.Parse("56128c75-379f-4c24-ac02-7ceb335807af"), value7);
+            Assert.AreEqual((sbyte)-3                                         , value8);
+        }
+    }
+}

--- a/src/Sweetener.Test/Threading/Tasks/MultiTask.Test.cs
+++ b/src/Sweetener.Test/Threading/Tasks/MultiTask.Test.cs
@@ -15,7 +15,7 @@ namespace Sweetener.Threading.Tasks.Test
         [TestMethod]
         public async Task WhenAllT2()
         {
-            // Exceptions
+            // Bad Input
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(
                 () => MultiTask.WhenAll(
                     (Task<int>)null!,
@@ -38,7 +38,7 @@ namespace Sweetener.Threading.Tasks.Test
         [TestMethod]
         public async Task WhenAllT3()
         {
-            // Exceptions
+            // Bad Input
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(
                 () => MultiTask.WhenAll(
                     (Task<int>)null!,
@@ -71,7 +71,7 @@ namespace Sweetener.Threading.Tasks.Test
         [TestMethod]
         public async Task WhenAllT4()
         {
-            // Exceptions
+            // Bad Input
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(
                 () => MultiTask.WhenAll(
                     (Task<int>)null!,
@@ -116,7 +116,7 @@ namespace Sweetener.Threading.Tasks.Test
         [TestMethod]
         public async Task WhenAllT5()
         {
-            // Exceptions
+            // Bad Input
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(
                 () => MultiTask.WhenAll(
                     (Task<int>)null!,
@@ -175,7 +175,7 @@ namespace Sweetener.Threading.Tasks.Test
         [TestMethod]
         public async Task WhenAllT6()
         {
-            // Exceptions
+            // Bad Input
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(
                 () => MultiTask.WhenAll(
                     (Task<int>)null!,
@@ -250,7 +250,7 @@ namespace Sweetener.Threading.Tasks.Test
         [TestMethod]
         public async Task WhenAllT7()
         {
-            // Exceptions
+            // Bad Input
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(
                 () => MultiTask.WhenAll(
                     (Task<int>)null!,
@@ -343,7 +343,7 @@ namespace Sweetener.Threading.Tasks.Test
         [TestMethod]
         public async Task WhenAllT8()
         {
-            // Exceptions
+            // Bad Input
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(
                 () => MultiTask.WhenAll(
                     (Task<int>)null!,

--- a/src/Sweetener.Test/Threading/Tasks/MultiTask.Test.tt
+++ b/src/Sweetener.Test/Threading/Tasks/MultiTask.Test.tt
@@ -21,7 +21,7 @@ namespace Sweetener.Threading.Tasks.Test
         [TestMethod]
         public async Task WhenAllT<#= parameterCount #>()
         {
-            // Exceptions
+            // Bad Input
 <#
             for (int i = 1; i <= parameterCount; i++)
             {

--- a/src/Sweetener.Test/Threading/Tasks/MultiTask.Test.tt
+++ b/src/Sweetener.Test/Threading/Tasks/MultiTask.Test.tt
@@ -1,0 +1,98 @@
+﻿<#@ template hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System" #>
+<#@ import namespace="System.Linq" #>
+<#@ include file="$(SrcDirectory)TextTemplating\Include.t4" #><# PrintHeader(); #>
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Threading.Tasks.Test
+{
+    [TestClass]
+    public class MultiTaskTest
+    {
+<#
+        for (int parameterCount = 2; parameterCount <= Arguments.Count; parameterCount++)
+        {
+#>
+        [TestMethod]
+        public async Task WhenAllT<#= parameterCount #>()
+        {
+            // Exceptions
+<#
+            for (int i = 1; i <= parameterCount; i++)
+            {
+#>
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => MultiTask.WhenAll(
+<#
+                for (int j = 1; j <= parameterCount; j++)
+                {
+                    string suffix = j == parameterCount ? ")).ConfigureAwait(false);" : ",";
+                    string taskExpr = j == i
+                        ? Enclose(Arguments[j - 1].TaskType, BracketType.Parentheses) + "null!"
+                        : string.Format(CultureInfo.InvariantCulture, "Task.FromResult({0})", Arguments[j - 1].Value);
+#>
+                    <#= taskExpr + suffix #>
+<#
+                }
+#>
+
+<#
+            }
+#>
+            // Success
+            <#= GetResultTuple(parameterCount) #> = await MultiTask.WhenAll(
+<#
+            for (int i = 1; i <= parameterCount; i++)
+            {
+                string suffix = i == parameterCount ? ").ConfigureAwait(false);" : ",";
+#>
+                <#= string.Format(CultureInfo.InvariantCulture, "Task.FromResult({0})", Arguments[i - 1].Value) + suffix #>
+<#
+            }
+#>
+
+<#
+            for (int i = 1; i <= parameterCount; i++)
+            {
+                int maxSize = Arguments.Take(parameterCount).Select(x => x.Value.Length).Max();
+#>
+            Assert.AreEqual(<#= Arguments[i - 1].Value.PadRight(maxSize) #>, value<#= i #>);
+<#
+            }
+#>
+        }
+<#
+            // Avoid extra newlines
+            if (parameterCount < Arguments.Count)
+            {
+#>
+
+<#
+            }
+        }
+#>
+    }
+}
+<#+
+public IReadOnlyList<(string TaskType, string ValueType, string Value)> Arguments = new List<(string, string, string)>
+{
+    ("Task<int>"     , "int"     ,"42"),
+    ("Task<string>"  , "string"  ,"\"Hello World\""),
+    ("Task<TimeSpan>", "TimeSpan","TimeSpan.FromHours(3)"),
+    ("Task<double>"  , "double"  ,"3.14d"),
+    ("Task<long>"    , "long"    ,"100L"),
+    ("Task<char>"    , "char"    ,"'a'"),
+    ("Task<Guid>"    , "Guid"    ,"Guid.Parse(\"56128c75-379f-4c24-ac02-7ceb335807af\")"),
+    ("Task<sbyte>"   , "sbyte"   ,"(sbyte)-3")
+};
+
+public string GetResultTuple(int count)
+    => Enclose(
+        string.Join(", ", Arguments.Take(count).Select((x, i) => x.ValueType + " value" + (i + 1))),
+        BracketType.Parentheses);
+#>

--- a/src/Sweetener.Test/Threading/Tasks/TaskExtensions.Test.cs
+++ b/src/Sweetener.Test/Threading/Tasks/TaskExtensions.Test.cs
@@ -16,10 +16,10 @@ namespace Sweetener.Threading.Tasks.Test
         [TestMethod]
         public async Task WithResultOnSuccess()
         {
+            // Bad Input
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(
                 () => TaskExtensions.WithResultOnSuccess(null!, s => 42, "State")).ConfigureAwait(false);
 
-            // Bad Input
             await Assert.ThrowsExceptionAsync<ArgumentNullException>(
                 () => Task.CompletedTask.WithResultOnSuccess<string, int>(null!, "State")).ConfigureAwait(false);
 

--- a/src/Sweetener.Test/Threading/Tasks/TaskExtensions.Test.cs
+++ b/src/Sweetener.Test/Threading/Tasks/TaskExtensions.Test.cs
@@ -1,0 +1,76 @@
+﻿// Copyright © William Sugarman.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Threading.Tasks.Test
+{
+    [TestClass]
+    public class TaskExtensionsTest
+    {
+        [TestMethod]
+        public async Task WithResultOnSuccess()
+        {
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => TaskExtensions.WithResultOnSuccess(null!, s => 42, "State")).ConfigureAwait(false);
+
+            // Bad Input
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => Task.CompletedTask.WithResultOnSuccess<string, int>(null!, "State")).ConfigureAwait(false);
+
+            // Success
+            string actual = await Task.CompletedTask.WithResultOnSuccess(s => s, "Success!").ConfigureAwait(false);
+            Assert.AreEqual("Success!", actual);
+
+            // Canceled
+            using CancellationTokenSource source = new CancellationTokenSource();
+            source.Cancel();
+
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            {
+                try
+                {
+                    await Task.FromCanceled(source.Token)
+                        .WithResultOnSuccess(s => s, "Hello World")
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException oce)
+                {
+                    Assert.AreEqual(source.Token, oce.CancellationToken);
+                    throw;
+                }
+            }).ConfigureAwait(false);
+
+            // Failure
+            await Assert.ThrowsExceptionAsync<IOException>(async () =>
+            {
+                Task t = Task
+                    .WhenAll(
+                        Task.FromException(new IOException()),
+                        Task.FromResult(5),
+                        Task.FromException(new NotSupportedException()))
+                    .WithResultOnSuccess(s => s, "Hello World");
+
+                try
+                {
+                    await t.ConfigureAwait(false);
+                }
+                catch (IOException)
+                {
+                    ReadOnlyCollection<Exception>? exceptions = t.Exception?.InnerExceptions;
+                    Assert.IsNotNull(exceptions);
+
+                    Assert.AreEqual(2, exceptions.Count);
+                    Assert.IsInstanceOfType(exceptions[0], typeof(IOException));
+                    Assert.IsInstanceOfType(exceptions[1], typeof(NotSupportedException));
+                    throw;
+                }
+            }).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Sweetener.Test/Threading/Tasks/TaskExtensions.Test.cs
+++ b/src/Sweetener.Test/Threading/Tasks/TaskExtensions.Test.cs
@@ -31,7 +31,7 @@ namespace Sweetener.Threading.Tasks.Test
             using CancellationTokenSource source = new CancellationTokenSource();
             source.Cancel();
 
-            await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            await Assert.ThrowsExceptionAsync<TaskCanceledException>(async () =>
             {
                 try
                 {
@@ -39,7 +39,7 @@ namespace Sweetener.Threading.Tasks.Test
                         .WithResultOnSuccess(s => s, "Hello World")
                         .ConfigureAwait(false);
                 }
-                catch (OperationCanceledException oce)
+                catch (TaskCanceledException oce)
                 {
                     Assert.AreEqual(source.Token, oce.CancellationToken);
                     throw;

--- a/src/Sweetener/Sweetener.csproj
+++ b/src/Sweetener/Sweetener.csproj
@@ -11,6 +11,10 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
   <!-- Generated Files -->
   <ItemGroup>
     <Compile Update="AsyncAction.cs">
@@ -22,6 +26,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>AsyncFunc.tt</DependentUpon>
       <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Update="Threading\Tasks\MultiTask.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>MultiTask.tt</DependentUpon>
     </Compile>
     <Compile Update="TryFunc.cs">
       <AutoGen>True</AutoGen>
@@ -39,6 +48,10 @@
     <None Update="AsyncAction.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>AsyncAction.cs</LastGenOutput>
+    </None>
+    <None Update="Threading\Tasks\MultiTask.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>MultiTask.cs</LastGenOutput>
     </None>
     <None Update="TryFunc.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/Sweetener/Sweetener.csproj
+++ b/src/Sweetener/Sweetener.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 
   <!-- Generated Files -->
@@ -57,10 +57,6 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>TryFunc.cs</LastGenOutput>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 
 </Project>

--- a/src/Sweetener/TextTemplating/Include.t4
+++ b/src/Sweetener/TextTemplating/Include.t4
@@ -3,36 +3,13 @@
 <#@ include file="$(SrcDirectory)TextTemplating\Include.t4" #><#+
 
     public void PrintDelegateParamsXmlDoc(int parameterCount, int indent)
-    {
-        if (parameterCount < 0)
-            throw new ArgumentOutOfRangeException(nameof(parameterCount));
-
-        string spaces = new string(' ', indent * SpacesPerTab);
-        for (int i = 1; i <= parameterCount; i++)
-        {
-            string param     = parameterCount == 1 ? "arg" : "arg" + i;
-            string qualifier = parameterCount == 1 ? string.Empty : GetNthWord(i) + " ";
-#>
-<#= spaces #>/// <param name="<#= param #>">The <#= qualifier #>parameter of the method that this delegate encapsulates.</param>
-<#+
-        }
-    }
+        => PrintParamsXmlDoc(parameterCount, indent, "The {0}parameter of the method that this delegate encapsulates.");
 
     public void PrintDelegateTypeParamsXmlDoc(int typeParameterCount, int indent, bool includeResult)
     {
-        if (typeParameterCount < 0)
-            throw new ArgumentOutOfRangeException(nameof(typeParameterCount));
+        PrintTypeParamsXmlDoc(typeParameterCount, indent, "The type of the {0}parameter of the method that this delegate encapsulates.");
 
         string spaces = new string(' ', indent * SpacesPerTab);
-        for (int i = 1; i <= typeParameterCount; i++)
-        {
-            string typeParameter = typeParameterCount == 1 ? "T" : "T" + i;
-            string qualifier     = typeParameterCount == 1 ? string.Empty : GetNthWord(i) + " ";
-#>
-<#= spaces #>/// <typeparam name="<#= typeParameter #>">The type of the <#= qualifier #>parameter of the method that this delegate encapsulates.</typeparam>
-<#+
-        }
-
         if (includeResult)
         {
 #>

--- a/src/Sweetener/Threading/Tasks/MultiTask.cs
+++ b/src/Sweetener/Threading/Tasks/MultiTask.cs
@@ -9,7 +9,8 @@ using System.Threading.Tasks;
 namespace Sweetener.Threading.Tasks
 {
     /// <summary>
-    /// Provides a set of <see langword="static"/> methods for interacting with multiple instances of <see cref="Task{T}"/> and <see cref="ValueTask{T}"/>.
+    /// Provides a set of <see langword="static"/> methods for interacting with multiple <see cref="Task{T}"/> objects
+    /// whose type arguments may differ.
     /// </summary>
     public static class MultiTask
     {
@@ -21,7 +22,7 @@ namespace Sweetener.Threading.Tasks
         /// <param name="task1">The first task to wait on for completion.</param>
         /// <param name="task2">The second task to wait on for completion.</param>
         /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
-        public static async Task<(T1, T2)> WhenAll<T1, T2>(Task<T1> task1, Task<T2> task2)
+        public static Task<(T1, T2)> WhenAll<T1, T2>(Task<T1> task1, Task<T2> task2)
         {
             if (task1 == null)
                 throw new ArgumentNullException(nameof(task1));
@@ -29,8 +30,9 @@ namespace Sweetener.Threading.Tasks
             if (task2 == null)
                 throw new ArgumentNullException(nameof(task2));
 
-            await Task.WhenAll(task1, task2).ConfigureAwait(false);
-            return (task1.Result, task2.Result);
+            return Task.WhenAll(task1, task2).WithResultOnSuccess(
+                t => (t.Task1.Result, t.Task2.Result),
+                (Task1: task1, Task2: task2));
         }
 
         /// <summary>
@@ -43,7 +45,7 @@ namespace Sweetener.Threading.Tasks
         /// <param name="task2">The second task to wait on for completion.</param>
         /// <param name="task3">The third task to wait on for completion.</param>
         /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
-        public static async Task<(T1, T2, T3)> WhenAll<T1, T2, T3>(Task<T1> task1, Task<T2> task2, Task<T3> task3)
+        public static Task<(T1, T2, T3)> WhenAll<T1, T2, T3>(Task<T1> task1, Task<T2> task2, Task<T3> task3)
         {
             if (task1 == null)
                 throw new ArgumentNullException(nameof(task1));
@@ -54,8 +56,9 @@ namespace Sweetener.Threading.Tasks
             if (task3 == null)
                 throw new ArgumentNullException(nameof(task3));
 
-            await Task.WhenAll(task1, task2, task3).ConfigureAwait(false);
-            return (task1.Result, task2.Result, task3.Result);
+            return Task.WhenAll(task1, task2, task3).WithResultOnSuccess(
+                t => (t.Task1.Result, t.Task2.Result, t.Task3.Result),
+                (Task1: task1, Task2: task2, Task3: task3));
         }
 
         /// <summary>
@@ -70,7 +73,7 @@ namespace Sweetener.Threading.Tasks
         /// <param name="task3">The third task to wait on for completion.</param>
         /// <param name="task4">The fourth task to wait on for completion.</param>
         /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
-        public static async Task<(T1, T2, T3, T4)> WhenAll<T1, T2, T3, T4>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4)
+        public static Task<(T1, T2, T3, T4)> WhenAll<T1, T2, T3, T4>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4)
         {
             if (task1 == null)
                 throw new ArgumentNullException(nameof(task1));
@@ -84,8 +87,9 @@ namespace Sweetener.Threading.Tasks
             if (task4 == null)
                 throw new ArgumentNullException(nameof(task4));
 
-            await Task.WhenAll(task1, task2, task3, task4).ConfigureAwait(false);
-            return (task1.Result, task2.Result, task3.Result, task4.Result);
+            return Task.WhenAll(task1, task2, task3, task4).WithResultOnSuccess(
+                t => (t.Task1.Result, t.Task2.Result, t.Task3.Result, t.Task4.Result),
+                (Task1: task1, Task2: task2, Task3: task3, Task4: task4));
         }
 
         /// <summary>
@@ -102,7 +106,7 @@ namespace Sweetener.Threading.Tasks
         /// <param name="task4">The fourth task to wait on for completion.</param>
         /// <param name="task5">The fifth task to wait on for completion.</param>
         /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
-        public static async Task<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5)
+        public static Task<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5)
         {
             if (task1 == null)
                 throw new ArgumentNullException(nameof(task1));
@@ -119,8 +123,9 @@ namespace Sweetener.Threading.Tasks
             if (task5 == null)
                 throw new ArgumentNullException(nameof(task5));
 
-            await Task.WhenAll(task1, task2, task3, task4, task5).ConfigureAwait(false);
-            return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result);
+            return Task.WhenAll(task1, task2, task3, task4, task5).WithResultOnSuccess(
+                t => (t.Task1.Result, t.Task2.Result, t.Task3.Result, t.Task4.Result, t.Task5.Result),
+                (Task1: task1, Task2: task2, Task3: task3, Task4: task4, Task5: task5));
         }
 
         /// <summary>
@@ -139,7 +144,7 @@ namespace Sweetener.Threading.Tasks
         /// <param name="task5">The fifth task to wait on for completion.</param>
         /// <param name="task6">The sixth task to wait on for completion.</param>
         /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
-        public static async Task<(T1, T2, T3, T4, T5, T6)> WhenAll<T1, T2, T3, T4, T5, T6>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6)
+        public static Task<(T1, T2, T3, T4, T5, T6)> WhenAll<T1, T2, T3, T4, T5, T6>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6)
         {
             if (task1 == null)
                 throw new ArgumentNullException(nameof(task1));
@@ -159,8 +164,9 @@ namespace Sweetener.Threading.Tasks
             if (task6 == null)
                 throw new ArgumentNullException(nameof(task6));
 
-            await Task.WhenAll(task1, task2, task3, task4, task5, task6).ConfigureAwait(false);
-            return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result, task6.Result);
+            return Task.WhenAll(task1, task2, task3, task4, task5, task6).WithResultOnSuccess(
+                t => (t.Task1.Result, t.Task2.Result, t.Task3.Result, t.Task4.Result, t.Task5.Result, t.Task6.Result),
+                (Task1: task1, Task2: task2, Task3: task3, Task4: task4, Task5: task5, Task6: task6));
         }
 
         /// <summary>
@@ -181,7 +187,7 @@ namespace Sweetener.Threading.Tasks
         /// <param name="task6">The sixth task to wait on for completion.</param>
         /// <param name="task7">The seventh task to wait on for completion.</param>
         /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
-        public static async Task<(T1, T2, T3, T4, T5, T6, T7)> WhenAll<T1, T2, T3, T4, T5, T6, T7>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6, Task<T7> task7)
+        public static Task<(T1, T2, T3, T4, T5, T6, T7)> WhenAll<T1, T2, T3, T4, T5, T6, T7>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6, Task<T7> task7)
         {
             if (task1 == null)
                 throw new ArgumentNullException(nameof(task1));
@@ -204,8 +210,9 @@ namespace Sweetener.Threading.Tasks
             if (task7 == null)
                 throw new ArgumentNullException(nameof(task7));
 
-            await Task.WhenAll(task1, task2, task3, task4, task5, task6, task7).ConfigureAwait(false);
-            return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result, task6.Result, task7.Result);
+            return Task.WhenAll(task1, task2, task3, task4, task5, task6, task7).WithResultOnSuccess(
+                t => (t.Task1.Result, t.Task2.Result, t.Task3.Result, t.Task4.Result, t.Task5.Result, t.Task6.Result, t.Task7.Result),
+                (Task1: task1, Task2: task2, Task3: task3, Task4: task4, Task5: task5, Task6: task6, Task7: task7));
         }
 
         /// <summary>
@@ -228,7 +235,7 @@ namespace Sweetener.Threading.Tasks
         /// <param name="task7">The seventh task to wait on for completion.</param>
         /// <param name="task8">The eighth task to wait on for completion.</param>
         /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
-        public static async Task<(T1, T2, T3, T4, T5, T6, T7, T8)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6, Task<T7> task7, Task<T8> task8)
+        public static Task<(T1, T2, T3, T4, T5, T6, T7, T8)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6, Task<T7> task7, Task<T8> task8)
         {
             if (task1 == null)
                 throw new ArgumentNullException(nameof(task1));
@@ -254,8 +261,9 @@ namespace Sweetener.Threading.Tasks
             if (task8 == null)
                 throw new ArgumentNullException(nameof(task8));
 
-            await Task.WhenAll(task1, task2, task3, task4, task5, task6, task7, task8).ConfigureAwait(false);
-            return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result, task6.Result, task7.Result, task8.Result);
+            return Task.WhenAll(task1, task2, task3, task4, task5, task6, task7, task8).WithResultOnSuccess(
+                t => (t.Task1.Result, t.Task2.Result, t.Task3.Result, t.Task4.Result, t.Task5.Result, t.Task6.Result, t.Task7.Result, t.Task8.Result),
+                (Task1: task1, Task2: task2, Task3: task3, Task4: task4, Task5: task5, Task6: task6, Task7: task7, Task8: task8));
         }
     }
 }

--- a/src/Sweetener/Threading/Tasks/MultiTask.cs
+++ b/src/Sweetener/Threading/Tasks/MultiTask.cs
@@ -1,0 +1,261 @@
+﻿// Copyright © William Sugarman.
+// Licensed under the MIT License.
+
+// Do not modify this file. It was automatically generated from MultiTask.tt
+
+using System;
+using System.Threading.Tasks;
+
+namespace Sweetener.Threading.Tasks
+{
+    /// <summary>
+    /// Provides a set of <see langword="static"/> methods for interacting with multiple instances of <see cref="Task{T}"/> and <see cref="ValueTask{T}"/>.
+    /// </summary>
+    public static class MultiTask
+    {
+        /// <summary>
+        /// Creates a task that will complete when all of the <see cref="Task{TResult}"/> objects have completed.
+        /// </summary>
+        /// <typeparam name="T1">The result type of the first task.</typeparam>
+        /// <typeparam name="T2">The result type of the second task.</typeparam>
+        /// <param name="task1">The first task to wait on for completion.</param>
+        /// <param name="task2">The second task to wait on for completion.</param>
+        /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+        public static async Task<(T1, T2)> WhenAll<T1, T2>(Task<T1> task1, Task<T2> task2)
+        {
+            if (task1 == null)
+                throw new ArgumentNullException(nameof(task1));
+
+            if (task2 == null)
+                throw new ArgumentNullException(nameof(task2));
+
+            await Task.WhenAll(task1, task2).ConfigureAwait(false);
+            return (task1.Result, task2.Result);
+        }
+
+        /// <summary>
+        /// Creates a task that will complete when all of the <see cref="Task{TResult}"/> objects have completed.
+        /// </summary>
+        /// <typeparam name="T1">The result type of the first task.</typeparam>
+        /// <typeparam name="T2">The result type of the second task.</typeparam>
+        /// <typeparam name="T3">The result type of the third task.</typeparam>
+        /// <param name="task1">The first task to wait on for completion.</param>
+        /// <param name="task2">The second task to wait on for completion.</param>
+        /// <param name="task3">The third task to wait on for completion.</param>
+        /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+        public static async Task<(T1, T2, T3)> WhenAll<T1, T2, T3>(Task<T1> task1, Task<T2> task2, Task<T3> task3)
+        {
+            if (task1 == null)
+                throw new ArgumentNullException(nameof(task1));
+
+            if (task2 == null)
+                throw new ArgumentNullException(nameof(task2));
+
+            if (task3 == null)
+                throw new ArgumentNullException(nameof(task3));
+
+            await Task.WhenAll(task1, task2, task3).ConfigureAwait(false);
+            return (task1.Result, task2.Result, task3.Result);
+        }
+
+        /// <summary>
+        /// Creates a task that will complete when all of the <see cref="Task{TResult}"/> objects have completed.
+        /// </summary>
+        /// <typeparam name="T1">The result type of the first task.</typeparam>
+        /// <typeparam name="T2">The result type of the second task.</typeparam>
+        /// <typeparam name="T3">The result type of the third task.</typeparam>
+        /// <typeparam name="T4">The result type of the fourth task.</typeparam>
+        /// <param name="task1">The first task to wait on for completion.</param>
+        /// <param name="task2">The second task to wait on for completion.</param>
+        /// <param name="task3">The third task to wait on for completion.</param>
+        /// <param name="task4">The fourth task to wait on for completion.</param>
+        /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+        public static async Task<(T1, T2, T3, T4)> WhenAll<T1, T2, T3, T4>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4)
+        {
+            if (task1 == null)
+                throw new ArgumentNullException(nameof(task1));
+
+            if (task2 == null)
+                throw new ArgumentNullException(nameof(task2));
+
+            if (task3 == null)
+                throw new ArgumentNullException(nameof(task3));
+
+            if (task4 == null)
+                throw new ArgumentNullException(nameof(task4));
+
+            await Task.WhenAll(task1, task2, task3, task4).ConfigureAwait(false);
+            return (task1.Result, task2.Result, task3.Result, task4.Result);
+        }
+
+        /// <summary>
+        /// Creates a task that will complete when all of the <see cref="Task{TResult}"/> objects have completed.
+        /// </summary>
+        /// <typeparam name="T1">The result type of the first task.</typeparam>
+        /// <typeparam name="T2">The result type of the second task.</typeparam>
+        /// <typeparam name="T3">The result type of the third task.</typeparam>
+        /// <typeparam name="T4">The result type of the fourth task.</typeparam>
+        /// <typeparam name="T5">The result type of the fifth task.</typeparam>
+        /// <param name="task1">The first task to wait on for completion.</param>
+        /// <param name="task2">The second task to wait on for completion.</param>
+        /// <param name="task3">The third task to wait on for completion.</param>
+        /// <param name="task4">The fourth task to wait on for completion.</param>
+        /// <param name="task5">The fifth task to wait on for completion.</param>
+        /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+        public static async Task<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5)
+        {
+            if (task1 == null)
+                throw new ArgumentNullException(nameof(task1));
+
+            if (task2 == null)
+                throw new ArgumentNullException(nameof(task2));
+
+            if (task3 == null)
+                throw new ArgumentNullException(nameof(task3));
+
+            if (task4 == null)
+                throw new ArgumentNullException(nameof(task4));
+
+            if (task5 == null)
+                throw new ArgumentNullException(nameof(task5));
+
+            await Task.WhenAll(task1, task2, task3, task4, task5).ConfigureAwait(false);
+            return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result);
+        }
+
+        /// <summary>
+        /// Creates a task that will complete when all of the <see cref="Task{TResult}"/> objects have completed.
+        /// </summary>
+        /// <typeparam name="T1">The result type of the first task.</typeparam>
+        /// <typeparam name="T2">The result type of the second task.</typeparam>
+        /// <typeparam name="T3">The result type of the third task.</typeparam>
+        /// <typeparam name="T4">The result type of the fourth task.</typeparam>
+        /// <typeparam name="T5">The result type of the fifth task.</typeparam>
+        /// <typeparam name="T6">The result type of the sixth task.</typeparam>
+        /// <param name="task1">The first task to wait on for completion.</param>
+        /// <param name="task2">The second task to wait on for completion.</param>
+        /// <param name="task3">The third task to wait on for completion.</param>
+        /// <param name="task4">The fourth task to wait on for completion.</param>
+        /// <param name="task5">The fifth task to wait on for completion.</param>
+        /// <param name="task6">The sixth task to wait on for completion.</param>
+        /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+        public static async Task<(T1, T2, T3, T4, T5, T6)> WhenAll<T1, T2, T3, T4, T5, T6>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6)
+        {
+            if (task1 == null)
+                throw new ArgumentNullException(nameof(task1));
+
+            if (task2 == null)
+                throw new ArgumentNullException(nameof(task2));
+
+            if (task3 == null)
+                throw new ArgumentNullException(nameof(task3));
+
+            if (task4 == null)
+                throw new ArgumentNullException(nameof(task4));
+
+            if (task5 == null)
+                throw new ArgumentNullException(nameof(task5));
+
+            if (task6 == null)
+                throw new ArgumentNullException(nameof(task6));
+
+            await Task.WhenAll(task1, task2, task3, task4, task5, task6).ConfigureAwait(false);
+            return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result, task6.Result);
+        }
+
+        /// <summary>
+        /// Creates a task that will complete when all of the <see cref="Task{TResult}"/> objects have completed.
+        /// </summary>
+        /// <typeparam name="T1">The result type of the first task.</typeparam>
+        /// <typeparam name="T2">The result type of the second task.</typeparam>
+        /// <typeparam name="T3">The result type of the third task.</typeparam>
+        /// <typeparam name="T4">The result type of the fourth task.</typeparam>
+        /// <typeparam name="T5">The result type of the fifth task.</typeparam>
+        /// <typeparam name="T6">The result type of the sixth task.</typeparam>
+        /// <typeparam name="T7">The result type of the seventh task.</typeparam>
+        /// <param name="task1">The first task to wait on for completion.</param>
+        /// <param name="task2">The second task to wait on for completion.</param>
+        /// <param name="task3">The third task to wait on for completion.</param>
+        /// <param name="task4">The fourth task to wait on for completion.</param>
+        /// <param name="task5">The fifth task to wait on for completion.</param>
+        /// <param name="task6">The sixth task to wait on for completion.</param>
+        /// <param name="task7">The seventh task to wait on for completion.</param>
+        /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+        public static async Task<(T1, T2, T3, T4, T5, T6, T7)> WhenAll<T1, T2, T3, T4, T5, T6, T7>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6, Task<T7> task7)
+        {
+            if (task1 == null)
+                throw new ArgumentNullException(nameof(task1));
+
+            if (task2 == null)
+                throw new ArgumentNullException(nameof(task2));
+
+            if (task3 == null)
+                throw new ArgumentNullException(nameof(task3));
+
+            if (task4 == null)
+                throw new ArgumentNullException(nameof(task4));
+
+            if (task5 == null)
+                throw new ArgumentNullException(nameof(task5));
+
+            if (task6 == null)
+                throw new ArgumentNullException(nameof(task6));
+
+            if (task7 == null)
+                throw new ArgumentNullException(nameof(task7));
+
+            await Task.WhenAll(task1, task2, task3, task4, task5, task6, task7).ConfigureAwait(false);
+            return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result, task6.Result, task7.Result);
+        }
+
+        /// <summary>
+        /// Creates a task that will complete when all of the <see cref="Task{TResult}"/> objects have completed.
+        /// </summary>
+        /// <typeparam name="T1">The result type of the first task.</typeparam>
+        /// <typeparam name="T2">The result type of the second task.</typeparam>
+        /// <typeparam name="T3">The result type of the third task.</typeparam>
+        /// <typeparam name="T4">The result type of the fourth task.</typeparam>
+        /// <typeparam name="T5">The result type of the fifth task.</typeparam>
+        /// <typeparam name="T6">The result type of the sixth task.</typeparam>
+        /// <typeparam name="T7">The result type of the seventh task.</typeparam>
+        /// <typeparam name="T8">The result type of the eighth task.</typeparam>
+        /// <param name="task1">The first task to wait on for completion.</param>
+        /// <param name="task2">The second task to wait on for completion.</param>
+        /// <param name="task3">The third task to wait on for completion.</param>
+        /// <param name="task4">The fourth task to wait on for completion.</param>
+        /// <param name="task5">The fifth task to wait on for completion.</param>
+        /// <param name="task6">The sixth task to wait on for completion.</param>
+        /// <param name="task7">The seventh task to wait on for completion.</param>
+        /// <param name="task8">The eighth task to wait on for completion.</param>
+        /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+        public static async Task<(T1, T2, T3, T4, T5, T6, T7, T8)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6, Task<T7> task7, Task<T8> task8)
+        {
+            if (task1 == null)
+                throw new ArgumentNullException(nameof(task1));
+
+            if (task2 == null)
+                throw new ArgumentNullException(nameof(task2));
+
+            if (task3 == null)
+                throw new ArgumentNullException(nameof(task3));
+
+            if (task4 == null)
+                throw new ArgumentNullException(nameof(task4));
+
+            if (task5 == null)
+                throw new ArgumentNullException(nameof(task5));
+
+            if (task6 == null)
+                throw new ArgumentNullException(nameof(task6));
+
+            if (task7 == null)
+                throw new ArgumentNullException(nameof(task7));
+
+            if (task8 == null)
+                throw new ArgumentNullException(nameof(task8));
+
+            await Task.WhenAll(task1, task2, task3, task4, task5, task6, task7, task8).ConfigureAwait(false);
+            return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result, task6.Result, task7.Result, task8.Result);
+        }
+    }
+}

--- a/src/Sweetener/Threading/Tasks/MultiTask.tt
+++ b/src/Sweetener/Threading/Tasks/MultiTask.tt
@@ -1,0 +1,59 @@
+﻿<#@ template hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System" #>
+<#@ include file="$(MSBuildProjectDirectory)\TextTemplating\Include.t4" #><# PrintHeader(); #>
+
+using System;
+using System.Threading.Tasks;
+
+namespace Sweetener.Threading.Tasks
+{
+    /// <summary>
+    /// Provides a set of <see langword="static"/> methods for interacting with multiple instances of <see cref="Task{T}"/> and <see cref="ValueTask{T}"/>.
+    /// </summary>
+    public static class MultiTask
+    {
+<#
+        const int MaxOverloads = 8;
+        for (int parameterCount = 2; parameterCount <= MaxOverloads; parameterCount++)
+        {
+            string parameters     = GetParameters(parameterCount, "Task<T{0}>", "task{0}");
+            string typeParameters = GetInputTypeParameters(parameterCount, "T{0}");
+#>
+        /// <summary>
+        /// Creates a task that will complete when all of the <see cref="Task{TResult}"/> objects have completed.
+        /// </summary>
+<#
+            PrintTypeParamsXmlDoc(parameterCount, indent: 2, messageFormat: "The result type of the {0}task."       , typeFormat: "T{0}");
+            PrintParamsXmlDoc    (parameterCount, indent: 2, messageFormat: "The {0}task to wait on for completion.", parameterFormat: "task{0}");
+#>
+        /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+        public static async Task<(<#= typeParameters #>)> WhenAll<<#= typeParameters #>>(<#= parameters #>)
+        {
+<#
+            for (int i = 1; i <= parameterCount; i++)
+            {
+                string taskName = string.Format(CultureInfo.InvariantCulture, "task{0}", i);
+#>
+            if (<#= taskName #> == null)
+                throw new ArgumentNullException(nameof(<#= taskName #>));
+
+<#
+            }
+#>
+            await Task.WhenAll(<#= GetArguments(parameterCount, "task{0}") #>).ConfigureAwait(false);
+            return (<#= GetArguments(parameterCount, "task{0}.Result") #>);
+        }
+<#
+            // Avoid extra newlines
+            if (parameterCount < MaxOverloads)
+            {
+#>
+
+<#
+            }
+        }
+#>
+    }
+}

--- a/src/Sweetener/Threading/Tasks/MultiTask.tt
+++ b/src/Sweetener/Threading/Tasks/MultiTask.tt
@@ -10,7 +10,8 @@ using System.Threading.Tasks;
 namespace Sweetener.Threading.Tasks
 {
     /// <summary>
-    /// Provides a set of <see langword="static"/> methods for interacting with multiple instances of <see cref="Task{T}"/> and <see cref="ValueTask{T}"/>.
+    /// Provides a set of <see langword="static"/> methods for interacting with multiple <see cref="Task{T}"/> objects
+    /// whose type arguments may differ.
     /// </summary>
     public static class MultiTask
     {
@@ -29,7 +30,7 @@ namespace Sweetener.Threading.Tasks
             PrintParamsXmlDoc    (parameterCount, indent: 2, messageFormat: "The {0}task to wait on for completion.", parameterFormat: "task{0}");
 #>
         /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
-        public static async Task<(<#= typeParameters #>)> WhenAll<<#= typeParameters #>>(<#= parameters #>)
+        public static Task<(<#= typeParameters #>)> WhenAll<<#= typeParameters #>>(<#= parameters #>)
         {
 <#
             for (int i = 1; i <= parameterCount; i++)
@@ -42,8 +43,9 @@ namespace Sweetener.Threading.Tasks
 <#
             }
 #>
-            await Task.WhenAll(<#= GetArguments(parameterCount, "task{0}") #>).ConfigureAwait(false);
-            return (<#= GetArguments(parameterCount, "task{0}.Result") #>);
+            return Task.WhenAll(<#= GetArguments(parameterCount, "task{0}") #>).WithResultOnSuccess(
+                t => (<#= GetArguments(parameterCount, "t.Task{0}.Result") #>),
+                (<#= GetArguments(parameterCount, "Task{0}: task{0}") #>));
         }
 <#
             // Avoid extra newlines

--- a/src/Sweetener/Threading/Tasks/TaskExtensions.cs
+++ b/src/Sweetener/Threading/Tasks/TaskExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Copyright © William Sugarman.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sweetener.Threading.Tasks
+{
+    internal static class TaskExtensions
+    {
+        // TODO: Add Task<T> if necessary
+        public static Task<TResult> WithResultOnSuccess<TState, TResult>(this Task task, Func<TState, TResult> resultSelector, TState state)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+
+            if (resultSelector == null)
+                throw new ArgumentNullException(nameof(resultSelector));
+
+            return task
+                .ContinueWith((t, obj) =>
+                    {
+                        switch (t.Status)
+                        {
+                            case TaskStatus.RanToCompletion:
+                                return Task.FromResult(resultSelector((TState)obj));
+                            case TaskStatus.Canceled:
+                                return ThrowIfCancellationRequested<TResult>(t);
+                            default:
+                                // Preserve all of the AggregateException's errors!
+                                TaskCompletionSource<TResult> tcs = new TaskCompletionSource<TResult>();
+                                tcs.SetException(t.Exception.InnerExceptions);
+                                return tcs.Task;
+                        }
+                    },
+                    state,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.DenyChildAttach,
+                    TaskScheduler.Default)
+                .Unwrap();
+        }
+
+        [ExcludeFromCodeCoverage]
+        private static Task<TResult> ThrowIfCancellationRequested<TResult>(Task t)
+        {
+            // Getting the result will cause an exception to be thrown such that
+            // the subsequent line is unreachable
+            t.GetAwaiter().GetResult();
+            return Task.FromResult<TResult>(default!);
+        }
+    }
+}

--- a/src/TextTemplating/Include.t4
+++ b/src/TextTemplating/Include.t4
@@ -1,6 +1,7 @@
 ﻿<#@ assembly name="System.Core" #>
 <#@ import namespace="System" #>
 <#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="System.Globalization" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="Microsoft.VisualStudio.TextTemplating" #>
@@ -36,42 +37,69 @@
         GenerationEnvironment.Length = 0; // Remove everything written thus far
     }
 
-    private string GetInputTypeParameters(int count, bool contravariant = false)
-        => GenerateIncrementingList(count, contravariant ? "in T" : "T"); // T1, T2, T3
+    private string GetInputTypeParameters(int count, string typeFormat = "T{0}", bool contravariant = false)
+        => GetIncrementingStrings(contravariant ? "in " + typeFormat : typeFormat, count); // T1, T2, T3
 
-    public string GetParameters(int count)
-        => GenerateIncrementingList(count, "T", "arg"); // T1 arg1, T2 arg2, T3 arg3
+    public string GetParameters(int count, string typeFormat = "T{0}", string nameFormat = "arg{0}")
+        => GetIncrementingStrings(typeFormat + " " + nameFormat, count); // T1 arg1, T2 arg2, T3 arg3
 
-    public string GetParameters(string[] types)
-        => GetParameters(types, types.Length);
+    public string GetArguments(int count, string nameFormat = "arg{0}")
+        => GetIncrementingStrings(nameFormat, count); // arg1, arg2, arg3
 
-    public string GetParameters(string[] types, int count)
-    {
-        if (count == 0)
-            return string.Empty;
-
-        return string.Join(", ", types.Take(count).Select((t, i) => t + " " + (count == 1 ? "arg" : "arg" + (i + 1))));
-    }
-
-    public string GetArguments(int count)
-        => GenerateIncrementingList(count, "arg"); // arg1, arg2, arg3
-
-    private string GenerateIncrementingList(int count, params string[] pattern)
+    private string GetIncrementingStrings(string formatString, int count)
     {
         if (count < 0)
             throw new ArgumentOutOfRangeException(nameof(count));
 
-        if (pattern == null || pattern.Length == 0)
-            throw new ArgumentException("At least 1 value must be specified", nameof(pattern));
+        if (string.IsNullOrWhiteSpace(formatString))
+            throw new ArgumentNullException(nameof(formatString));
 
         if (count == 0)
             return string.Empty;
 
         IEnumerable<string> elements = Enumerable
-            .Repeat(pattern, count)
-            .Select((p, i) => string.Join(" ", pattern.Select(x => count == 1 ? x : x + (i + 1))));
+            .Repeat(formatString, count)
+            .Select((p, i) => string.Format(p, count == 1 ? (int?)null : i + 1));
 
         return string.Join(", ", elements);
+    }
+
+    public void PrintParamsXmlDoc(int parameterCount, int indent, string messageFormat, string parameterFormat = "arg{0}")
+    {
+        if (parameterCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(parameterCount));
+
+        if (string.IsNullOrWhiteSpace(messageFormat))
+            throw new ArgumentNullException(nameof(messageFormat));
+
+        string spaces = new string(' ', indent * SpacesPerTab);
+        for (int i = 1; i <= parameterCount; i++)
+        {
+            string param     = string.Format(CultureInfo.InvariantCulture, parameterFormat, parameterCount == 1 ? (int?)null : i);
+            string qualifier = parameterCount == 1 ? string.Empty : GetNthWord(i) + " ";
+#>
+<#= spaces #>/// <param name="<#= param #>"><#= string.Format(CultureInfo.InvariantCulture, messageFormat, qualifier) #></param>
+<#+
+        }
+    }
+
+    public void PrintTypeParamsXmlDoc(int typeParameterCount, int indent, string messageFormat, string typeFormat = "T{0}")
+    {
+        if (typeParameterCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(typeParameterCount));
+
+        if (string.IsNullOrWhiteSpace(messageFormat))
+            throw new ArgumentNullException(nameof(messageFormat));
+
+        string spaces = new string(' ', indent * SpacesPerTab);
+        for (int i = 1; i <= typeParameterCount; i++)
+        {
+            string typeParameter = string.Format(CultureInfo.InvariantCulture, typeFormat, typeParameterCount == 1 ? (int?)null : i);
+            string qualifier     = typeParameterCount == 1 ? string.Empty : GetNthWord(i) + " ";
+#>
+<#= spaces #>/// <typeparam name="<#= typeParameter #>"><#= string.Format(CultureInfo.InvariantCulture, messageFormat, qualifier) #></typeparam>
+<#+
+        }
     }
 
     public string Enclose(string value, BracketType bracketType)

--- a/src/TextTemplating/Include.t4
+++ b/src/TextTemplating/Include.t4
@@ -22,7 +22,6 @@
 
 // Do not modify this file. It was automatically generated from <#= GetTemplateFileName() #>
 <#+
-
     }
 
     public void SaveOutput(string outputFileName)
@@ -33,7 +32,7 @@
         string templateDirectory = Path.GetDirectoryName(Host.TemplateFile);
         string outputFilePath    = Path.Combine(templateDirectory, outputFileName);
 
-        File.WriteAllText(outputFilePath, GenerationEnvironment.ToString()); 
+        File.WriteAllText(outputFilePath, GenerationEnvironment.ToString());
         GenerationEnvironment.Length = 0; // Remove everything written thus far
     }
 


### PR DESCRIPTION
- Add new class `MultiClass` that contains utility methods for operating upon `Task<TResult>` with different type arguments
- Add `WhenAll` which emulates `Task.WhenAll` except that it returns a `ValueTuple` containing all of the results upon success
    - To maintain parity, `WhenAll` also returns a `Task` containing all of the exceptions and will wait until the completion of every task, even if 1 task fails early