### PR TITLE
Add SelectWhere, SkipLast, and TakeLast

### DIFF
--- a/src/Core/Sweetener.Linq.Test/Collection.AppendPrepend.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Collection.AppendPrepend.Test.cs
@@ -25,6 +25,21 @@ partial class CollectionTest
         source.Add("hello");
         Assert.AreEqual(2, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "hello", "world");
+
+        // Append additional element
+        actual = actual.Append("!");
+        Assert.AreEqual(3, actual.Count);
+        CodeCoverageAssert.AreSequencesEqual(actual, "hello", "world", "!");
+
+        // Prepend element
+        actual = actual.Prepend("why");
+        Assert.AreEqual(4, actual.Count);
+        CodeCoverageAssert.AreSequencesEqual(actual, "why", "hello", "world", "!");
+
+        // Append to decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 4).Append(5);
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 1, 2, 3, 4, 5);
     }
 
     [TestMethod]
@@ -42,5 +57,20 @@ partial class CollectionTest
         source.Add("world");
         Assert.AreEqual(2, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "hello", "world");
+
+        // Prepend additional element
+        actual = actual.Prepend("why");
+        Assert.AreEqual(3, actual.Count);
+        CodeCoverageAssert.AreSequencesEqual(actual, "why", "hello", "world");
+
+        // Append element
+        actual = actual.Append("!");
+        Assert.AreEqual(4, actual.Count);
+        CodeCoverageAssert.AreSequencesEqual(actual, "why", "hello", "world", "!");
+
+        // Prepend to decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(2, 4).Prepend(1);
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 1, 2, 3, 4, 5);
     }
 }

--- a/src/Core/Sweetener.Linq.Test/Collection.Concat.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Collection.Concat.Test.cs
@@ -29,5 +29,14 @@ partial class CollectionTest
         second.Add(5);
         Assert.AreEqual(6, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, 0, 1, 2, 3, 4, 5);
+
+        // Concatenate a decorator
+        IReadOnlyCollection<int> back = actual.Concat(new int[] { 6, 7, 8 });
+        Assert.AreEqual(9, back.Count);
+        CodeCoverageAssert.AreSequencesEqual(back, 0, 1, 2, 3, 4, 5, 6, 7, 8);
+
+        IReadOnlyCollection<int> front = new int[] { -3, -2, -1 }.Concat(actual);
+        Assert.AreEqual(9, front.Count);
+        CodeCoverageAssert.AreSequencesEqual(front, -3, -2, -1, 0, 1, 2, 3, 4, 5);
     }
 }

--- a/src/Core/Sweetener.Linq.Test/Collection.OrderBy.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Collection.OrderBy.Test.cs
@@ -27,6 +27,11 @@ partial class CollectionTest
         source.Add("depmuj");
         Assert.AreEqual(4, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "nworb", "xof", "depmuj", "kciuq");
+
+        // Order decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).Reverse().OrderBy(x => x);
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 1, 2, 3, 4, 5);
     }
 
     [TestMethod]
@@ -39,8 +44,10 @@ partial class CollectionTest
         // Lazily evaluate the ordering and its resulting count
         IOrderedReadOnlyCollection<string> actual;
 
+        IComparer<int> reverseComparer = Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(y, x));
         List<string> source = new List<string> { "apple", "tuna", "spinach" };
-        actual = source.OrderBy(x => x.Length, Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(y, x))); // Reverse
+
+        actual = source.OrderBy(x => x.Length, reverseComparer);
         Assert.AreEqual(3, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "spinach", "apple", "tuna");
 
@@ -51,6 +58,11 @@ partial class CollectionTest
         // Null comparer uses default
         actual = source.OrderBy(x => x.Length, null);
         CodeCoverageAssert.AreSequencesEqual(actual, "tuna", "apple", "spinach", "pistachio");
+
+        // Order decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).OrderBy(x => x, reverseComparer);
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 5, 4, 3, 2, 1);
     }
 
     [TestMethod]
@@ -62,14 +74,19 @@ partial class CollectionTest
 
         // Lazily evaluate the ordering and its resulting count
         List<string> source = new List<string> { "banana", "apple", "alpaca" };
-        IOrderedReadOnlyCollection<string> orderedSource = source.OrderBy(x => x[0]);
-        IOrderedReadOnlyCollection<string> actual = orderedSource.ThenBy(x => x.Length);
+
+        IOrderedReadOnlyCollection<string> actual = source.OrderBy(x => x[0]).ThenBy(x => x.Length);
         Assert.AreEqual(3, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "apple", "alpaca", "banana");
 
         source.Add("apricot");
         Assert.AreEqual(4, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "apple", "alpaca", "apricot", "banana");
+
+        // Order decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).Reverse().OrderBy(x => x % 2).ThenBy(x => x);
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 2, 4, 1, 3, 5);
     }
 
     [TestMethod]
@@ -80,9 +97,11 @@ partial class CollectionTest
         Assert.ThrowsException<ArgumentNullException>(() => Collection.ThenBy(Array.Empty<string>().OrderBy(x => x), null!, Comparer<string>.Default));
 
         // Lazily evaluate the ordering and its resulting count
+        IComparer<int> reverseComparer = Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(y, x));
         List<string> source = new List<string> { "banana", "apple", "alpaca" };
+
         IOrderedReadOnlyCollection<string> orderedSource = source.OrderBy(x => x[0]);
-        IOrderedReadOnlyCollection<string> actual = orderedSource.ThenBy(x => x.Length, Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(y, x)));
+        IOrderedReadOnlyCollection<string> actual = orderedSource.ThenBy(x => x.Length, reverseComparer);
         Assert.AreEqual(3, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "alpaca", "apple", "banana");
 
@@ -93,6 +112,11 @@ partial class CollectionTest
         // Null comparer uses default
         actual = orderedSource.ThenBy(x => x.Length, null);
         CodeCoverageAssert.AreSequencesEqual(actual, "apple", "alpaca", "apricot", "banana");
+
+        // Order decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).OrderBy(x => x % 2).ThenBy(x => x, reverseComparer);
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 4, 2, 5, 3, 1);
     }
 
     [TestMethod]
@@ -104,6 +128,7 @@ partial class CollectionTest
 
         // Lazily evaluate the ordering and its resulting count
         List<string> source = new List<string> { "xof", "nworb", "kciuq" };
+
         IOrderedReadOnlyCollection<string> actual = source.OrderByDescending(x => x[^1]);
         Assert.AreEqual(3, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "kciuq", "xof", "nworb");
@@ -111,6 +136,11 @@ partial class CollectionTest
         source.Add("depmuj");
         Assert.AreEqual(4, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "kciuq", "depmuj", "xof", "nworb");
+
+        // Order decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).OrderByDescending(x => x);
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 5, 4, 3, 2, 1);
     }
 
     [TestMethod]
@@ -123,8 +153,10 @@ partial class CollectionTest
         // Lazily evaluate the ordering and its resulting count
         IOrderedReadOnlyCollection<string> actual;
 
+        IComparer<int> reverseComparer = Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(y, x));
         List<string> source = new List<string> { "apple", "tuna", "spinach" };
-        actual = source.OrderByDescending(x => x.Length, Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(y, x))); // Reverse
+
+        actual = source.OrderByDescending(x => x.Length, reverseComparer);
         Assert.AreEqual(3, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "tuna", "apple", "spinach");
 
@@ -135,6 +167,11 @@ partial class CollectionTest
         // Null comparer uses default
         actual = source.OrderByDescending(x => x.Length, null);
         CodeCoverageAssert.AreSequencesEqual(actual, "pistachio", "spinach", "apple", "tuna");
+
+        // Order decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).Reverse().OrderByDescending(x => x, reverseComparer);
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 1, 2, 3, 4, 5);
     }
 
     [TestMethod]
@@ -146,14 +183,19 @@ partial class CollectionTest
 
         // Lazily evaluate the ordering and its resulting count
         List<string> source = new List<string> { "banana", "apple", "alpaca" };
-        IOrderedReadOnlyCollection<string> orderedSource = source.OrderBy(x => x[0]);
-        IOrderedReadOnlyCollection<string> actual = orderedSource.ThenByDescending(x => x.Length);
+
+        IOrderedReadOnlyCollection<string> actual = source.OrderBy(x => x[0]).ThenByDescending(x => x.Length);
         Assert.AreEqual(3, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "alpaca", "apple", "banana");
 
         source.Add("apricot");
         Assert.AreEqual(4, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "apricot", "alpaca", "apple", "banana");
+
+        // Order decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).OrderBy(x => x % 2).ThenByDescending(x => x);
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 4, 2, 5, 3, 1);
     }
 
     [TestMethod]
@@ -164,9 +206,10 @@ partial class CollectionTest
         Assert.ThrowsException<ArgumentNullException>(() => Collection.ThenByDescending(Array.Empty<string>().OrderBy(x => x), null!, Comparer<string>.Default));
 
         // Lazily evaluate the ordering and its resulting count
+        IComparer<int> reverseComparer = Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(y, x));
         List<string> source = new List<string> { "banana", "apple", "alpaca" };
-        IOrderedReadOnlyCollection<string> orderedSource = source.OrderBy(x => x[0]);
-        IOrderedReadOnlyCollection<string> actual = orderedSource.ThenByDescending(x => x.Length, Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(y, x)));
+
+        IOrderedReadOnlyCollection<string> actual = source.OrderBy(x => x[0]).ThenByDescending(x => x.Length, reverseComparer);
         Assert.AreEqual(3, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, "apple", "alpaca", "banana");
 
@@ -175,8 +218,13 @@ partial class CollectionTest
         CodeCoverageAssert.AreSequencesEqual(actual, "apple", "alpaca", "apricot", "banana");
 
         // Null comparer uses default
-        actual = orderedSource.ThenByDescending(x => x.Length, null);
+        actual = source.OrderBy(x => x[0]).ThenByDescending(x => x.Length, null);
         CodeCoverageAssert.AreSequencesEqual(actual, "apricot", "alpaca", "apple", "banana");
+
+        // Order decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).Reverse().OrderBy(x => x % 2).ThenByDescending(x => x, reverseComparer);
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 2, 4, 1, 3, 5);
     }
 
     [TestMethod]

--- a/src/Core/Sweetener.Linq.Test/Collection.Reverse.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Collection.Reverse.Test.cs
@@ -26,5 +26,10 @@ partial class CollectionTest
         source.Add(2);
         Assert.AreEqual(5, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, 2, 1, 0, -1, -2);
+
+        // Reverse a decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).Reverse();
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 5, 4, 3, 2, 1);
     }
 }

--- a/src/Core/Sweetener.Linq.Test/Collection.Select.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Collection.Select.Test.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Sweetener.Linq;
 
@@ -27,6 +28,16 @@ partial class CollectionTest
         source.Add(5);
         Assert.AreEqual(5, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, 2, 4, 6, 8, 10);
+
+        // Multiple projections
+        IReadOnlyCollection<double> composite = actual.Select(x => TimeSpan.FromSeconds(x).TotalMilliseconds);
+        Assert.AreEqual(5, composite.Count);
+        CodeCoverageAssert.AreSequencesEqual(composite, 2000d, 4000d, 6000d, 8000d, 10000d);
+
+        // Select on a decorator
+        IReadOnlyCollection<string> numbers = Collection.Range(1, 5).Select(x => x.ToString(CultureInfo.InvariantCulture));
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, "1", "2", "3", "4", "5");
     }
 
     [TestMethod]
