### PR TITLE
Refactor Argument Exceptions

### DIFF
--- a/src/Core/Sweetener.Test/ArgumentEmptyException.Test.cs
+++ b/src/Core/Sweetener.Test/ArgumentEmptyException.Test.cs
@@ -9,35 +9,35 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Sweetener.Test;
 
 [TestClass]
-public class ArgumentNullOrWhiteSpaceExceptionTest
+public class ArgumentEmptyExceptionTest
 {
     [TestMethod]
     public void Ctor()
     {
-        ArgumentNullOrWhiteSpaceException exception = new ArgumentNullOrWhiteSpaceException();
+        ArgumentEmptyException exception = new ArgumentEmptyException();
 
-        Assert.AreEqual(null                              , exception.InnerException);
-        Assert.AreEqual(SR.ArgumentNullOrWhiteSpaceMessage, exception.Message       );
-        Assert.AreEqual(null                              , exception.ParamName     );
+        Assert.AreEqual(null                   , exception.InnerException);
+        Assert.AreEqual(SR.ArgumentEmptyMessage, exception.Message       );
+        Assert.AreEqual(null                   , exception.ParamName     );
     }
 
     [TestMethod]
     public void Ctor_ParameterName()
     {
-        ArgumentNullOrWhiteSpaceException exception = new ArgumentNullOrWhiteSpaceException("parameter1");
+        ArgumentEmptyException exception = new ArgumentEmptyException("parameter1");
 
         Assert.AreEqual(null        , exception.InnerException);
         Assert.AreEqual("parameter1", exception.ParamName     );
 
         // There will be an additional line concerning the parameter name
-        Assert.IsTrue(exception.Message.StartsWith(SR.ArgumentNullOrWhiteSpaceMessage, StringComparison.Ordinal));
+        Assert.IsTrue(exception.Message.StartsWith(SR.ArgumentEmptyMessage, StringComparison.Ordinal));
     }
 
     [TestMethod]
     public void Ctor_Message_InnerException()
     {
         Exception innerException = new FormatException();
-        ArgumentNullOrWhiteSpaceException exception = new ArgumentNullOrWhiteSpaceException("Hello World", innerException);
+        ArgumentEmptyException exception = new ArgumentEmptyException("Hello World", innerException);
 
         Assert.AreSame (innerException, exception.InnerException);
         Assert.AreEqual("Hello World" , exception.Message       );
@@ -47,7 +47,7 @@ public class ArgumentNullOrWhiteSpaceExceptionTest
     [TestMethod]
     public void Ctor_ParameterName_Message()
     {
-        ArgumentNullOrWhiteSpaceException exception = new ArgumentNullOrWhiteSpaceException("parameter1", "Hello World");
+        ArgumentEmptyException exception = new ArgumentEmptyException("parameter1", "Hello World");
 
         Assert.AreEqual(null        , exception.InnerException);
         Assert.AreEqual("parameter1", exception.ParamName     );
@@ -60,8 +60,8 @@ public class ArgumentNullOrWhiteSpaceExceptionTest
     [TestMethod]
     public void Ctor_SerializationInfo_StreamingContext()
     {
-        ArgumentNullOrWhiteSpaceException? after;
-        ArgumentNullOrWhiteSpaceException before = new ArgumentNullOrWhiteSpaceException("parameter1", "Hello World");
+        ArgumentEmptyException? after;
+        ArgumentEmptyException before = new ArgumentEmptyException("parameter1", "Hello World");
 
         using (MemoryStream buffer = new MemoryStream())
         {
@@ -73,7 +73,7 @@ public class ArgumentNullOrWhiteSpaceExceptionTest
 
             buffer.Seek(0, SeekOrigin.Begin);
 
-            after = formatter.Deserialize(buffer) as ArgumentNullOrWhiteSpaceException;
+            after = formatter.Deserialize(buffer) as ArgumentEmptyException;
 #pragma warning restore CA2300, CA2301, SYSLIB0011
         }
 

--- a/src/Core/Sweetener.Test/ArgumentWhiteSpaceException.Test.cs
+++ b/src/Core/Sweetener.Test/ArgumentWhiteSpaceException.Test.cs
@@ -9,35 +9,35 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Sweetener.Test;
 
 [TestClass]
-public class ArgumentNullOrEmptyExceptionTest
+public class ArgumentWhiteSpaceExceptionTest
 {
     [TestMethod]
     public void Ctor()
     {
-        ArgumentNullOrEmptyException exception = new ArgumentNullOrEmptyException();
+        ArgumentWhiteSpaceException exception = new ArgumentWhiteSpaceException();
 
-        Assert.AreEqual(null                         , exception.InnerException);
-        Assert.AreEqual(SR.ArgumentNullOrEmptyMessage, exception.Message       );
-        Assert.AreEqual(null                         , exception.ParamName     );
+        Assert.AreEqual(null                        , exception.InnerException);
+        Assert.AreEqual(SR.ArgumentWhiteSpaceMessage, exception.Message       );
+        Assert.AreEqual(null                        , exception.ParamName     );
     }
 
     [TestMethod]
     public void Ctor_ParameterName()
     {
-        ArgumentNullOrEmptyException exception = new ArgumentNullOrEmptyException("parameter1");
+        ArgumentWhiteSpaceException exception = new ArgumentWhiteSpaceException("parameter1");
 
         Assert.AreEqual(null        , exception.InnerException);
         Assert.AreEqual("parameter1", exception.ParamName     );
 
         // There will be an additional line concerning the parameter name
-        Assert.IsTrue(exception.Message.StartsWith(SR.ArgumentNullOrEmptyMessage, StringComparison.Ordinal));
+        Assert.IsTrue(exception.Message.StartsWith(SR.ArgumentWhiteSpaceMessage, StringComparison.Ordinal));
     }
 
     [TestMethod]
     public void Ctor_Message_InnerException()
     {
         Exception innerException = new FormatException();
-        ArgumentNullOrEmptyException exception = new ArgumentNullOrEmptyException("Hello World", innerException);
+        ArgumentWhiteSpaceException exception = new ArgumentWhiteSpaceException("Hello World", innerException);
 
         Assert.AreSame (innerException, exception.InnerException);
         Assert.AreEqual("Hello World" , exception.Message       );
@@ -47,7 +47,7 @@ public class ArgumentNullOrEmptyExceptionTest
     [TestMethod]
     public void Ctor_ParameterName_Message()
     {
-        ArgumentNullOrEmptyException exception = new ArgumentNullOrEmptyException("parameter1", "Hello World");
+        ArgumentWhiteSpaceException exception = new ArgumentWhiteSpaceException("parameter1", "Hello World");
 
         Assert.AreEqual(null        , exception.InnerException);
         Assert.AreEqual("parameter1", exception.ParamName     );
@@ -60,8 +60,8 @@ public class ArgumentNullOrEmptyExceptionTest
     [TestMethod]
     public void Ctor_SerializationInfo_StreamingContext()
     {
-        ArgumentNullOrEmptyException? after;
-        ArgumentNullOrEmptyException before = new ArgumentNullOrEmptyException("parameter1", "Hello World");
+        ArgumentWhiteSpaceException? after;
+        ArgumentWhiteSpaceException before = new ArgumentWhiteSpaceException("parameter1", "Hello World");
 
         using (MemoryStream buffer = new MemoryStream())
         {
@@ -73,7 +73,7 @@ public class ArgumentNullOrEmptyExceptionTest
 
             buffer.Seek(0, SeekOrigin.Begin);
 
-            after = formatter.Deserialize(buffer) as ArgumentNullOrEmptyException;
+            after = formatter.Deserialize(buffer) as ArgumentWhiteSpaceException;
 #pragma warning restore CA2300, CA2301, SYSLIB0011
         }
 

--- a/src/Core/Sweetener.Test/String.Extensions.Test.cs
+++ b/src/Core/Sweetener.Test/String.Extensions.Test.cs
@@ -1,0 +1,23 @@
+﻿// Copyright © William Sugarman.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Test;
+
+[TestClass]
+public class StringExtensionsTest
+{
+    [TestMethod]
+    public void IsWhiteSpace()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => StringExtensions.IsWhiteSpace(null!));
+
+        Assert.IsFalse("foo"    .IsWhiteSpace());
+        Assert.IsFalse(" bar "  .IsWhiteSpace());
+        Assert.IsTrue (""       .IsWhiteSpace());
+        Assert.IsTrue (" "      .IsWhiteSpace());
+        Assert.IsTrue ("\t\r\n ".IsWhiteSpace());
+    }
+}

--- a/src/Core/Sweetener/ArgumentEmptyException.cs
+++ b/src/Core/Sweetener/ArgumentEmptyException.cs
@@ -7,33 +7,33 @@ using System.Runtime.Serialization;
 namespace Sweetener;
 
 /// <summary>
-/// The exception that is thrown when the value of an argument is <see langword="null"/> or empty.
+/// The exception that is thrown when the value of an argument is empty.
 /// </summary>
 [Serializable]
-public class ArgumentNullOrEmptyException : ArgumentException
+public class ArgumentEmptyException : ArgumentException
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentNullOrEmptyException"/> class.
+    /// Initializes a new instance of the <see cref="ArgumentEmptyException"/> class.
     /// </summary>
     /// <remarks>
     /// This constructor initializes the <see cref="Exception.Message"/> property of
     /// the new instance to a system-supplied message that describes the error,
-    /// such as "Value cannot be null or empty." This message takes into account the current
+    /// such as "Value cannot be empty." This message takes into account the current
     /// system culture.
     /// </remarks>
-    public ArgumentNullOrEmptyException()
+    public ArgumentEmptyException()
         : this(paramName: null)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentNullOrEmptyException"/> class
+    /// Initializes a new instance of the <see cref="ArgumentEmptyException"/> class
     /// with the name of the parameter that causes this exception.
     /// </summary>
     /// <remarks>
     /// <para>
     /// This constructor initializes the <see cref="Exception.Message"/> property of the
     /// new instance to a system-supplied message that describes the error, such as
-    /// "Value cannot be null or empty." This message takes into account the current system culture.
+    /// "Value cannot be empty." This message takes into account the current system culture.
     /// </para>
     /// <para>
     /// This constructor initializes the <see cref="ArgumentException.ParamName"/> property
@@ -42,12 +42,12 @@ public class ArgumentNullOrEmptyException : ArgumentException
     /// </para>
     /// </remarks>
     /// <param name="paramName">The name of the parameter that causes this exception.</param>
-    public ArgumentNullOrEmptyException(string? paramName)
-        : base(SR.ArgumentNullOrEmptyMessage, paramName)
+    public ArgumentEmptyException(string? paramName)
+        : base(SR.ArgumentEmptyMessage, paramName)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentNullOrEmptyException"/> class
+    /// Initializes a new instance of the <see cref="ArgumentEmptyException"/> class
     /// with a specified error message and the exception that is the cause of this exception.
     /// </summary>
     /// <remarks>
@@ -72,12 +72,12 @@ public class ArgumentNullOrEmptyException : ArgumentException
     /// The exception that is the cause of the current exception, or <see langword="null"/>
     /// if no inner exception is specified.
     /// </param>
-    public ArgumentNullOrEmptyException(string? message, Exception? innerException)
+    public ArgumentEmptyException(string? message, Exception? innerException)
         : base(message, innerException)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentNullOrEmptyException"/> class
+    /// Initializes a new instance of the <see cref="ArgumentEmptyException"/> class
     /// with the name of the parameter that causes this exception and a specified error message.
     /// </summary>
     /// <remarks>
@@ -96,12 +96,12 @@ public class ArgumentNullOrEmptyException : ArgumentException
     /// </remarks>
     /// <param name="paramName">The name of the parameter that caused the exception.</param>
     /// <param name="message">The message that describes the error.</param>
-    public ArgumentNullOrEmptyException(string? paramName, string? message)
+    public ArgumentEmptyException(string? paramName, string? message)
         : base(message, paramName)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentNullOrEmptyException"/> class
+    /// Initializes a new instance of the <see cref="ArgumentEmptyException"/> class
     /// with serialized data.
     /// </summary>
     /// <remarks>
@@ -111,7 +111,7 @@ public class ArgumentNullOrEmptyException : ArgumentException
     /// </remarks>
     /// <param name="info">The object that holds the serialized object data.</param>
     /// <param name="context">An object that describes the source or destination of the serialized data.</param>
-    protected ArgumentNullOrEmptyException(SerializationInfo info, StreamingContext context)
+    protected ArgumentEmptyException(SerializationInfo info, StreamingContext context)
         : base(info, context)
     { }
 }

--- a/src/Core/Sweetener/ArgumentWhiteSpaceException.cs
+++ b/src/Core/Sweetener/ArgumentWhiteSpaceException.cs
@@ -7,34 +7,34 @@ using System.Runtime.Serialization;
 namespace Sweetener;
 
 /// <summary>
-/// The exception that is thrown when the value of an argument is <see langword="null"/>, empty,
+/// The exception that is thrown when the value of an argument is empty
 /// or consists only of white-space characters.
 /// </summary>
 [Serializable]
-public class ArgumentNullOrWhiteSpaceException : ArgumentException
+public class ArgumentWhiteSpaceException : ArgumentException
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentNullOrWhiteSpaceException"/> class.
+    /// Initializes a new instance of the <see cref="ArgumentWhiteSpaceException"/> class.
     /// </summary>
     /// <remarks>
     /// This constructor initializes the <see cref="Exception.Message"/> property of
     /// the new instance to a system-supplied message that describes the error,
-    /// such as "Value cannot be null, empty, or consist only of white-space characters."
+    /// such as "Value cannot be empty or consist only of white-space characters."
     /// This message takes into account the current system culture.
     /// </remarks>
-    public ArgumentNullOrWhiteSpaceException()
+    public ArgumentWhiteSpaceException()
         : this(paramName: null)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentNullOrWhiteSpaceException"/> class
+    /// Initializes a new instance of the <see cref="ArgumentWhiteSpaceException"/> class
     /// with the name of the parameter that causes this exception.
     /// </summary>
     /// <remarks>
     /// <para>
     /// This constructor initializes the <see cref="Exception.Message"/> property of the
     /// new instance to a system-supplied message that describes the error, such as
-    /// "Value cannot be null, empty, or consist only of white-space characters."
+    /// "Value cannot be empty or consist only of white-space characters."
     /// This message takes into account the current system culture.
     /// </para>
     /// <para>
@@ -44,12 +44,12 @@ public class ArgumentNullOrWhiteSpaceException : ArgumentException
     /// </para>
     /// </remarks>
     /// <param name="paramName">The name of the parameter that causes this exception.</param>
-    public ArgumentNullOrWhiteSpaceException(string? paramName)
-        : base(SR.ArgumentNullOrWhiteSpaceMessage, paramName)
+    public ArgumentWhiteSpaceException(string? paramName)
+        : base(SR.ArgumentWhiteSpaceMessage, paramName)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentNullOrWhiteSpaceException"/> class
+    /// Initializes a new instance of the <see cref="ArgumentWhiteSpaceException"/> class
     /// with a specified error message and the exception that is the cause of this exception.
     /// </summary>
     /// <remarks>
@@ -74,12 +74,12 @@ public class ArgumentNullOrWhiteSpaceException : ArgumentException
     /// The exception that is the cause of the current exception, or <see langword="null"/>
     /// if no inner exception is specified.
     /// </param>
-    public ArgumentNullOrWhiteSpaceException(string? message, Exception? innerException)
+    public ArgumentWhiteSpaceException(string? message, Exception? innerException)
         : base(message, innerException)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentNullOrWhiteSpaceException"/> class
+    /// Initializes a new instance of the <see cref="ArgumentWhiteSpaceException"/> class
     /// with the name of the parameter that causes this exception and a specified error message.
     /// </summary>
     /// <remarks>
@@ -98,12 +98,12 @@ public class ArgumentNullOrWhiteSpaceException : ArgumentException
     /// </remarks>
     /// <param name="paramName">The name of the parameter that caused the exception.</param>
     /// <param name="message">The message that describes the error.</param>
-    public ArgumentNullOrWhiteSpaceException(string? paramName, string? message)
+    public ArgumentWhiteSpaceException(string? paramName, string? message)
         : base(message, paramName)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentNullOrWhiteSpaceException"/> class
+    /// Initializes a new instance of the <see cref="ArgumentWhiteSpaceException"/> class
     /// with serialized data.
     /// </summary>
     /// <remarks>
@@ -113,7 +113,7 @@ public class ArgumentNullOrWhiteSpaceException : ArgumentException
     /// </remarks>
     /// <param name="info">The object that holds the serialized object data.</param>
     /// <param name="context">An object that describes the source or destination of the serialized data.</param>
-    protected ArgumentNullOrWhiteSpaceException(SerializationInfo info, StreamingContext context)
+    protected ArgumentWhiteSpaceException(SerializationInfo info, StreamingContext context)
         : base(info, context)
     { }
 }

--- a/src/Core/Sweetener/Resources/Exceptions.resx
+++ b/src/Core/Sweetener/Resources/Exceptions.resx
@@ -117,14 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ArgumentEmptyMessage" xml:space="preserve">
+    <value>Value cannot be empty.</value>
+  </data>
   <data name="ArgumentNegativeMessage" xml:space="preserve">
     <value>Specified argument was negative.</value>
   </data>
-  <data name="ArgumentNullOrEmptyMessage" xml:space="preserve">
-    <value>Value cannot be null or empty.</value>
-  </data>
-  <data name="ArgumentNullOrWhiteSpaceMessage" xml:space="preserve">
-    <value>Value cannot be null, empty, or consist only of white-space characters.</value>
+  <data name="ArgumentWhiteSpaceMessage" xml:space="preserve">
+    <value>Value cannot be empty or consist only of white-space characters.</value>
   </data>
   <data name="MissingOptionalValueMessage" xml:space="preserve">
     <value>Optional object must have a value.</value>

--- a/src/Core/Sweetener/SR.cs
+++ b/src/Core/Sweetener/SR.cs
@@ -10,9 +10,9 @@ internal static class SR
 {
     public static string ArgumentNegativeMessage => ExceptionResourceManager.GetString(nameof(ArgumentNegativeMessage), CultureInfo.CurrentUICulture);
 
-    public static string ArgumentNullOrEmptyMessage => ExceptionResourceManager.GetString(nameof(ArgumentNullOrEmptyMessage), CultureInfo.CurrentUICulture);
+    public static string ArgumentEmptyMessage => ExceptionResourceManager.GetString(nameof(ArgumentEmptyMessage), CultureInfo.CurrentUICulture);
 
-    public static string ArgumentNullOrWhiteSpaceMessage => ExceptionResourceManager.GetString(nameof(ArgumentNullOrWhiteSpaceMessage), CultureInfo.CurrentUICulture);
+    public static string ArgumentWhiteSpaceMessage => ExceptionResourceManager.GetString(nameof(ArgumentWhiteSpaceMessage), CultureInfo.CurrentUICulture);
 
     public static string MissingOptionalValueMessage => ExceptionResourceManager.GetString(nameof(MissingOptionalValueMessage), CultureInfo.CurrentUICulture);
 

--- a/src/Core/Sweetener/String.Extensions.cs
+++ b/src/Core/Sweetener/String.Extensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright © William Sugarman.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Sweetener;
+
+/// <summary>
+/// Provides a set of additional methods for <see cref="string"/> instances.
+/// </summary>
+public static class StringExtensions
+{
+    /// <summary>
+    /// Indicates whether a specified string is <see cref="string.Empty"/>
+    /// or consists only of white-space characters.
+    /// </summary>
+    /// <param name="value">The string to test.</param>
+    /// <returns>
+    /// <see langword="true"/> if the <paramref name="value"/> parameter is <see cref="string.Empty"/>
+    /// or consists exclusively of white-space characters; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+    public static bool IsWhiteSpace(this string value)
+    {
+        if (value is null)
+            throw new ArgumentNullException(nameof(value));
+
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (!char.IsWhiteSpace(value[i]))
+                return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
- Remove `null` from the argument exceptions so that users can differentiate between the values
  - `ArgumentNullException` is reserved for `null` values
  - `ArgumentEmptyException` and `ArgumentWhiteSpaceException` may be used when the value is not `null` but still invalid
- Add new `IsWhiteSpace()` extension method to help users determine if a `string` is non-`null` but still only white-space characters