### PR TITLE
Use Associated User for Tag

### DIFF
--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -34,12 +34,13 @@ runs:
 
     - name: Tag
       if: ${{ steps.release.outputs.exists == 'false' }}
-      shell: bash
+      shell: pwsh
       run: |
-        git tag -s -m "${{ inputs.project }} Version ${{ steps.package.outputs.version }}" \
-          ${{ steps.package.outputs.tag }} \
-          ${{ github.sha }}
-        git push origin ${{ steps.package.outputs.tag }}
+        ./.github/actions/github-release/scripts/TagRelease.ps1 `
+          -ProjectName '${{ inputs.project }}' `
+          -Version '${{ steps.package.outputs.version }}' `
+          -Tag '${{ steps.package.outputs.tag }}' `
+          -CommitSha '${{ github.sha }}'
 
     - name: Create Release
       if: ${{ steps.release.outputs.exists == 'false' }}

--- a/.github/actions/github-release/scripts/TagRelease.ps1
+++ b/.github/actions/github-release/scripts/TagRelease.ps1
@@ -21,14 +21,14 @@ param
 Set-PSDebug -Off
 $ErrorActionPreference = "Stop"
 
-# Determine who committed this release
+# Determine who committed this change
 $username = git log -n 1 --pretty=format:%an $CommitSha
 $email = git log -n 1 --pretty=format:%ae $CommitSha
 
-# Update the config to reflect this user
+# Update the config to reflect the above user
 & git config user.name "$username"
 & git config user.email "$email"
 
-# Create the tag
+# Create the tag and push it
 & git tag -s -m "$ProjectName Version $Version" $Tag $CommitSha
 & git push origin $Tag

--- a/.github/actions/github-release/scripts/TagRelease.ps1
+++ b/.github/actions/github-release/scripts/TagRelease.ps1
@@ -1,0 +1,34 @@
+param
+(
+    [Parameter(Mandatory=$True)]
+    [string]
+    $ProjectName,
+
+    [Parameter(Mandatory=$True)]
+    [string]
+    $Version,
+
+    [Parameter(Mandatory=$True)]
+    [string]
+    $Tag,
+
+    [Parameter(Mandatory=$True)]
+    [string]
+    $CommitSha
+)
+
+# Turn off trace and stop on any error
+Set-PSDebug -Off
+$ErrorActionPreference = "Stop"
+
+# Determine who committed this release
+$username = git log -n 1 --pretty=format:%an $CommitSha
+$email = git log -n 1 --pretty=format:%ae $CommitSha
+
+# Update the config to reflect this user
+& git config user.name "$username"
+& git config user.email "$email"
+
+# Create the tag
+& git tag -s -m "$ProjectName Version $Version" $Tag $CommitSha
+& git push origin $Tag


### PR DESCRIPTION
- Configure `git` client to create tag using the user name and email from the associated commit