@@ -46,5 +57,15 @@ partial class CollectionTest
         source.Add(5);
         Assert.AreEqual(5, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, 2, 5, 8, 11, 14);
+
+        // Multiple projections
+        IReadOnlyCollection<string> composite = actual.Select((x, i) => string.Join("", Collection.Repeat(x.ToString(CultureInfo.InvariantCulture), i)));
+        Assert.AreEqual(5, composite.Count);
+        CodeCoverageAssert.AreSequencesEqual(composite, "", "5", "88", "111111", "14141414");
+
+        // Select on a decorator
+        IReadOnlyCollection<string> numbers = Collection.Range(1, 5).Select((x, i) => (x + i).ToString(CultureInfo.InvariantCulture));
+        Assert.AreEqual(5, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, "1", "3", "5", "7", "9");
     }
 }

--- a/src/Core/Sweetener.Linq.Test/Collection.Skip.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Collection.Skip.Test.cs
@@ -33,4 +33,30 @@ partial class CollectionTest
         Assert.AreEqual(3, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, 3, 4, 5);
     }
+
+#if NET6_0_OR_GREATER
+    [TestMethod]
+    public void SkipLast()
+    {
+        // Invalid source
+        Assert.ThrowsException<ArgumentNullException>(() => Collection.SkipLast<long>(null!, 1));
+
+        IReadOnlyCollection<long> actual;
+        List<long> source = new List<long> { 1 };
+
+        // Empty
+        actual = source.SkipLast(-5);
+        Assert.AreEqual(1, actual.Count);
+        CodeCoverageAssert.AreSequencesEqual(actual, 1);
+
+        // Lazily evaluate the skip and its resulting count
+        actual = source.SkipLast(2);
+        Assert.AreEqual(0, actual.Count);
+        CodeCoverageAssert.AreSequencesEqual(Array.Empty<long>(), actual);
+
+        source.AddRange(new long[] { 2, 3, 4, 5 });
+        Assert.AreEqual(3, actual.Count);
+        CodeCoverageAssert.AreSequencesEqual(actual, 1, 2, 3);
+    }
+#endif
 }

--- a/src/Core/Sweetener.Linq.Test/Collection.Skip.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Collection.Skip.Test.cs
@@ -32,6 +32,11 @@ partial class CollectionTest
         source.AddRange(new long[] { 2, 3, 4, 5 });
         Assert.AreEqual(3, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, 3, 4, 5);
+
+        // Evaluate the take for decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).Skip(2);
+        Assert.AreEqual(3, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 3, 4, 5);
     }
 
 #if NET6_0_OR_GREATER
@@ -57,6 +62,11 @@ partial class CollectionTest
         source.AddRange(new long[] { 2, 3, 4, 5 });
         Assert.AreEqual(3, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, 1, 2, 3);
+
+        // Evaluate the skip for decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).SkipLast(2);
+        Assert.AreEqual(3, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 1, 2, 3);
     }
 #endif
 }

--- a/src/Core/Sweetener.Linq.Test/Collection.Take.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Collection.Take.Test.cs
@@ -32,6 +32,11 @@ partial class CollectionTest
         source.AddRange(new long[] { 2, 3, 4, 5 });
         Assert.AreEqual(2, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, 1, 2);
+
+        // Evaluate the take for decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).Take(2);
+        Assert.AreEqual(2, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 1, 2);
     }
 
 #if NET6_0_OR_GREATER
@@ -57,6 +62,11 @@ partial class CollectionTest
         source.AddRange(new long[] { 2, 3, 4, 5 });
         Assert.AreEqual(2, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, 4, 5);
+
+        // Evaluate the take for decorator
+        IReadOnlyCollection<int> numbers = Collection.Range(1, 5).TakeLast(2);
+        Assert.AreEqual(2, numbers.Count);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 4, 5);
     }
 #endif
 }

--- a/src/Core/Sweetener.Linq.Test/Collection.Take.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Collection.Take.Test.cs
@@ -33,4 +33,30 @@ partial class CollectionTest
         Assert.AreEqual(2, actual.Count);
         CodeCoverageAssert.AreSequencesEqual(actual, 1, 2);
     }
+
+#if NET6_0_OR_GREATER
+    [TestMethod]
+    public void TakeLast()
+    {
+        // Invalid source
+        Assert.ThrowsException<ArgumentNullException>(() => Collection.TakeLast<long>(null!, 1));
+
+        IReadOnlyCollection<long> actual;
+        List<long> source = new List<long> { 1 };
+
+        // Empty
+        actual = source.TakeLast(-3);
+        Assert.AreEqual(0, actual.Count);
+        CodeCoverageAssert.AreSequencesEqual(Array.Empty<long>(), actual);
+
+        // Lazily evaluate the take and its resulting count
+        actual = source.TakeLast(2);
+        Assert.AreEqual(1, actual.Count);
+        CodeCoverageAssert.AreSequencesEqual(actual, 1);
+
+        source.AddRange(new long[] { 2, 3, 4, 5 });
+        Assert.AreEqual(2, actual.Count);
+        CodeCoverageAssert.AreSequencesEqual(actual, 4, 5);
+    }
+#endif
 }

--- a/src/Core/Sweetener.Linq.Test/Enumerable.Extensions.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Enumerable.Extensions.Test.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Sweetener.Test.Linq;
 
 namespace Sweetener.Linq.Test;
 
@@ -19,28 +20,17 @@ public class EnumerableExtensionsTest
         Assert.ThrowsException<ArgumentNullException>(() => EnumerableExtensions.SelectWhere(Array.Empty<string>(), (TryFunc<string, double>)null!));
 
         // Single Transform
-        List<int> numbers = new string?[] { "1", "2", "foo", "3", "four", "4", "5", null }
-            .SelectWhere<string?, int>(int.TryParse)
-            .ToList();
+        IEnumerable<int> numbers = new string?[] { "1", "2", "foo", "3", "four", "4", "5", null }
+            .SelectWhere<string?, int>(int.TryParse);
 
-        Assert.AreEqual(5, numbers.Count);
-
-        Assert.AreEqual(1, numbers[0]);
-        Assert.AreEqual(2, numbers[1]);
-        Assert.AreEqual(3, numbers[2]);
-        Assert.AreEqual(4, numbers[3]);
-        Assert.AreEqual(5, numbers[4]);
+        CodeCoverageAssert.AreSequencesEqual(numbers, 1, 2, 3, 4, 5);
 
         // Multiple transformations
-        List<long> moreNumbers = new string?[] { "1", "2", "foo", "3", "four", "4", "5", null }
+        IEnumerable<long> moreNumbers = new string?[] { "1", "2", "foo", "3", "four", "4", "5", null }
             .SelectWhere<string?, int>(int.TryParse)
-            .SelectWhere<int, long>(TryDouble)
-            .ToList();
+            .SelectWhere<int, long>(TryDouble);
 
