### PR TITLE
Use DateTimeOffset for IClock

### DIFF
--- a/src/Core/Sweetener.SourceGeneration/Input.cs
+++ b/src/Core/Sweetener.SourceGeneration/Input.cs
@@ -17,7 +17,7 @@ internal static class Input
         => GetIncrementingStrings(typeFormat + " " + nameFormat, count); // T1 arg1, T2 arg2, T3 arg3
 
     public static IEnumerable<string> GetTypeParameters(int count, string typeFormat = "T{0}", bool contravariant = false)
-    => GetIncrementingStrings(contravariant ? "in " + typeFormat : typeFormat, count); // T1, T2, T3
+        => GetIncrementingStrings(contravariant ? "in " + typeFormat : typeFormat, count); // T1, T2, T3
 
     private static IEnumerable<string> GetIncrementingStrings(string formatString, int count)
     {

--- a/src/Core/Sweetener.Test/Clock.Test.cs
+++ b/src/Core/Sweetener.Test/Clock.Test.cs
@@ -13,69 +13,38 @@ public class ClockTest
     public void System()
     {
         // Now
-        DateTime before = DateTime.Now;
-        DateTime now    = Clock.System.Now;
-        DateTime after  = DateTime.Now;
+        DateTimeOffset before = DateTimeOffset.Now;
+        DateTimeOffset now    = Clock.System.Now;
+        DateTimeOffset after  = DateTimeOffset.Now;
 
-        Assert.AreEqual(DateTimeKind.Local, now.Kind);
         Assert.IsTrue(before <= now);
         Assert.IsTrue(now <= after);
 
         // UtcNow
-        DateTime utcBefore = DateTime.UtcNow;
-        DateTime utcNow    = Clock.System.UtcNow;
-        DateTime utcAfter  = DateTime.UtcNow;
+        DateTimeOffset utcBefore = DateTimeOffset.UtcNow;
+        DateTimeOffset utcNow    = Clock.System.UtcNow;
+        DateTimeOffset utcAfter  = DateTimeOffset.UtcNow;
 
-        Assert.AreEqual(DateTimeKind.Utc, utcNow.Kind);
+        Assert.AreEqual(TimeSpan.Zero, utcNow.Offset);
         Assert.IsTrue(utcBefore <= utcNow);
         Assert.IsTrue(utcNow <= utcAfter);
     }
 
     [TestMethod]
-    public void FromLocal()
+    public void From()
     {
         IClock clock;
 
-        // Unspecified
-        DateTime unspecifiedNow = new DateTime(2021, 6, 16, 1, 2, 3, 4, DateTimeKind.Unspecified);
-        clock = Clock.FromLocal(unspecifiedNow);
-        Assert.AreEqual(unspecifiedNow                  , clock.Now);
-        Assert.AreEqual(unspecifiedNow.ToUniversalTime(), clock.UtcNow);
-
-        // Local
-        DateTime now = DateTime.Now;
-        clock = Clock.FromLocal(now);
-        Assert.AreEqual(now                  , clock.Now);
-        Assert.AreEqual(now.ToUniversalTime(), clock.UtcNow);
+        // Offset from UTC
+        DateTimeOffset offsetValue = new DateTimeOffset(2021, 6, 16, 1, 2, 3, 4, TimeSpan.FromHours(-8));
+        clock = Clock.From(offsetValue);
+        Assert.AreEqual(offsetValue.ToLocalTime()    , clock.Now);
+        Assert.AreEqual(offsetValue.ToUniversalTime(), clock.UtcNow);
 
         // UTC
-        DateTime utcNow = DateTime.UtcNow;
-        clock = Clock.FromLocal(utcNow);
-        Assert.AreEqual(utcNow.ToLocalTime(), clock.Now);
-        Assert.AreEqual(utcNow              , clock.UtcNow);
-    }
-
-    [TestMethod]
-    public void FromUtc()
-    {
-        IClock clock;
-
-        // Unspecified
-        DateTime unspecifiedNow = new DateTime(2021, 6, 16, 1, 2, 3, 4, DateTimeKind.Unspecified);
-        clock = Clock.FromUtc(unspecifiedNow);
-        Assert.AreEqual(unspecifiedNow.ToLocalTime(), clock.Now);
-        Assert.AreEqual(unspecifiedNow              , clock.UtcNow);
-
-        // Local
-        DateTime now = DateTime.Now;
-        clock = Clock.FromUtc(now);
-        Assert.AreEqual(now                  , clock.Now);
-        Assert.AreEqual(now.ToUniversalTime(), clock.UtcNow);
-
-        // UTC
-        DateTime utcNow = DateTime.UtcNow;
-        clock = Clock.FromUtc(utcNow);
-        Assert.AreEqual(utcNow.ToLocalTime(), clock.Now);
-        Assert.AreEqual(utcNow              , clock.UtcNow);
+        DateTimeOffset utcValue = new DateTimeOffset(2021, 6, 16, 1, 2, 3, 4, TimeSpan.Zero);
+        clock = Clock.From(utcValue);
+        Assert.AreEqual(utcValue.ToLocalTime(), clock.Now);
+        Assert.AreEqual(utcValue              , clock.UtcNow);
     }
 }