-        Assert.AreEqual(2, moreNumbers.Count);
-
-        Assert.AreEqual(4, moreNumbers[0]);
-        Assert.AreEqual(8, moreNumbers[1]);
+        CodeCoverageAssert.AreSequencesEqual(moreNumbers, 4, 8);
 
         static bool TryDouble(int n, out long value)
         {
@@ -61,28 +51,18 @@ public class EnumerableExtensionsTest
         Assert.ThrowsException<ArgumentNullException>(() => EnumerableExtensions.SelectWhere<string, double>(null!, TryParse));
         Assert.ThrowsException<ArgumentNullException>(() => EnumerableExtensions.SelectWhere(Array.Empty<string>(), (TryFunc<string, int, TimeSpan>)null!));
 
-        List<double> numbers = new string?[] { "1.1", "2.2", "foo", "3.3", "four", "4.4", "5.5", null }
+        // Single Transform
+        IEnumerable<double> numbers = new string?[] { "1.1", "2.2", "foo", "3.3", "four", "4.4", "5.5", null }
+            .SelectWhere<string?, double>(TryParse);
+
+        CodeCoverageAssert.AreSequencesEqual(numbers, 0.0d, 2.2d, 9.9d, 22.0d, 33.0d);
+
+        // Multiple transformations
+        IEnumerable<int> moreNumbers = new string?[] { "1.1", "2.2", "foo", "3.3", "four", "4.4", "5.5", null }
             .SelectWhere<string?, double>(TryParse)
-            .ToList();
+            .SelectWhere<double, int>(TryGetInteger);
 
-        Assert.AreEqual(5, numbers.Count);
-
-        Assert.AreEqual( 0.0d, numbers[0]);
-        Assert.AreEqual( 2.2d, numbers[1]);
-        Assert.AreEqual( 9.9d, numbers[2]);
-        Assert.AreEqual(22.0d, numbers[3]);
-        Assert.AreEqual(33.0d, numbers[4]);
-
-        List<int> moreNumbers = new string?[] { "1.1", "2.2", "foo", "3.3", "four", "4.4", "5.5", null }
-            .SelectWhere<string?, double>(TryParse)
-            .SelectWhere<double, int>(TryGetInteger)
-            .ToList();
-
-        Assert.AreEqual(3, moreNumbers.Count);
-
-        Assert.AreEqual( 0, moreNumbers[0]);
-        Assert.AreEqual(25, moreNumbers[1]);
-        Assert.AreEqual(37, moreNumbers[2]);
+        CodeCoverageAssert.AreSequencesEqual(moreNumbers, 0, 25, 37);
 
         static bool TryParse(string? s, int i, out double value)
         {

--- a/src/Core/Sweetener.Linq.Test/Enumerable.Extensions.Test.cs
+++ b/src/Core/Sweetener.Linq.Test/Enumerable.Extensions.Test.cs
@@ -1,0 +1,110 @@
+﻿// Copyright © William Sugarman.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sweetener.Linq.Test;
+
+[TestClass]
+public class EnumerableExtensionsTest
+{
+    [TestMethod]
+    public void SelectWhere()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => EnumerableExtensions.SelectWhere<string, int>(null!, int.TryParse));
+        Assert.ThrowsException<ArgumentNullException>(() => EnumerableExtensions.SelectWhere(Array.Empty<string>(), (TryFunc<string, double>)null!));
+
+        // Single Transform
+        List<int> numbers = new string?[] { "1", "2", "foo", "3", "four", "4", "5", null }
+            .SelectWhere<string?, int>(int.TryParse)
+            .ToList();
+
+        Assert.AreEqual(5, numbers.Count);
+
+        Assert.AreEqual(1, numbers[0]);
+        Assert.AreEqual(2, numbers[1]);
+        Assert.AreEqual(3, numbers[2]);
+        Assert.AreEqual(4, numbers[3]);
+        Assert.AreEqual(5, numbers[4]);
+
+        // Multiple transformations
+        List<long> moreNumbers = new string?[] { "1", "2", "foo", "3", "four", "4", "5", null }
+            .SelectWhere<string?, int>(int.TryParse)
+            .SelectWhere<int, long>(TryDouble)
+            .ToList();
+
+        Assert.AreEqual(2, moreNumbers.Count);
+
+        Assert.AreEqual(4, moreNumbers[0]);
+        Assert.AreEqual(8, moreNumbers[1]);
+
+        static bool TryDouble(int n, out long value)
+        {
+            if (n % 2 == 0)
+            {
+                value = n * 2;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+    }
+
+    [TestMethod]
+    public void SelectWhere_Index()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => EnumerableExtensions.SelectWhere<string, double>(null!, TryParse));
+        Assert.ThrowsException<ArgumentNullException>(() => EnumerableExtensions.SelectWhere(Array.Empty<string>(), (TryFunc<string, int, TimeSpan>)null!));
+
+        List<double> numbers = new string?[] { "1.1", "2.2", "foo", "3.3", "four", "4.4", "5.5", null }
+            .SelectWhere<string?, double>(TryParse)
+            .ToList();
+
+        Assert.AreEqual(5, numbers.Count);
+
+        Assert.AreEqual( 0.0d, numbers[0]);
+        Assert.AreEqual( 2.2d, numbers[1]);
+        Assert.AreEqual( 9.9d, numbers[2]);
+        Assert.AreEqual(22.0d, numbers[3]);
+        Assert.AreEqual(33.0d, numbers[4]);
+
+        List<int> moreNumbers = new string?[] { "1.1", "2.2", "foo", "3.3", "four", "4.4", "5.5", null }
+            .SelectWhere<string?, double>(TryParse)
+            .SelectWhere<double, int>(TryGetInteger)
+            .ToList();
+
+        Assert.AreEqual(3, moreNumbers.Count);
+
+        Assert.AreEqual( 0, moreNumbers[0]);
+        Assert.AreEqual(25, moreNumbers[1]);
+        Assert.AreEqual(37, moreNumbers[2]);
+
+        static bool TryParse(string? s, int i, out double value)
+        {
+            if (double.TryParse(s, out value))
+            {
+                value = Math.Round(value * i, 1);
+                return true;
+            }
+
+            return false;
+        }
+
+        static bool TryGetInteger(double d, int i, out int value)
+        {
+            if (d == (int)d)
+            {
+                value = (int)d + i;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+    }
+}

--- a/src/Core/Sweetener.Linq/Collection.AppendPrepend.cs
+++ b/src/Core/Sweetener.Linq/Collection.AppendPrepend.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Sweetener.Linq;
@@ -32,9 +33,12 @@ static partial class Collection
     public static IReadOnlyCollection<TSource> Prepend<TSource>(this IReadOnlyCollection<TSource> source, TSource element)
         => new AdditionalCollection<TSource>(source, Enumerable.Prepend(source, element));
 
-    private sealed class AdditionalCollection<TElement> : IReadOnlyCollection<TElement>
+    private sealed class AdditionalCollection<TElement> : ICollection<TElement>, IReadOnlyCollection<TElement>
     {
         public int Count => _source.Count + 1;
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.IsReadOnly => true;
 
         private readonly IReadOnlyCollection<TElement> _source;
         private readonly IEnumerable<TElement> _transformation;
@@ -50,5 +54,25 @@ static partial class Collection
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Add(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Clear()
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Contains(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Remove(TElement item)
+            => throw new NotSupportedException();
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.AppendPrepend.cs
+++ b/src/Core/Sweetener.Linq/Collection.AppendPrepend.cs
@@ -20,7 +20,11 @@ static partial class Collection
     /// <returns>A new collection that ends with <paramref name="element"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     public static IReadOnlyCollection<TSource> Append<TSource>(this IReadOnlyCollection<TSource> source, TSource element)
-        => new AdditionalCollection<TSource>(source, Enumerable.Append(source, element));
+        => new AdditionalCollection<TSource>(
+            source,
+            Enumerable.Append(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                element));
 
     /// <summary>
     /// Adds a value to the beginning of the collection.
@@ -31,48 +35,18 @@ static partial class Collection
     /// <returns>A new collection that begins with <paramref name="element"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     public static IReadOnlyCollection<TSource> Prepend<TSource>(this IReadOnlyCollection<TSource> source, TSource element)
-        => new AdditionalCollection<TSource>(source, Enumerable.Prepend(source, element));
+        => new AdditionalCollection<TSource>(
+            source,
+            Enumerable.Prepend(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                element));
 
-    private sealed class AdditionalCollection<TElement> : ICollection<TElement>, IReadOnlyCollection<TElement>
+    private sealed class AdditionalCollection<TElement> : MutableDecoratorCollection<TElement>
     {
-        public int Count => _source.Count + 1;
+        public override int Count => Source.Count + 1;
 
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.IsReadOnly => true;
-
-        private readonly IReadOnlyCollection<TElement> _source;
-        private readonly IEnumerable<TElement> _transformation;
-
-        public AdditionalCollection(IReadOnlyCollection<TElement> source, IEnumerable<TElement> transformation)
-        {
-            _source         = source;
-            _transformation = transformation;
-        }
-
-        public IEnumerator<TElement> GetEnumerator()
-            => _transformation.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator()
-            => GetEnumerator();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Add(TElement item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Clear()
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Contains(TElement item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Remove(TElement item)
-            => throw new NotSupportedException();
+        public AdditionalCollection(IReadOnlyCollection<TElement> source, IEnumerable<TElement> results)
+            : base(source, results)
+        { }
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.AppendPrepend.cs
+++ b/src/Core/Sweetener.Linq/Collection.AppendPrepend.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -20,11 +17,7 @@ static partial class Collection
     /// <returns>A new collection that ends with <paramref name="element"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     public static IReadOnlyCollection<TSource> Append<TSource>(this IReadOnlyCollection<TSource> source, TSource element)
-        => new AdditionalCollection<TSource>(
-            source,
-            Enumerable.Append(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
-                element));
+        => new AdditionalCollection<TSource>(source, Enumerable.Append(source, element));
 
     /// <summary>
     /// Adds a value to the beginning of the collection.
@@ -35,11 +28,7 @@ static partial class Collection
     /// <returns>A new collection that begins with <paramref name="element"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     public static IReadOnlyCollection<TSource> Prepend<TSource>(this IReadOnlyCollection<TSource> source, TSource element)
-        => new AdditionalCollection<TSource>(
-            source,
-            Enumerable.Prepend(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
-                element));
+        => new AdditionalCollection<TSource>(source, Enumerable.Prepend(source, element));
 
     private sealed class AdditionalCollection<TElement> : MutableDecoratorCollection<TElement>
     {

--- a/src/Core/Sweetener.Linq/Collection.Concat.cs
+++ b/src/Core/Sweetener.Linq/Collection.Concat.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Sweetener.Linq;
@@ -25,23 +26,46 @@ static partial class Collection
     public static IReadOnlyCollection<TSource> Concat<TSource>(this IReadOnlyCollection<TSource> first, IReadOnlyCollection<TSource> second)
         => new ConcatenatedCollection<TSource>(first, second);
 
-    private sealed class ConcatenatedCollection<TSource> : IReadOnlyCollection<TSource>
+    private sealed class ConcatenatedCollection<TElement> : ICollection<TElement>, IReadOnlyCollection<TElement>
     {
         public int Count => _first.Count + _second.Count;
 
-        private readonly IReadOnlyCollection<TSource> _first;
-        private readonly IReadOnlyCollection<TSource> _second;
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.IsReadOnly => true;
 
-        public ConcatenatedCollection(IReadOnlyCollection<TSource> first, IReadOnlyCollection<TSource> second)
+        private readonly IReadOnlyCollection<TElement> _first;
+        private readonly IReadOnlyCollection<TElement> _second;
+
+        public ConcatenatedCollection(IReadOnlyCollection<TElement> first, IReadOnlyCollection<TElement> second)
         {
             _first  = first  ?? throw new ArgumentNullException(nameof(first));
             _second = second ?? throw new ArgumentNullException(nameof(second));
         }
 
-        public IEnumerator<TSource> GetEnumerator()
+        public IEnumerator<TElement> GetEnumerator()
             => Enumerable.Concat(_first, _second).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Add(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Clear()
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Contains(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Remove(TElement item)
+            => throw new NotSupportedException();
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.Concat.cs
+++ b/src/Core/Sweetener.Linq/Collection.Concat.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -26,18 +23,14 @@ static partial class Collection
     public static IReadOnlyCollection<TSource> Concat<TSource>(this IReadOnlyCollection<TSource> first, IReadOnlyCollection<TSource> second)
         => new ConcatenatedCollection<TSource>(first, second);
 
-    private sealed class ConcatenatedCollection<TElement> : DecoratorCollection<TElement>
+    private sealed class ConcatenatedCollection<T> : MutableDecoratorCollection<T>
     {
-        public override int Count => _first.Count + _second.Count;
+        public override int Count => Source.Count + _source2.Count;
 
-        private readonly IReadOnlyCollection<TElement> _first;
-        private readonly IReadOnlyCollection<TElement> _second;
+        private readonly IReadOnlyCollection<T> _source2;
 
-        public ConcatenatedCollection(IReadOnlyCollection<TElement> first, IReadOnlyCollection<TElement> second)
-            : base(Enumerable.Concat(first, second))
-        {
-            _first  = first  ?? throw new ArgumentNullException(nameof(first));
-            _second = second ?? throw new ArgumentNullException(nameof(second));
-        }
+        public ConcatenatedCollection(IReadOnlyCollection<T> first, IReadOnlyCollection<T> second)
+            : base(first, Enumerable.Concat(first, second))
+            => _source2 = second;
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.Concat.cs
+++ b/src/Core/Sweetener.Linq/Collection.Concat.cs
@@ -23,14 +23,21 @@ static partial class Collection
     public static IReadOnlyCollection<TSource> Concat<TSource>(this IReadOnlyCollection<TSource> first, IReadOnlyCollection<TSource> second)
         => new ConcatenatedCollection<TSource>(first, second);
 
-    private sealed class ConcatenatedCollection<T> : MutableDecoratorCollection<T>
+    private sealed class ConcatenatedCollection<T> : DecoratorCollection<T>
     {
-        public override int Count => Source.Count + _source2.Count;
+        public override int Count => Source1.Count + Source2.Count;
 
-        private readonly IReadOnlyCollection<T> _source2;
+        public override IEnumerable<T> Enumerable { get; }
+
+        public IReadOnlyCollection<T> Source1 { get; }
+
+        public IReadOnlyCollection<T> Source2 { get; }
 
         public ConcatenatedCollection(IReadOnlyCollection<T> first, IReadOnlyCollection<T> second)
-            : base(first, Enumerable.Concat(first, second))
-            => _source2 = second;
+        {
+            Enumerable = Collection.EnumerableDecorator.Concat(first, second);
+            Source1 = first;
+            Source2 = second;
+        }
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.Concat.cs
+++ b/src/Core/Sweetener.Linq/Collection.Concat.cs
@@ -26,46 +26,18 @@ static partial class Collection
     public static IReadOnlyCollection<TSource> Concat<TSource>(this IReadOnlyCollection<TSource> first, IReadOnlyCollection<TSource> second)
         => new ConcatenatedCollection<TSource>(first, second);
 
-    private sealed class ConcatenatedCollection<TElement> : ICollection<TElement>, IReadOnlyCollection<TElement>
+    private sealed class ConcatenatedCollection<TElement> : DecoratorCollection<TElement>
     {
-        public int Count => _first.Count + _second.Count;
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.IsReadOnly => true;
+        public override int Count => _first.Count + _second.Count;
 
         private readonly IReadOnlyCollection<TElement> _first;
         private readonly IReadOnlyCollection<TElement> _second;
 
         public ConcatenatedCollection(IReadOnlyCollection<TElement> first, IReadOnlyCollection<TElement> second)
+            : base(Enumerable.Concat(first, second))
         {
             _first  = first  ?? throw new ArgumentNullException(nameof(first));
             _second = second ?? throw new ArgumentNullException(nameof(second));
         }
-
-        public IEnumerator<TElement> GetEnumerator()
-            => Enumerable.Concat(_first, _second).GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator()
-            => GetEnumerator();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Add(TElement item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Clear()
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Contains(TElement item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Remove(TElement item)
-            => throw new NotSupportedException();
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.Enumerable.cs
+++ b/src/Core/Sweetener.Linq/Collection.Enumerable.cs
@@ -1,0 +1,79 @@
+﻿// Copyright © William Sugarman.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using LinqEnumerable = System.Linq.Enumerable;
+
+namespace Sweetener.Linq;
+
+static partial class Collection
+{
+    // The Enumerable class provides optimized calls to the BCL's corresponding methods
+    private static class Enumerable
+    {
+        public static IEnumerable<TSource> Append<TSource>(IReadOnlyCollection<TSource> source, TSource element)
+            => LinqEnumerable.Append(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                element);
+
+        public static IEnumerable<TSource> Concat<TSource>(IReadOnlyCollection<TSource> first, IReadOnlyCollection<TSource> second)
+            => LinqEnumerable.Concat(
+                first  is DecoratorCollection<TSource> d1 ? d1.Elements : first,
+                second is DecoratorCollection<TSource> d2 ? d2.Elements : second);
+
+        public static System.Linq.IOrderedEnumerable<TSource> OrderBy<TSource, TKey>(IReadOnlyCollection<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
+            => LinqEnumerable.OrderBy(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                keySelector,
+                comparer);
+
+        public static System.Linq.IOrderedEnumerable<TSource> OrderByDescending<TSource, TKey>(IReadOnlyCollection<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
+            => LinqEnumerable.OrderByDescending(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                keySelector,
+                comparer);
+
+        public static IEnumerable<TSource> Prepend<TSource>(IReadOnlyCollection<TSource> source, TSource element)
+            => LinqEnumerable.Prepend(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                element);
+
+        public static IEnumerable<TSource> Reverse<TSource>(IReadOnlyCollection<TSource> source)
+            => LinqEnumerable.Reverse(source is DecoratorCollection<TSource> decorator ? decorator.Elements : source);
+
+        public static IEnumerable<TResult> Select<TSource, TResult>(IReadOnlyCollection<TSource> source, Func<TSource, TResult> selector)
+            => LinqEnumerable.Select(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                selector);
+
+        public static IEnumerable<TResult> Select<TSource, TResult>(IReadOnlyCollection<TSource> source, Func<TSource, int, TResult> selector)
+            => LinqEnumerable.Select(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                selector);
+
+        public static IEnumerable<TSource> Skip<TSource>(IReadOnlyCollection<TSource> source, int count)
+            => LinqEnumerable.Skip(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                count);
+
+#if NETCOREAPP2_0_OR_GREATER
+        public static IEnumerable<TSource> SkipLast<TSource>(IReadOnlyCollection<TSource> source, int count)
+            => LinqEnumerable.SkipLast(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                count);
+#endif
+
+        public static IEnumerable<TSource> Take<TSource>(IReadOnlyCollection<TSource> source, int count)
+            => LinqEnumerable.Take(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                count);
+
+#if NETCOREAPP2_0_OR_GREATER
+        public static IEnumerable<TSource> TakeLast<TSource>(IReadOnlyCollection<TSource> source, int count)
+            => LinqEnumerable.TakeLast(
+                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+                count);
+#endif
+    }
+}

--- a/src/Core/Sweetener.Linq/Collection.Enumerable.cs
+++ b/src/Core/Sweetener.Linq/Collection.Enumerable.cs
@@ -3,76 +3,80 @@
 
 using System;
 using System.Collections.Generic;
-using LinqEnumerable = System.Linq.Enumerable;
+using System.Linq;
 
 namespace Sweetener.Linq;
 
 static partial class Collection
 {
     // The Enumerable class provides optimized calls to the BCL's corresponding methods
-    private static class Enumerable
+    private static class EnumerableDecorator
     {
         public static IEnumerable<TSource> Append<TSource>(IReadOnlyCollection<TSource> source, TSource element)
-            => LinqEnumerable.Append(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
-                element);
+            => source is DecoratorCollection<TSource> decorator ? Append(decorator, element) : Enumerable.Append(source, element);
+
+        public static IEnumerable<TSource> Append<TSource>(DecoratorCollection<TSource> source, TSource element)
+            => Enumerable.Append(source.Enumerable, element);
 
         public static IEnumerable<TSource> Concat<TSource>(IReadOnlyCollection<TSource> first, IReadOnlyCollection<TSource> second)
-            => LinqEnumerable.Concat(
-                first  is DecoratorCollection<TSource> d1 ? d1.Elements : first,
-                second is DecoratorCollection<TSource> d2 ? d2.Elements : second);
+            => Enumerable.Concat(
+                first  is DecoratorCollection<TSource> d1 ? d1.Enumerable : first,
+                second is DecoratorCollection<TSource> d2 ? d2.Enumerable : second);
 
         public static System.Linq.IOrderedEnumerable<TSource> OrderBy<TSource, TKey>(IReadOnlyCollection<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
-            => LinqEnumerable.OrderBy(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+            => Enumerable.OrderBy(
+                source is DecoratorCollection<TSource> decorator ? decorator.Enumerable : source,
                 keySelector,
                 comparer);
 
         public static System.Linq.IOrderedEnumerable<TSource> OrderByDescending<TSource, TKey>(IReadOnlyCollection<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
-            => LinqEnumerable.OrderByDescending(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+            => Enumerable.OrderByDescending(
+                source is DecoratorCollection<TSource> decorator ? decorator.Enumerable : source,
                 keySelector,
                 comparer);
 
         public static IEnumerable<TSource> Prepend<TSource>(IReadOnlyCollection<TSource> source, TSource element)
-            => LinqEnumerable.Prepend(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
-                element);
+            => source is DecoratorCollection<TSource> decorator ? Prepend(decorator, element) : Enumerable.Prepend(source, element);
+
+        public static IEnumerable<TSource> Prepend<TSource>(DecoratorCollection<TSource> source, TSource element)
+            => Enumerable.Prepend(source.Enumerable, element);
 
         public static IEnumerable<TSource> Reverse<TSource>(IReadOnlyCollection<TSource> source)
-            => LinqEnumerable.Reverse(source is DecoratorCollection<TSource> decorator ? decorator.Elements : source);
+            => Enumerable.Reverse(source is DecoratorCollection<TSource> decorator ? decorator.Enumerable : source);
 
         public static IEnumerable<TResult> Select<TSource, TResult>(IReadOnlyCollection<TSource> source, Func<TSource, TResult> selector)
-            => LinqEnumerable.Select(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
-                selector);
+            => source is DecoratorCollection<TSource> decorator ? Select(decorator, selector) : Enumerable.Select(source, selector);
+
+        public static IEnumerable<TResult> Select<TSource, TResult>(DecoratorCollection<TSource> source, Func<TSource, TResult> selector)
+            => Enumerable.Select(source.Enumerable, selector);
 
         public static IEnumerable<TResult> Select<TSource, TResult>(IReadOnlyCollection<TSource> source, Func<TSource, int, TResult> selector)
-            => LinqEnumerable.Select(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
-                selector);
+            => source is DecoratorCollection<TSource> decorator ? Select(decorator, selector) : Enumerable.Select(source, selector);
+
+        public static IEnumerable<TResult> Select<TSource, TResult>(DecoratorCollection<TSource> source, Func<TSource, int, TResult> selector)
+            => Enumerable.Select(source.Enumerable, selector);
 
         public static IEnumerable<TSource> Skip<TSource>(IReadOnlyCollection<TSource> source, int count)
-            => LinqEnumerable.Skip(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+            => Enumerable.Skip(
+                source is DecoratorCollection<TSource> decorator ? decorator.Enumerable : source,
                 count);
 
 #if NETCOREAPP2_0_OR_GREATER
         public static IEnumerable<TSource> SkipLast<TSource>(IReadOnlyCollection<TSource> source, int count)
-            => LinqEnumerable.SkipLast(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+            => Enumerable.SkipLast(
+                source is DecoratorCollection<TSource> decorator ? decorator.Enumerable : source,
                 count);
 #endif
 
         public static IEnumerable<TSource> Take<TSource>(IReadOnlyCollection<TSource> source, int count)
-            => LinqEnumerable.Take(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+            => Enumerable.Take(
+                source is DecoratorCollection<TSource> decorator ? decorator.Enumerable : source,
                 count);
 
 #if NETCOREAPP2_0_OR_GREATER
         public static IEnumerable<TSource> TakeLast<TSource>(IReadOnlyCollection<TSource> source, int count)
-            => LinqEnumerable.TakeLast(
-                source is DecoratorCollection<TSource> decorator ? decorator.Elements : source,
+            => Enumerable.TakeLast(
+                source is DecoratorCollection<TSource> decorator ? decorator.Enumerable : source,
                 count);
 #endif
     }

--- a/src/Core/Sweetener.Linq/Collection.OrderBy.cs
+++ b/src/Core/Sweetener.Linq/Collection.OrderBy.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -168,19 +165,25 @@ partial class Collection
         return source.CreateOrderedCollection(keySelector, comparer ?? Comparer<TKey>.Default, descending: true);
     }
 
-    private sealed class OrderedCollection<TElement> : DecoratorCollection<TElement>, IOrderedReadOnlyCollection<TElement>
+    private sealed class OrderedCollection<T> : DecoratorCollection<T>, IOrderedReadOnlyCollection<T>
     {
-        public int Count => _source.Count;
+        public override int Count => _source.Count;
 
+        public override IEnumerable<T> Elements => _ordered;
 
-        public OrderedCollection(IReadOnlyCollection<TElement> source, IOrderedEnumerable<TElement> ordered)
-            : base(source, ordered)
-        { }
+        private readonly IReadOnlyCollection<T> _source;
+        private readonly System.Linq.IOrderedEnumerable<T> _ordered;
 
-        public IOrderedReadOnlyCollection<TElement> CreateOrderedCollection<TKey>(Func<TElement, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
-            => new OrderedCollection<TElement>(_source, _ordered.CreateOrderedEnumerable(keySelector, comparer, descending));
+        public OrderedCollection(IReadOnlyCollection<T> source, System.Linq.IOrderedEnumerable<T> ordered)
+        {
+            _ordered = ordered;
+            _source  = source;
+        }
 
-        public IOrderedEnumerable<TElement> CreateOrderedEnumerable<TKey>(Func<TElement, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
+        public IOrderedReadOnlyCollection<T> CreateOrderedCollection<TKey>(Func<T, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
+            => new OrderedCollection<T>(_source, _ordered.CreateOrderedEnumerable(keySelector, comparer, descending));
+
+        System.Linq.IOrderedEnumerable<T> System.Linq.IOrderedEnumerable<T>.CreateOrderedEnumerable<TKey>(Func<T, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
             => _ordered.CreateOrderedEnumerable(keySelector, comparer, descending);
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.OrderBy.cs
+++ b/src/Core/Sweetener.Linq/Collection.OrderBy.cs
@@ -168,52 +168,19 @@ partial class Collection
         return source.CreateOrderedCollection(keySelector, comparer ?? Comparer<TKey>.Default, descending: true);
     }
 
-    private sealed class OrderedCollection<TElement> : ICollection<TElement>, IOrderedReadOnlyCollection<TElement>
+    private sealed class OrderedCollection<TElement> : DecoratorCollection<TElement>, IOrderedReadOnlyCollection<TElement>
     {
         public int Count => _source.Count;
 
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.IsReadOnly => true;
-
-        private readonly IReadOnlyCollection<TElement> _source;
-        private readonly IOrderedEnumerable<TElement> _ordered;
 
         public OrderedCollection(IReadOnlyCollection<TElement> source, IOrderedEnumerable<TElement> ordered)
-        {
-            _source  = source;
-            _ordered = ordered;
-        }
+            : base(source, ordered)
+        { }
 
         public IOrderedReadOnlyCollection<TElement> CreateOrderedCollection<TKey>(Func<TElement, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
             => new OrderedCollection<TElement>(_source, _ordered.CreateOrderedEnumerable(keySelector, comparer, descending));
 
         public IOrderedEnumerable<TElement> CreateOrderedEnumerable<TKey>(Func<TElement, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
             => _ordered.CreateOrderedEnumerable(keySelector, comparer, descending);
-
-        public IEnumerator<TElement> GetEnumerator()
-            => _ordered.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator()
-            => GetEnumerator();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Add(TElement item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Clear()
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Contains(TElement item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Remove(TElement item)
-            => throw new NotSupportedException();
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.OrderBy.cs
+++ b/src/Core/Sweetener.Linq/Collection.OrderBy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -39,7 +40,7 @@ partial class Collection
     /// <paramref name="source"/> or <paramref name="keySelector"/> <see langword="null"/>.
     /// </exception>
     public static IOrderedReadOnlyCollection<TSource> OrderBy<TSource, TKey>(this IReadOnlyCollection<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
-        => new OrderedCollection<TSource>(source, Enumerable.OrderBy(source, keySelector, comparer));
+        => new OrderedCollection<TSource>(source, EnumerableDecorator.OrderBy(source, keySelector, comparer));
 
     /// <summary>
     /// Sorts the elements of a collection in descending order according to a key.
@@ -74,7 +75,7 @@ partial class Collection
     /// <paramref name="source"/> or <paramref name="keySelector"/> <see langword="null"/>.
     /// </exception>
     public static IOrderedReadOnlyCollection<TSource> OrderByDescending<TSource, TKey>(this IReadOnlyCollection<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
-        => new OrderedCollection<TSource>(source, Enumerable.OrderByDescending(source, keySelector, comparer));
+        => new OrderedCollection<TSource>(source, EnumerableDecorator.OrderByDescending(source, keySelector, comparer));
 
     /// <summary>
     /// Performs a subsequent ordering of the elements in a collection in ascending order according to a key.
@@ -169,12 +170,12 @@ partial class Collection
     {
         public override int Count => _source.Count;
 
-        public override IEnumerable<T> Elements => _ordered;
+        public override IEnumerable<T> Enumerable => _ordered;
 
         private readonly IReadOnlyCollection<T> _source;
         private readonly System.Linq.IOrderedEnumerable<T> _ordered;
 
-        public OrderedCollection(IReadOnlyCollection<T> source, System.Linq.IOrderedEnumerable<T> ordered)
+        public OrderedCollection(IReadOnlyCollection<T> source, IOrderedEnumerable<T> ordered)
         {
             _ordered = ordered;
             _source  = source;
@@ -183,7 +184,7 @@ partial class Collection
         public IOrderedReadOnlyCollection<T> CreateOrderedCollection<TKey>(Func<T, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
             => new OrderedCollection<T>(_source, _ordered.CreateOrderedEnumerable(keySelector, comparer, descending));
 
-        System.Linq.IOrderedEnumerable<T> System.Linq.IOrderedEnumerable<T>.CreateOrderedEnumerable<TKey>(Func<T, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
+        IOrderedEnumerable<T> IOrderedEnumerable<T>.CreateOrderedEnumerable<TKey>(Func<T, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
             => _ordered.CreateOrderedEnumerable(keySelector, comparer, descending);
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.OrderBy.cs
+++ b/src/Core/Sweetener.Linq/Collection.OrderBy.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Sweetener.Linq;
@@ -167,9 +168,12 @@ partial class Collection
         return source.CreateOrderedCollection(keySelector, comparer ?? Comparer<TKey>.Default, descending: true);
     }
 
-    private sealed class OrderedCollection<TElement> : IOrderedReadOnlyCollection<TElement>
+    private sealed class OrderedCollection<TElement> : ICollection<TElement>, IOrderedReadOnlyCollection<TElement>
     {
         public int Count => _source.Count;
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.IsReadOnly => true;
 
         private readonly IReadOnlyCollection<TElement> _source;
         private readonly IOrderedEnumerable<TElement> _ordered;
@@ -191,5 +195,25 @@ partial class Collection
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Add(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Clear()
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Contains(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Remove(TElement item)
+            => throw new NotSupportedException();
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.Range.cs
+++ b/src/Core/Sweetener.Linq/Collection.Range.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -23,5 +22,5 @@ static partial class Collection
     /// <para><paramref name="start"/> + <paramref name="count"/> -1 is larger than <see cref="int.MaxValue"/>.</para>
     /// </exception>
     public static IReadOnlyCollection<int> Range(int start, int count)
-        => count == 0 ? Array.Empty<int>() : new ImmutableDecoratorCollection<int>(Enumerable.Range(start, count), count);
+        => count == 0 ? Array.Empty<int>() : new ImmutableDecoratorCollection<int>(System.Linq.Enumerable.Range(start, count), count);
 }

--- a/src/Core/Sweetener.Linq/Collection.Range.cs
+++ b/src/Core/Sweetener.Linq/Collection.Range.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -22,5 +23,5 @@ static partial class Collection
     /// <para><paramref name="start"/> + <paramref name="count"/> -1 is larger than <see cref="int.MaxValue"/>.</para>
     /// </exception>
     public static IReadOnlyCollection<int> Range(int start, int count)
-        => count == 0 ? Array.Empty<int>() : new ImmutableDecoratorCollection<int>(System.Linq.Enumerable.Range(start, count), count);
+        => count == 0 ? Array.Empty<int>() : new GeneratedDecoratorCollection<int>(Enumerable.Range(start, count), count);
 }

--- a/src/Core/Sweetener.Linq/Collection.Range.cs
+++ b/src/Core/Sweetener.Linq/Collection.Range.cs
@@ -23,5 +23,5 @@ static partial class Collection
     /// <para><paramref name="start"/> + <paramref name="count"/> -1 is larger than <see cref="int.MaxValue"/>.</para>
     /// </exception>
     public static IReadOnlyCollection<int> Range(int start, int count)
-        => count == 0 ? Array.Empty<int>() : new ReadOnlyCollection<int>(Enumerable.Range(start, count), count);
+        => count == 0 ? Array.Empty<int>() : new ImmutableDecoratorCollection<int>(Enumerable.Range(start, count), count);
 }

--- a/src/Core/Sweetener.Linq/Collection.Repeat.cs
+++ b/src/Core/Sweetener.Linq/Collection.Repeat.cs
@@ -18,5 +18,5 @@ static partial class Collection
     /// <returns>An <see cref="IReadOnlyCollection{T}"/> that contains a repeated value.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than 0.</exception>
     public static IReadOnlyCollection<TResult> Repeat<TResult>(TResult element, int count)
-        => count == 0 ? Array.Empty<TResult>() : new ReadOnlyCollection<TResult>(Enumerable.Repeat(element, count), count);
+        => count == 0 ? Array.Empty<TResult>() : new ImmutableDecoratorCollection<TResult>(Enumerable.Repeat(element, count), count);
 }

--- a/src/Core/Sweetener.Linq/Collection.Repeat.cs
+++ b/src/Core/Sweetener.Linq/Collection.Repeat.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -17,5 +18,5 @@ static partial class Collection
     /// <returns>An <see cref="IReadOnlyCollection{T}"/> that contains a repeated value.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than 0.</exception>
     public static IReadOnlyCollection<TResult> Repeat<TResult>(TResult element, int count)
-        => count == 0 ? Array.Empty<TResult>() : new ImmutableDecoratorCollection<TResult>(System.Linq.Enumerable.Repeat(element, count), count);
+        => count == 0 ? Array.Empty<TResult>() : new GeneratedDecoratorCollection<TResult>(Enumerable.Repeat(element, count), count);
 }

--- a/src/Core/Sweetener.Linq/Collection.Repeat.cs
+++ b/src/Core/Sweetener.Linq/Collection.Repeat.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -18,5 +17,5 @@ static partial class Collection
     /// <returns>An <see cref="IReadOnlyCollection{T}"/> that contains a repeated value.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than 0.</exception>
     public static IReadOnlyCollection<TResult> Repeat<TResult>(TResult element, int count)
-        => count == 0 ? Array.Empty<TResult>() : new ImmutableDecoratorCollection<TResult>(Enumerable.Repeat(element, count), count);
+        => count == 0 ? Array.Empty<TResult>() : new ImmutableDecoratorCollection<TResult>(System.Linq.Enumerable.Repeat(element, count), count);
 }

--- a/src/Core/Sweetener.Linq/Collection.Reverse.cs
+++ b/src/Core/Sweetener.Linq/Collection.Reverse.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -19,5 +18,5 @@ static partial class Collection
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     public static IReadOnlyCollection<TSource> Reverse<TSource>(this IReadOnlyCollection<TSource> source)
-        => new EnumerableCollection<TSource>(source, Enumerable.Reverse(source));
+        => new MutableDecoratorCollection<TSource>(source, Enumerable.Reverse(source));
 }

--- a/src/Core/Sweetener.Linq/Collection.Reverse.cs
+++ b/src/Core/Sweetener.Linq/Collection.Reverse.cs
@@ -18,5 +18,5 @@ static partial class Collection
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     public static IReadOnlyCollection<TSource> Reverse<TSource>(this IReadOnlyCollection<TSource> source)
-        => new MutableDecoratorCollection<TSource>(source, Enumerable.Reverse(source));
+        => new FixedDecoratorTransformationCollection<TSource>(source, EnumerableDecorator.Reverse(source));
 }

--- a/src/Core/Sweetener.Linq/Collection.Select.cs
+++ b/src/Core/Sweetener.Linq/Collection.Select.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -26,7 +23,7 @@ partial class Collection
     /// <paramref name="source"/> or <paramref name="selector"/> is <see langword="null"/>.
     /// </exception>
     public static IReadOnlyCollection<TResult> Select<TSource, TResult>(this IReadOnlyCollection<TSource> source, Func<TSource, TResult> selector)
-        => new SelectCollection<TSource, TResult>(source, Enumerable.Select(source, selector));
+        => new MutableProjectionDecoratorCollection<TSource, TResult>(source, Enumerable.Select(source, selector));
 
     /// <summary>
     /// Projects each element of a collection into a new form by incorporating the element's index.
@@ -46,53 +43,5 @@ partial class Collection
     /// <paramref name="source"/> or <paramref name="selector"/> is <see langword="null"/>.
     /// </exception>
     public static IReadOnlyCollection<TResult> Select<TSource, TResult>(this IReadOnlyCollection<TSource> source, Func<TSource, int, TResult> selector)
-        => new SelectCollection<TSource, TResult>(source, Enumerable.Select(source, selector));
-
-    private sealed class SelectCollection<TSource, TResult> : ICollection<TResult>, DecoratorCollection<TSource>, IReadOnlyCollection<TResult>
-    {
-        public int Count => _source.Count;
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TResult>.IsReadOnly => true;
-
-        private readonly IReadOnlyCollection<TSource> _source;
-        private readonly IEnumerable<TResult> _projection;
-
-        public SelectCollection(IReadOnlyCollection<TSource> source, IEnumerable<TResult> projection)
-        {
-            _source     = source;
-            _projection = projection;
-        }
-
-        public IEnumerator<TResult> GetEnumerator()
-            => _projection.GetEnumerator();
-
-        public IReadOnlyCollection<TResult2> Select<TResult2>(Func<TResult, TResult2> selector)
-            => new SelectCollection<TSource, TResult2>(_source, _projection.Select(selector));
-
-        IEnumerator IEnumerable.GetEnumerator()
-            => GetEnumerator();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TResult>.Add(TResult item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TResult>.Clear()
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TResult>.Contains(TResult item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TResult>.CopyTo(TResult[] array, int arrayIndex)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TResult>.Remove(TResult item)
-            => throw new NotSupportedException();
-
-        IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => throw new NotImplementedException();
-    }
+        => new MutableProjectionDecoratorCollection<TSource, TResult>(source, Enumerable.Select(source, selector));
 }

--- a/src/Core/Sweetener.Linq/Collection.Select.cs
+++ b/src/Core/Sweetener.Linq/Collection.Select.cs
@@ -48,7 +48,7 @@ partial class Collection
     public static IReadOnlyCollection<TResult> Select<TSource, TResult>(this IReadOnlyCollection<TSource> source, Func<TSource, int, TResult> selector)
         => new SelectCollection<TSource, TResult>(source, Enumerable.Select(source, selector));
 
-    private sealed class SelectCollection<TSource, TResult> : ICollection<TResult>, IReadOnlyCollection<TResult>
+    private sealed class SelectCollection<TSource, TResult> : ICollection<TResult>, DecoratorCollection<TSource>, IReadOnlyCollection<TResult>
     {
         public int Count => _source.Count;
 
@@ -66,6 +66,9 @@ partial class Collection
 
         public IEnumerator<TResult> GetEnumerator()
             => _projection.GetEnumerator();
+
+        public IReadOnlyCollection<TResult2> Select<TResult2>(Func<TResult, TResult2> selector)
+            => new SelectCollection<TSource, TResult2>(_source, _projection.Select(selector));
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
@@ -89,5 +92,7 @@ partial class Collection
         [ExcludeFromCodeCoverage]
         bool ICollection<TResult>.Remove(TResult item)
             => throw new NotSupportedException();
+
+        IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => throw new NotImplementedException();
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.Select.cs
+++ b/src/Core/Sweetener.Linq/Collection.Select.cs
@@ -23,7 +23,9 @@ partial class Collection
     /// <paramref name="source"/> or <paramref name="selector"/> is <see langword="null"/>.
     /// </exception>
     public static IReadOnlyCollection<TResult> Select<TSource, TResult>(this IReadOnlyCollection<TSource> source, Func<TSource, TResult> selector)
-        => new MutableProjectionDecoratorCollection<TSource, TResult>(source, Enumerable.Select(source, selector));
+        => source is IProjectable<TSource> transformation
+            ? transformation.Select(selector)
+            : new FixedDecoratorTransformationCollection<TSource, TResult>(source, EnumerableDecorator.Select(source, selector));
 
     /// <summary>
     /// Projects each element of a collection into a new form by incorporating the element's index.
@@ -43,5 +45,7 @@ partial class Collection
     /// <paramref name="source"/> or <paramref name="selector"/> is <see langword="null"/>.
     /// </exception>
     public static IReadOnlyCollection<TResult> Select<TSource, TResult>(this IReadOnlyCollection<TSource> source, Func<TSource, int, TResult> selector)
-        => new MutableProjectionDecoratorCollection<TSource, TResult>(source, Enumerable.Select(source, selector));
+        => source is IProjectable<TSource> transformation
+            ? transformation.Select(selector)
+            : new FixedDecoratorTransformationCollection<TSource, TResult>(source, EnumerableDecorator.Select(source, selector));
 }

--- a/src/Core/Sweetener.Linq/Collection.Select.cs
+++ b/src/Core/Sweetener.Linq/Collection.Select.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Sweetener.Linq;
@@ -47,9 +48,12 @@ partial class Collection
     public static IReadOnlyCollection<TResult> Select<TSource, TResult>(this IReadOnlyCollection<TSource> source, Func<TSource, int, TResult> selector)
         => new SelectCollection<TSource, TResult>(source, Enumerable.Select(source, selector));
 
-    private sealed class SelectCollection<TSource, TResult> : IReadOnlyCollection<TResult>
+    private sealed class SelectCollection<TSource, TResult> : ICollection<TResult>, IReadOnlyCollection<TResult>
     {
         public int Count => _source.Count;
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TResult>.IsReadOnly => true;
 
         private readonly IReadOnlyCollection<TSource> _source;
         private readonly IEnumerable<TResult> _projection;
@@ -65,5 +69,25 @@ partial class Collection
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TResult>.Add(TResult item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TResult>.Clear()
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TResult>.Contains(TResult item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TResult>.CopyTo(TResult[] array, int arrayIndex)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TResult>.Remove(TResult item)
+            => throw new NotSupportedException();
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.Skip.cs
+++ b/src/Core/Sweetener.Linq/Collection.Skip.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Sweetener.Linq;
@@ -14,7 +15,7 @@ static partial class Collection
     /// Bypasses a specified number of elements in a collection and then returns the remaining elements.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-    /// <param name="source">An <see cref="ICollection{T}"/> to return elements from.</param>
+    /// <param name="source">An <see cref="IReadOnlyCollection{T}"/> to return elements from.</param>
     /// <param name="count">The number of elements to skip before returning the remaining elements.</param>
     /// <returns>
     /// An <see cref="IReadOnlyCollection{T}"/> that contains the elements that occur after
@@ -24,11 +25,29 @@ static partial class Collection
     public static IReadOnlyCollection<TSource> Skip<TSource>(this IReadOnlyCollection<TSource> source, int count)
         => new SkipCollection<TSource>(source, Enumerable.Skip(source, count), count);
 
-    // TODO: Implement SkipLast when moving to .NET Core
+#if NETCOREAPP2_0_OR_GREATER
+    /// <summary>
+    /// Returns a new collection that contains the elements from <paramref name="source"/> with the last
+    /// <paramref name="count"/> elements of the source collection omitted.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements in the collection.</typeparam>
+    /// <param name="source">A collection instance.</param>
+    /// <param name="count">The number of elements to omit from the end of the collection.</param>
+    /// <returns>
+    /// A new collection that contains the elements from <paramref name="source"/> minus <paramref name="count"/>
+    /// elements from the end of the collection.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+    public static IReadOnlyCollection<TSource> SkipLast<TSource>(this IReadOnlyCollection<TSource> source, int count)
+        => new SkipCollection<TSource>(source, Enumerable.SkipLast(source, count), count);
+#endif
 
-    private sealed class SkipCollection<TElement> : IReadOnlyCollection<TElement>
+    private sealed class SkipCollection<TElement> : ICollection<TElement>, IReadOnlyCollection<TElement>
     {
         public int Count => Math.Max(0, _source.Count - _skip);
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.IsReadOnly => true;
 
         private readonly IReadOnlyCollection<TElement> _source;
         private readonly IEnumerable<TElement> _transformation;
@@ -46,5 +65,25 @@ static partial class Collection
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Add(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Clear()
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Contains(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Remove(TElement item)
+            => throw new NotSupportedException();
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.Skip.cs
+++ b/src/Core/Sweetener.Linq/Collection.Skip.cs
@@ -20,7 +20,7 @@ static partial class Collection
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     public static IReadOnlyCollection<TSource> Skip<TSource>(this IReadOnlyCollection<TSource> source, int count)
-        => new SkipCollection<TSource>(source, Enumerable.Skip(source, count), count);
+        => new SkipCollection<TSource>(source, EnumerableDecorator.Skip(source, count), count);
 
 #if NETCOREAPP2_0_OR_GREATER
     /// <summary>
@@ -36,10 +36,10 @@ static partial class Collection
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     public static IReadOnlyCollection<TSource> SkipLast<TSource>(this IReadOnlyCollection<TSource> source, int count)
-        => new SkipCollection<TSource>(source, Enumerable.SkipLast(source, count), count);
+        => new SkipCollection<TSource>(source, EnumerableDecorator.SkipLast(source, count), count);
 #endif
 
-    private sealed class SkipCollection<T> : MutableDecoratorCollection<T>
+    private sealed class SkipCollection<T> : DecoratorTransformationCollection<T>
     {
         public override int Count => Math.Max(0, Source.Count - _skip);
 

--- a/src/Core/Sweetener.Linq/Collection.Skip.cs
+++ b/src/Core/Sweetener.Linq/Collection.Skip.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -42,48 +39,14 @@ static partial class Collection
         => new SkipCollection<TSource>(source, Enumerable.SkipLast(source, count), count);
 #endif
 
-    private sealed class SkipCollection<TElement> : ICollection<TElement>, IReadOnlyCollection<TElement>
+    private sealed class SkipCollection<T> : MutableDecoratorCollection<T>
     {
-        public int Count => Math.Max(0, _source.Count - _skip);
+        public override int Count => Math.Max(0, Source.Count - _skip);
 
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.IsReadOnly => true;
-
-        private readonly IReadOnlyCollection<TElement> _source;
-        private readonly IEnumerable<TElement> _transformation;
         private readonly int _skip;
 
-        public SkipCollection(IReadOnlyCollection<TElement> source, IEnumerable<TElement> transformation, int skip)
-        {
-            _source         = source;
-            _transformation = transformation;
-            _skip           = skip <= 0 ? 0 : skip;
-        }
-
-        public IEnumerator<TElement> GetEnumerator()
-            => _transformation.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator()
-            => GetEnumerator();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Add(TElement item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Clear()
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Contains(TElement item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Remove(TElement item)
-            => throw new NotSupportedException();
+        public SkipCollection(IReadOnlyCollection<T> source, IEnumerable<T> transformation, int skip)
+            : base(source, transformation)
+            => _skip = skip <= 0 ? 0 : skip;
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.Take.cs
+++ b/src/Core/Sweetener.Linq/Collection.Take.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Sweetener.Linq;
@@ -24,11 +25,27 @@ static partial class Collection
     public static IReadOnlyCollection<TSource> Take<TSource>(this IReadOnlyCollection<TSource> source, int count)
         => new TakeCollection<TSource>(source, Enumerable.Take(source, count), count);
 
-    // TODO: Implement TakeLast when moving to .NET Core
+#if NETCOREAPP2_0_OR_GREATER
+    /// <summary>
+    /// Returns a new collection that contains the last <paramref name="count"/> elements from <paramref name="source"/>.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements in the collection.</typeparam>
+    /// <param name="source">A collection instance.</param>
+    /// <param name="count">The number of elements to take from the end of the collection.</param>
+    /// <returns>
+    /// A new collection that contains the last <paramref name="count"/> elements from <paramref name="source"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+    public static IReadOnlyCollection<TSource> TakeLast<TSource>(this IReadOnlyCollection<TSource> source, int count)
+        => new TakeCollection<TSource>(source, Enumerable.TakeLast(source, count), count);
+#endif
 
-    private sealed class TakeCollection<TElement> : IReadOnlyCollection<TElement>
+    private sealed class TakeCollection<TElement> : ICollection<TElement>, IReadOnlyCollection<TElement>
     {
         public int Count => Math.Min(_source.Count, _count);
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.IsReadOnly => true;
 
         private readonly IReadOnlyCollection<TElement> _source;
         private readonly IEnumerable<TElement> _transformation;
@@ -46,5 +63,25 @@ static partial class Collection
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Add(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Clear()
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Contains(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Remove(TElement item)
+            => throw new NotSupportedException();
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.Take.cs
+++ b/src/Core/Sweetener.Linq/Collection.Take.cs
@@ -20,7 +20,7 @@ static partial class Collection
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     public static IReadOnlyCollection<TSource> Take<TSource>(this IReadOnlyCollection<TSource> source, int count)
-        => new TakeCollection<TSource>(source, Enumerable.Take(source, count), count);
+        => new TakeCollection<TSource>(source, EnumerableDecorator.Take(source, count), count);
 
 #if NETCOREAPP2_0_OR_GREATER
     /// <summary>
@@ -34,10 +34,10 @@ static partial class Collection
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     public static IReadOnlyCollection<TSource> TakeLast<TSource>(this IReadOnlyCollection<TSource> source, int count)
-        => new TakeCollection<TSource>(source, Enumerable.TakeLast(source, count), count);
+        => new TakeCollection<TSource>(source, EnumerableDecorator.TakeLast(source, count), count);
 #endif
 
-    private sealed class TakeCollection<T> : MutableDecoratorCollection<T>
+    private sealed class TakeCollection<T> : DecoratorTransformationCollection<T>
     {
         public override int Count => Math.Min(Source.Count, _take);
 

--- a/src/Core/Sweetener.Linq/Collection.Take.cs
+++ b/src/Core/Sweetener.Linq/Collection.Take.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Sweetener.Linq;
 
@@ -40,48 +37,14 @@ static partial class Collection
         => new TakeCollection<TSource>(source, Enumerable.TakeLast(source, count), count);
 #endif
 
-    private sealed class TakeCollection<TElement> : ICollection<TElement>, IReadOnlyCollection<TElement>
+    private sealed class TakeCollection<T> : MutableDecoratorCollection<T>
     {
-        public int Count => Math.Min(_source.Count, _count);
+        public override int Count => Math.Min(Source.Count, _take);
 
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.IsReadOnly => true;
+        private readonly int _take;
 
-        private readonly IReadOnlyCollection<TElement> _source;
-        private readonly IEnumerable<TElement> _transformation;
-        private readonly int _count;
-
-        public TakeCollection(IReadOnlyCollection<TElement> source, IEnumerable<TElement> transformation, int count)
-        {
-            _source         = source;
-            _transformation = transformation;
-            _count          = count <= 0 ? 0 : count;
-        }
-
-        public IEnumerator<TElement> GetEnumerator()
-            => _transformation.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator()
-            => GetEnumerator();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Add(TElement item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Clear()
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Contains(TElement item)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
-            => throw new NotSupportedException();
-
-        [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Remove(TElement item)
-            => throw new NotSupportedException();
+        public TakeCollection(IReadOnlyCollection<T> source, IEnumerable<T> transformation, int count)
+            : base(source, transformation)
+            => _take = count <= 0 ? 0 : count;
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.cs
+++ b/src/Core/Sweetener.Linq/Collection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright © William Sugarman.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -13,9 +14,12 @@ namespace Sweetener.Linq;
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Collection class is meant to parallel Enumerable. ")]
 public static partial class Collection
 {
-    private sealed class EnumerableCollection<TElement> : IReadOnlyCollection<TElement>
+    private sealed class EnumerableCollection<TElement> : ICollection<TElement>, IReadOnlyCollection<TElement>
     {
         public int Count => _source.Count;
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.IsReadOnly => true;
 
         private readonly IReadOnlyCollection<TElement> _source;
         private readonly IEnumerable<TElement> _transformation;
@@ -31,11 +35,34 @@ public static partial class Collection
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Add(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Clear()
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Contains(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Remove(TElement item)
+            => throw new NotSupportedException();
     }
 
-    private sealed class ReadOnlyCollection<TElement> : IReadOnlyCollection<TElement>
+    private sealed class ReadOnlyCollection<TElement> : ICollection<TElement>, IReadOnlyCollection<TElement>
     {
         public int Count { get; }
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.IsReadOnly => true;
 
         private readonly IEnumerable<TElement> _elements;
 
@@ -50,5 +77,25 @@ public static partial class Collection
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Add(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.Clear()
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Contains(TElement item)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
+            => throw new NotSupportedException();
+
+        [ExcludeFromCodeCoverage]
+        bool ICollection<TElement>.Remove(TElement item)
+            => throw new NotSupportedException();
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.cs
+++ b/src/Core/Sweetener.Linq/Collection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Sweetener.Linq;
@@ -14,20 +15,31 @@ namespace Sweetener.Linq;
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Collection class is meant to parallel Enumerable.")]
 public static partial class Collection
 {
+    private interface IProjectable<T>
+    {
+        [SuppressMessage("Naming", "CA1716:Identifiers should not match keywords", Justification = "Name matches method in System.Linq.Enumerable.")]
+        IReadOnlyCollection<TResult> Select<TResult>(Func<T, TResult> selector);
+
+        [SuppressMessage("Naming", "CA1716:Identifiers should not match keywords", Justification = "Name matches method in System.Linq.Enumerable.")]
+        IReadOnlyCollection<TResult> Select<TResult>(Func<T, int, TResult> selector);
+    }
+
     private abstract class DecoratorCollection<T> : ICollection<T>, IEnumerable<T>, IReadOnlyCollection<T>
     {
         public abstract int Count { get; }
 
-        public abstract IEnumerable<T> Elements { get; }
+        public abstract IEnumerable<T> Enumerable { get; }
 
         [ExcludeFromCodeCoverage]
         bool ICollection<T>.IsReadOnly => true;
 
         public IEnumerator<T> GetEnumerator()
-            => Elements.GetEnumerator();
+            => Enumerable.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
+
+        #region ICollection<T> Implementation
 
         [ExcludeFromCodeCoverage]
         void ICollection<T>.Add(T item)
@@ -48,48 +60,64 @@ public static partial class Collection
         [ExcludeFromCodeCoverage]
         bool ICollection<T>.Remove(T item)
             => throw new NotSupportedException();
+
+        #endregion
     }
 
-    private class MutableDecoratorCollection<T> : DecoratorCollection<T>
+    private sealed class GeneratedDecoratorCollection<T> : DecoratorCollection<T>
     {
-        public override int Count => Source.Count;
+        public sealed override int Count { get; }
 
-        public override IEnumerable<T> Elements { get; }
+        public sealed override IEnumerable<T> Enumerable { get; }
 
-        protected IReadOnlyCollection<T> Source { get; }
-
-        public MutableDecoratorCollection(IReadOnlyCollection<T> source, IEnumerable<T> result)
-        {
-            Elements = result;
-            Source   = source;
-        }
-    }
-
-    private class MutableProjectionDecoratorCollection<TSource, TResult> : DecoratorCollection<TResult>
-    {
-        public override int Count => Source.Count;
-
-        public override IEnumerable<TResult> Elements { get; }
-
-        protected IReadOnlyCollection<TSource> Source { get; }
-
-        public MutableProjectionDecoratorCollection(IReadOnlyCollection<TSource> source, IEnumerable<TResult> result)
-        {
-            Elements = result;
-            Source   = source;
-        }
-    }
-
-    private sealed class ImmutableDecoratorCollection<T> : DecoratorCollection<T>
-    {
-        public override int Count { get; }
-
-        public override IEnumerable<T> Elements { get; }
-
-        public ImmutableDecoratorCollection(IEnumerable<T> elements, int count)
+        public GeneratedDecoratorCollection(IEnumerable<T> elements, int count)
         {
             Count    = count;
-            Elements = elements;
+            Enumerable = elements;
         }
+    }
+
+    private class DecoratorTransformationCollection<TSource, TResult> : DecoratorCollection<TResult>
+    {
+        public override int Count => Source.Count;
+
+        public sealed override IEnumerable<TResult> Enumerable { get; }
+
+        public IReadOnlyCollection<TSource> Source { get; }
+
+        public DecoratorTransformationCollection(IReadOnlyCollection<TSource> source, IEnumerable<TResult> result)
+        {
+            Enumerable = result;
+            Source   = source;
+        }
+    }
+
+    private class DecoratorTransformationCollection<T> : DecoratorTransformationCollection<T, T>
+    {
+        public DecoratorTransformationCollection(IReadOnlyCollection<T> source, IEnumerable<T> result)
+            : base(source, result)
+        { }
+    }
+
+    private class FixedDecoratorTransformationCollection<TSource, TResult> : DecoratorTransformationCollection<TSource, TResult>, IProjectable<TResult>
+    {
+        public sealed override int Count => Source.Count;
+
+        public FixedDecoratorTransformationCollection(IReadOnlyCollection<TSource> source, IEnumerable<TResult> result)
+            : base(source, result)
+        { }
+
+        public IReadOnlyCollection<TResult2> Select<TResult2>(Func<TResult, TResult2> selector)
+            => new FixedDecoratorTransformationCollection<TSource, TResult2>(Source, Collection.EnumerableDecorator.Select(this, selector));
+
+        public IReadOnlyCollection<TResult2> Select<TResult2>(Func<TResult, int, TResult2> selector)
+            => new FixedDecoratorTransformationCollection<TSource, TResult2>(Source, Collection.EnumerableDecorator.Select(this, selector));
+    }
+
+    private class FixedDecoratorTransformationCollection<T> : FixedDecoratorTransformationCollection<T, T>
+    {
+        public FixedDecoratorTransformationCollection(IReadOnlyCollection<T> source, IEnumerable<T> result)
+            : base(source, result)
+        { }
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.cs
+++ b/src/Core/Sweetener.Linq/Collection.cs
@@ -14,73 +14,82 @@ namespace Sweetener.Linq;
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Collection class is meant to parallel Enumerable.")]
 public static partial class Collection
 {
-    private abstract class DecoratorCollection<TElement> : ICollection<TElement>, IEnumerable<TElement>, IReadOnlyCollection<TElement>
+    private abstract class DecoratorCollection<T> : ICollection<T>, IEnumerable<T>, IReadOnlyCollection<T>
     {
         public abstract int Count { get; }
 
-        public IEnumerable<TElement> Elements { get; }
+        public abstract IEnumerable<T> Elements { get; }
 
         [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.IsReadOnly => true;
+        bool ICollection<T>.IsReadOnly => true;
 
-        protected DecoratorCollection(IEnumerable<TElement> elements)
-            => Elements = elements;
-
-        public IEnumerator<TElement> GetEnumerator()
+        public IEnumerator<T> GetEnumerator()
             => Elements.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
 
         [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Add(TElement item)
+        void ICollection<T>.Add(T item)
             => throw new NotSupportedException();
 
         [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.Clear()
+        void ICollection<T>.Clear()
             => throw new NotSupportedException();
 
         [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Contains(TElement item)
+        bool ICollection<T>.Contains(T item)
             => throw new NotSupportedException();
 
         [ExcludeFromCodeCoverage]
-        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
+        void ICollection<T>.CopyTo(T[] array, int arrayIndex)
             => throw new NotSupportedException();
 
         [ExcludeFromCodeCoverage]
-        bool ICollection<TElement>.Remove(TElement item)
+        bool ICollection<T>.Remove(T item)
             => throw new NotSupportedException();
     }
 
-    private class MutableDecoratorCollection<TElement> : DecoratorCollection<TElement>
+    private class MutableDecoratorCollection<T> : DecoratorCollection<T>
     {
         public override int Count => Source.Count;
 
-        protected IReadOnlyCollection<TElement> Source { get; }
+        public override IEnumerable<T> Elements { get; }
 
-        public MutableDecoratorCollection(IReadOnlyCollection<TElement> source, IEnumerable<TElement> result)
-            : base(result)
-            => Source = source;
+        protected IReadOnlyCollection<T> Source { get; }
+
+        public MutableDecoratorCollection(IReadOnlyCollection<T> source, IEnumerable<T> result)
+        {
+            Elements = result;
+            Source   = source;
+        }
     }
 
     private class MutableProjectionDecoratorCollection<TSource, TResult> : DecoratorCollection<TResult>
     {
         public override int Count => Source.Count;
 
+        public override IEnumerable<TResult> Elements { get; }
+
         protected IReadOnlyCollection<TSource> Source { get; }
 
         public MutableProjectionDecoratorCollection(IReadOnlyCollection<TSource> source, IEnumerable<TResult> result)
-            : base(result)
-            => Source = source;
+        {
+            Elements = result;
+            Source   = source;
+        }
     }
 
-    private sealed class ImmutableDecoratorCollection<TElement> : DecoratorCollection<TElement>
+    private sealed class ImmutableDecoratorCollection<T> : DecoratorCollection<T>
     {
         public override int Count { get; }
 
-        public ImmutableDecoratorCollection(IEnumerable<TElement> elements, int count)
-            : base(elements)
-            => Count = count;
+        public override IEnumerable<T> Elements { get; }
+
+        public ImmutableDecoratorCollection(IEnumerable<T> elements, int count)
+        {
+            Count    = count;
+            Elements = elements;
+        }
     }
 }

--- a/src/Core/Sweetener.Linq/Collection.cs
+++ b/src/Core/Sweetener.Linq/Collection.cs
@@ -77,24 +77,22 @@ public static partial class Collection
         }
     }
 
-    private class DecoratorTransformationCollection<TSource, TResult> : DecoratorCollection<TResult>
+    private abstract class DecoratorTransformationCollection<TSource, TResult> : DecoratorCollection<TResult>
     {
-        public override int Count => Source.Count;
-
         public sealed override IEnumerable<TResult> Enumerable { get; }
 
         public IReadOnlyCollection<TSource> Source { get; }
 
-        public DecoratorTransformationCollection(IReadOnlyCollection<TSource> source, IEnumerable<TResult> result)
+        protected DecoratorTransformationCollection(IReadOnlyCollection<TSource> source, IEnumerable<TResult> result)
         {
             Enumerable = result;
             Source   = source;
         }
     }
 
-    private class DecoratorTransformationCollection<T> : DecoratorTransformationCollection<T, T>
+    private abstract class DecoratorTransformationCollection<T> : DecoratorTransformationCollection<T, T>
     {
-        public DecoratorTransformationCollection(IReadOnlyCollection<T> source, IEnumerable<T> result)
+        protected DecoratorTransformationCollection(IReadOnlyCollection<T> source, IEnumerable<T> result)
             : base(source, result)
         { }
     }

--- a/src/Core/Sweetener.Linq/Enumerable.Extensions.cs
+++ b/src/Core/Sweetener.Linq/Enumerable.Extensions.cs
@@ -1,0 +1,142 @@
+﻿// Copyright © William Sugarman.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+
+namespace Sweetener.Linq;
+
+/// <summary>
+/// Provides a set of <see langword="static"/> methods for querying objects that implement <see cref="IEnumerable{T}"/>
+/// beyond those provided by <see cref="Enumerable"/>.
+/// </summary>
+public static class EnumerableExtensions
+{
+    /// <summary>
+    /// Projects each element of a collection into a new form based on a predicate.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selectorPredicate"/>.</typeparam>
+    /// <param name="source">A collection of values to invoke a transform function on.</param>
+    /// <param name="selectorPredicate">
+    /// A function to test each element for a condition and apply a transformation if it returns <see langword="true"/>.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IReadOnlyCollection{T}"/> whose elements are the result of invoking the transform function
+    /// on each element of <paramref name="source"/> that satisfy the condition.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="source"/> or <paramref name="selectorPredicate"/> is <see langword="null"/>.
+    /// </exception>
+    public static IEnumerable<TResult> SelectWhere<TSource, TResult>(this IEnumerable<TSource> source, TryFunc<TSource, TResult> selectorPredicate)
+    {
+        if (source is null)
+            throw new ArgumentNullException(nameof(source));
+
+        if (selectorPredicate is null)
+            throw new ArgumentNullException(nameof(selectorPredicate));
+
+        return source is Enumerable<TSource> existing
+            ? existing.SelectWhere(selectorPredicate)
+            : new SelectWhereEnumerable<TSource, TResult>(source, selectorPredicate);
+    }
+
+    /// <summary>
+    /// Projects each element of a collection into a new form based on a predicate
+    /// by incorporating the element's index.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selectorPredicate"/>.</typeparam>
+    /// <param name="source">A collection of values to invoke a transform function on.</param>
+    /// <param name="selectorPredicate">
+    /// A function to test each element for a condition and apply a transformation if it returns <see langword="true"/>;
+    /// the second parameter of the function represents the index of the source element.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IReadOnlyCollection{T}"/> whose elements are the result of invoking the transform function
+    /// on each element of <paramref name="source"/> that satisfy the condition.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="source"/> or <paramref name="selectorPredicate"/> is <see langword="null"/>.
+    /// </exception>
+    public static IEnumerable<TResult> SelectWhere<TSource, TResult>(this IEnumerable<TSource> source, TryFunc<TSource, int, TResult> selectorPredicate)
+    {
+        if (source is null)
+            throw new ArgumentNullException(nameof(source));
+
+        if (selectorPredicate is null)
+            throw new ArgumentNullException(nameof(selectorPredicate));
+
+        return SelectWhereIterator(source, selectorPredicate);
+    }
+
+    private static IEnumerable<TResult> SelectWhereIterator<TSource, TResult>(IEnumerable<TSource> source, TryFunc<TSource, int, TResult> selectorPredicate)
+    {
+        // Note: The BCLs do not optimize the index delegates
+        int i = -1;
+        foreach (TSource element in source)
+        {
+            checked
+            {
+                i++;
+            }
+
+            if (selectorPredicate(element, i, out TResult? result))
+                yield return result;
+        }
+    }
+
+    // Note: This class is meant to represent our own Enumerables defined in Sweetener to help optimize
+    // TODO: It may be advantageous to mirror the internal Iterator<TSource> class in the BCL
+    [SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Class is not a collection.")]
+    private interface Enumerable<TSource> : IEnumerable<TSource>
+    {
+        IEnumerable<TResult> SelectWhere<TResult>(TryFunc<TSource, TResult> selectorPredicate);
+    }
+
+    [SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Class is not a collection.")]
+    private sealed class SelectWhereEnumerable<TSource, TResult> : Enumerable<TResult>
+    {
+        private readonly IEnumerable<TSource> _source;
+        private readonly TryFunc<TSource, TResult> _selectorPredicate;
+
+        public SelectWhereEnumerable(IEnumerable<TSource> source, TryFunc<TSource, TResult> selectorPredicate)
+        {
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+            _selectorPredicate = selectorPredicate ?? throw new ArgumentNullException(nameof(selectorPredicate));
+        }
+
+        public IEnumerator<TResult> GetEnumerator()
+        {
+            foreach (TSource element in _source)
+            {
+                if (_selectorPredicate(element, out TResult? result))
+                    yield return result;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public IEnumerable<TResult2> SelectWhere<TResult2>(TryFunc<TResult, TResult2> selectorPredicate)
+            => new SelectWhereEnumerable<TSource, TResult2>(_source, CombineSelectorPredicates(_selectorPredicate, selectorPredicate));
+    }
+
+    private static TryFunc<TSource, TResult> CombineSelectorPredicates<TSource, TMiddle, TResult>(
+        TryFunc<TSource, TMiddle> selectorPredicate1,
+        TryFunc<TMiddle, TResult> selectorPredicate2)
+        => (TSource x, [MaybeNullWhen(false)] out TResult z) =>
+        {
+            if (!selectorPredicate1(x, out TMiddle? y))
+            {
+                z = default;
+                return false;
+            }
+
+            return selectorPredicate2(y, out z);
+        };
+}

--- a/src/Core/Sweetener.Linq/Sweetener.Linq.csproj
+++ b/src/Core/Sweetener.Linq/Sweetener.Linq.csproj
@@ -17,4 +17,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Sweetener\Sweetener.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Core/Sweetener.Linq/Sweetener.Linq.csproj
+++ b/src/Core/Sweetener.Linq/Sweetener.Linq.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Sweetener\Sweetener.csproj" />
+    <PackageReference Include="Sweetener" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageVersion Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageVersion Include="Sweetener" Version="1.0.0-beta.2" />
+    <PackageVersion Include="Sweetener" Version="1.0.0-beta.3" />
     <PackageVersion Include="System.IO.Hashing" Version="6.0.1" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
   </ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageVersion Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageVersion Include="Sweetener" Version="1.0.0-beta.2" />
     <PackageVersion Include="System.IO.Hashing" Version="6.0.1" />
     <PackageVersion Include="System.Memory" Version="4.5.4" />
   </ItemGroup>


### PR DESCRIPTION
- Add new `SelectWhere` method that accepts "try methods" (eg. `int.TryParse`) to efficiently check the input's validity and parse the its value at the same time
- Add `SkipLast` and `TakeLast` for `Collection`
- Refactor internal calling patterns to help optimize larger queries