--- a/src/Core/Sweetener/Clock.cs
+++ b/src/Core/Sweetener/Clock.cs
@@ -17,36 +17,20 @@ public static class Clock
     public static IClock System { get; } = new SystemClock();
 
     /// <summary>
-    /// Returns a new clock whose value is the specified local date and time.
+    /// Returns a new clock whose value is the specified date and time.
     /// </summary>
-    /// <remarks>
-    /// If the specified <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Unspecified"/>, the value is
-    /// assumed to be a local date and time.
-    /// </remarks>
     /// <param name="value">A date and time.</param>
     /// <returns>An <see cref="IClock"/> whose current date and time is the specified value.</returns>
-    public static IClock FromLocal(DateTime value)
+    public static IClock From(DateTimeOffset value)
         => new FixedClock(value.ToUniversalTime());
-
-    /// <summary>
-    /// Returns a new clock whose value is the specified Coordinated Universal Time (UTC) date and time.
-    /// </summary>
-    /// <remarks>
-    /// If the specified <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Unspecified"/>, the value is
-    /// assumed to be a UTC date and time.
-    /// </remarks>
-    /// <param name="value">A date and time.</param>
-    /// <returns>An <see cref="IClock"/> whose current date and time is the specified value.</returns>
-    public static IClock FromUtc(DateTime value)
-        => new FixedClock(value.Kind == DateTimeKind.Local ? value.ToUniversalTime() : value);
 
     #region System Clock
 
     private sealed class SystemClock : IClock
     {
-        public DateTime Now => DateTime.Now;
+        public DateTimeOffset Now => DateTimeOffset.Now;
 
-        public DateTime UtcNow => DateTime.UtcNow;
+        public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
 
         public SystemClock()
         { }
@@ -58,11 +42,11 @@ public static class Clock
 
     private sealed class FixedClock : IClock
     {
-        public DateTime Now => UtcNow.ToLocalTime();
+        public DateTimeOffset Now => UtcNow.ToLocalTime();
 
-        public DateTime UtcNow { get; private set; }
+        public DateTimeOffset UtcNow { get; private set; }
 
-        public FixedClock(DateTime utcNow)
+        public FixedClock(DateTimeOffset utcNow)
             => UtcNow = utcNow;
     }
 

--- a/src/Core/Sweetener/Clock.cs
+++ b/src/Core/Sweetener/Clock.cs
@@ -44,7 +44,7 @@ public static class Clock
     {
         public DateTimeOffset Now => UtcNow.ToLocalTime();
 
-        public DateTimeOffset UtcNow { get; private set; }
+        public DateTimeOffset UtcNow { get; }
 
         public FixedClock(DateTimeOffset utcNow)
             => UtcNow = utcNow;

--- a/src/Core/Sweetener/IClock.cs
+++ b/src/Core/Sweetener/IClock.cs
@@ -10,16 +10,9 @@ namespace Sweetener;
 /// </summary>
 public interface IClock
 {
-    /// <summary>
-    /// Gets a <see cref="DateTime"/> object that is set to the current date and time, expressed as the local time.
-    /// </summary>
-    /// <value>An object whose value is the current local date and time.</value>
-    DateTime Now { get; }
+    /// <inheritdoc cref="DateTimeOffset.Now"/>
+    DateTimeOffset Now { get; }
 
-    /// <summary>
-    /// Gets a <see cref="DateTime"/> object that is set to the current date and time, expressed as the
-    /// Coordinated Universal Time (UTC).
-    /// </summary>
-    /// <value>An object whose value is the current UTC date and time.</value>
-    DateTime UtcNow { get; }
+    /// <inheritdoc cref="DateTimeOffset.UtcNow"/>
+    DateTimeOffset UtcNow { get; }
 }


### PR DESCRIPTION
- Use `DateTimeOffset` instead of `DateTime` in `IClock`
- Refactor factory methods
- Fix indent in source generation project