### PR TITLE
Refactor BinaryComparer

### DIFF
--- a/src/Core/Sweetener.Test/Collections/Generic/BinaryComparer.Test.cs
+++ b/src/Core/Sweetener.Test/Collections/Generic/BinaryComparer.Test.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © William Sugarman.
+// Copyright © William Sugarman.
 // Licensed under the MIT License.
 
 using System;
@@ -23,38 +23,6 @@ public class BinaryComparerTest
             skipNullCase: true);
 
     [TestMethod]
-    public void Compare_ReadOnlySpan_x86()
-        => Compare(
-            (x, y) =>
-            {
-                unsafe
-                {
-                    fixed (byte* xPtr = x)
-                    fixed (byte* yPtr = y)
-                    {
-                        return BinaryComparer.Compare((uint*)xPtr, (uint*)yPtr, x!.Length, y!.Length);
-                    }
-                }
-            },
-            skipNullCase: true);
-
-    [TestMethod]
-    public void Compare_ReadOnlySpan_x64()
-        => Compare(
-            (x, y) =>
-            {
-                unsafe
-                {
-                    fixed (byte* xPtr = x)
-                    fixed (byte* yPtr = y)
-                    {
-                        return BinaryComparer.Compare((ulong*)xPtr, (ulong*)yPtr, x!.Length, y!.Length);
-                    }
-                }
-            },
-            skipNullCase: true);
-
-    [TestMethod]
     public void Compare_Stream()
         => Compare(
             (x, y) =>
@@ -67,30 +35,6 @@ public class BinaryComparerTest
                 else
                     return BinaryComparer.Instance.Compare(xStream, yStream);
             });
-
-    [TestMethod]
-    public void Compare_Stream_x32()
-        => Compare(
-            (x, y) =>
-            {
-                using Stream xStream = new MemoryStream(x!);
-                using Stream yStream = new MemoryStream(y!);
-
-                return BinaryComparer.Compare32(xStream, yStream);
-            },
-            skipNullCase: true);
-
-    [TestMethod]
-    public void Compare_Stream_x64()
-        => Compare(
-            (x, y) =>
-            {
-                using Stream xStream = new MemoryStream(x!);
-                using Stream yStream = new MemoryStream(y!);
-
-                return BinaryComparer.Compare64(xStream, yStream);
-            },
-            skipNullCase: true);
 
     [TestMethod]
     public void Equals_Array()
@@ -110,40 +54,6 @@ public class BinaryComparerTest
             skipNullCase: true);
 
     [TestMethod]
-    public void Equals_ReadOnlySpan_x86()
-        => Equals(
-            (x, y) =>
-            {
-                unsafe
-                {
-                    fixed (byte* xPtr = x)
-                    fixed (byte* yPtr = y)
-                    {
-                        return BinaryComparer.Equals((uint*)xPtr, (uint*)yPtr, x!.Length);
-                    }
-                }
-            },
-            skipNullCase: true,
-            skipUnequalLength: true);
-
-    [TestMethod]
-    public void Equals_ReadOnlySpan_x64()
-        => Equals(
-            (x, y) =>
-            {
-                unsafe
-                {
-                    fixed (byte* xPtr = x)
-                    fixed (byte* yPtr = y)
-                    {
-                        return BinaryComparer.Equals((ulong*)xPtr, (ulong*)yPtr, x!.Length);
-                    }
-                }
-            },
-            skipNullCase: true,
-            skipUnequalLength: true);
-
-    [TestMethod]
     public void Equals_Stream()
         => Equals(
             (x, y) =>
@@ -156,30 +66,6 @@ public class BinaryComparerTest
                 else
                     return BinaryComparer.Instance.Equals(xStream, yStream);
             });
-
-    [TestMethod]
-    public void Equals_Stream_x32()
-        => Equals(
-            (x, y) =>
-            {
-                using Stream xStream = new MemoryStream(x!);
-                using Stream yStream = new MemoryStream(y!);
-
-                return BinaryComparer.Equals32(xStream, yStream);
-            },
-            skipNullCase: true);
-
-    [TestMethod]
-    public void Equals_Stream_x64()
-        => Equals(
-            (x, y) =>
-            {
-                using Stream xStream = new MemoryStream(x!);
-                using Stream yStream = new MemoryStream(y!);
-
-                return BinaryComparer.Equals64(xStream, yStream);
-            },
-            skipNullCase: true);
 
     [TestMethod]
     public void GetHashCode_Array()
@@ -261,7 +147,7 @@ public class BinaryComparerTest
     }
 
     [SuppressMessage("Performance", "CA1825:Avoid zero-length array allocations", Justification = "Avoid reference equality.")]
-    private static void Equals(Func<byte[]?, byte[]?, bool> equals, bool skipNullCase = false, bool skipUnequalLength = false)
+    private static void Equals(Func<byte[]?, byte[]?, bool> equals, bool skipNullCase = false)
     {
         byte[] aligned1 = new byte[]
         {
@@ -310,14 +196,11 @@ public class BinaryComparerTest
         Assert.IsTrue(equals(new byte[0], new byte[0]));
 
         // Not Equal
-        if (!skipUnequalLength)
-        {
-            Assert.IsFalse(equals(aligned1           , Array.Empty<byte>()));
-            Assert.IsFalse(equals(Array.Empty<byte>(), aligned1           ));
+        Assert.IsFalse(equals(aligned1           , Array.Empty<byte>()));
+        Assert.IsFalse(equals(Array.Empty<byte>(), aligned1           ));
 
-            Assert.IsFalse(equals(aligned1, extra1));
-            Assert.IsFalse(equals(aligned2, extra1));
-        }
+        Assert.IsFalse(equals(aligned1, extra1));
+        Assert.IsFalse(equals(aligned2, extra1));
 
         Assert.IsFalse(equals(aligned1, aligned2));
         Assert.IsFalse(equals(aligned2, aligned1));

--- a/src/Core/Sweetener/AsyncLazy.T.cs
+++ b/src/Core/Sweetener/AsyncLazy.T.cs
@@ -212,6 +212,7 @@ public sealed class AsyncLazy<T> : IDisposable
         }
     }
 
+    [SuppressMessage("Performance", "CA1849:Call async methods when in an async method", Justification = "The _valueTask field is guaranteed to be complete.")]
     private async Task<T> ExecuteAndPublishThreadSafeAsync(CancellationToken cancellationToken)
     {
         Task<T>? valueTask = null;
@@ -229,7 +230,7 @@ public sealed class AsyncLazy<T> : IDisposable
                 return result;
             }
 
-            return await _valueTask.ConfigureAwait(false);
+            return _valueTask.Result;
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {

--- a/src/Core/Sweetener/Collections/Generic/BinaryComparer.cs
+++ b/src/Core/Sweetener/Collections/Generic/BinaryComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © William Sugarman.
+// Copyright © William Sugarman.
 // Licensed under the MIT License.
 
 using System;
@@ -132,14 +132,30 @@ public sealed class BinaryComparer : IComparer<byte[]>, IComparer<Stream>, IEqua
     /// </returns>
     public int Compare(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y)
     {
+        int xCount = x.Length;
+        int yCount = y.Length;
+
         unsafe
         {
-            fixed (byte* xPtr = x)
-            fixed (byte* yPtr = y)
+            fixed (byte* xFixed = x)
+            fixed (byte* yFixed = y)
             {
-                return IntPtr.Size == sizeof(uint)
-                    ? Compare((uint*)xPtr, (uint*)yPtr, x.Length, y.Length)
-                    : Compare((ulong*)xPtr, (ulong*)yPtr, x.Length, y.Length);
+                nuint* px = (nuint*)xFixed;
+                nuint* py = (nuint*)yFixed;
+
+                for (; xCount >= sizeof(nuint) && yCount >= sizeof(nuint); px++, py++)
+                {
+                    // Note: Parentheses left for clarity
+                    if (*px < *py)
+                        return -1;
+                    if (*px > *py)
+                        return 1;
+
+                    xCount -= sizeof(nuint);
+                    yCount -= sizeof(nuint);
+                }
+
+                return Compare((byte*)px, (byte*)py, xCount, yCount);
             }
         }
     }
@@ -193,7 +209,61 @@ public sealed class BinaryComparer : IComparer<byte[]>, IComparer<Stream>, IEqua
         else if (y is null)
             return 1;
 
-        return IntPtr.Size == sizeof(uint) ? Compare32(x, y) : Compare64(x, y);
+        unsafe
+        {
+#if NETCOREAPP2_1_OR_GREATER
+            nuint xWord;
+            nuint yWord;
+            Span<byte> xBuffer = new Span<byte>(&xWord, 8);
+            Span<byte> yBuffer = new Span<byte>(&yWord, 8);
+
+            int cmp;
+            int xCount;
+            int yCount;
+
+            do
+            {
+                xCount = FillBuffer(x, xBuffer);
+                yCount = FillBuffer(y, yBuffer);
+
+                if (xCount < sizeof(nuint) || yCount < sizeof(nuint))
+                    return Compare((byte*)&xWord, (byte*)&yWord, xCount, yCount);
+
+                cmp = xWord.CompareTo(yWord);
+            } while (cmp == 0);
+
+            return cmp;
+#else
+            byte[] xBuffer = ArrayPool<byte>.Shared.Rent(sizeof(nuint));
+            byte[] yBuffer = ArrayPool<byte>.Shared.Rent(sizeof(nuint));
+
+            try
+            {
+                fixed (byte* px = xBuffer)
+                fixed (byte* py = yBuffer)
+                {
+                    int xCount;
+                    int yCount;
+
+                    do
+                    {
+                        xCount = FillBuffer(x, xBuffer, sizeof(nuint));
+                        yCount = FillBuffer(y, yBuffer, sizeof(nuint));
+
+                        if (xCount < sizeof(nuint) || yCount < sizeof(nuint))
+                            return Compare(px, py, xCount, yCount);
+                    } while (*px == *py);
+
+                    return *px < *py ? -1 : 1;
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(xBuffer);
+                ArrayPool<byte>.Shared.Return(yBuffer);
+            }
+#endif
+        }
     }
 
     /// <summary>
@@ -244,12 +314,21 @@ public sealed class BinaryComparer : IComparer<byte[]>, IComparer<Stream>, IEqua
 
         unsafe
         {
-            fixed (byte* xPtr = x)
-            fixed (byte* yPtr = y)
+            fixed (byte* xFixed = x)
+            fixed (byte* yFixed = y)
             {
-                return IntPtr.Size == sizeof(uint)
-                    ? Equals((uint*)xPtr, (uint*)yPtr, x.Length)
-                    : Equals((ulong*)xPtr, (ulong*)yPtr, x.Length);
+                int count = x.Length;
+                nuint* px = (nuint*)xFixed;
+                nuint* py = (nuint*)yFixed;
+
+                for (; count >= sizeof(nuint); count -= sizeof(nuint))
+                {
+                    // Note: Parentheses left for clarity
+                    if (*(px++) != *(py++))
+                        return false;
+                }
+
+                return Equals((byte*)px, (byte*)py, count);
             }
         }
     }
@@ -272,7 +351,58 @@ public sealed class BinaryComparer : IComparer<byte[]>, IComparer<Stream>, IEqua
         if (x is null || y is null)
             return false;
 
-        return IntPtr.Size == sizeof(uint) ? Equals32(x, y) : Equals64(x, y);
+        unsafe
+        {
+#if NETCOREAPP2_1_OR_GREATER
+            nuint xWord;
+            nuint yWord;
+            Span<byte> xBuffer = new Span<byte>(&xWord, 8);
+            Span<byte> yBuffer = new Span<byte>(&yWord, 8);
+
+            int xCount;
+            int yCount;
+
+            do
+            {
+                xCount = FillBuffer(x, xBuffer);
+                yCount = FillBuffer(y, yBuffer);
+
+                if (xCount < sizeof(nuint) || yCount < sizeof(nuint))
+                    return Equals((byte*)&xWord, (byte*)&yWord, xCount, yCount);
+            } while (xWord == yWord);
+
+            return false;
+#else
+            byte[] xBuffer = ArrayPool<byte>.Shared.Rent(sizeof(nuint));
+            byte[] yBuffer = ArrayPool<byte>.Shared.Rent(sizeof(nuint));
+
+            try
+            {
+                fixed (byte* px = xBuffer)
+                fixed (byte* py = yBuffer)
+                {
+                    int xCount;
+                    int yCount;
+
+                    do
+                    {
+                        xCount = FillBuffer(x, xBuffer, sizeof(nuint));
+                        yCount = FillBuffer(y, yBuffer, sizeof(nuint));
+
+                        if (xCount < sizeof(nuint) || yCount < sizeof(nuint))
+                            return Equals(px, py, xCount, yCount);
+                    } while (*(nuint*)px == *(nuint*)py);
+
+                    return false;
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(xBuffer);
+                ArrayPool<byte>.Shared.Return(yBuffer);
+            }
+#endif
+        }
     }
 
     /// <summary>
@@ -340,344 +470,6 @@ public sealed class BinaryComparer : IComparer<byte[]>, IComparer<Stream>, IEqua
             return hash;
         }
     }
-
-    internal static unsafe int Compare(uint* x, uint* y, int xCount, int yCount)
-    {
-        int cmp = 0;
-        while (xCount >= sizeof(uint) && yCount >= sizeof(uint))
-        {
-            // Note: Parentheses left for clarity
-            cmp = (x++)->CompareTo(*(y++));
-            if (cmp != 0)
-                return cmp;
-
-            xCount -= sizeof(uint);
-            yCount -= sizeof(uint);
-        }
-
-        return Compare((byte*)x, (byte*)y, xCount, yCount);
-    }
-
-    internal static unsafe int Compare(ulong* x, ulong* y, int xCount, int yCount)
-    {
-        int cmp = 0;
-        while (xCount >= sizeof(ulong) && yCount >= sizeof(ulong))
-        {
-            // Note: Parentheses left for clarity
-            cmp = (x++)->CompareTo(*(y++));
-            if (cmp != 0)
-                return cmp;
-
-            xCount -= sizeof(ulong);
-            yCount -= sizeof(ulong);
-        }
-
-        return Compare((byte*)x, (byte*)y, xCount, yCount);
-    }
-
-#if NETCOREAPP2_1_OR_GREATER
-    internal static int Compare32(Stream x, Stream y)
-    {
-        unsafe
-        {
-            ulong xLong;
-            ulong yLong;
-            Span<byte> xBuffer = new Span<byte>(&xLong, 8);
-            Span<byte> yBuffer = new Span<byte>(&yLong, 8);
-
-            int cmp;
-            int xCount;
-            int yCount;
-
-            do
-            {
-                xCount = FillBuffer(x, xBuffer);
-                yCount = FillBuffer(y, yBuffer);
-
-                if (xCount < sizeof(ulong) || yCount < sizeof(ulong))
-                    break;
-
-                cmp = xLong.CompareTo(yLong);
-                if (cmp != 0)
-                    return cmp;
-            } while (true);
-
-            return Compare((byte*)&xLong, (byte*)&yLong, xCount, yCount);
-        }
-    }
-
-    internal static int Compare64(Stream x, Stream y)
-    {
-        unsafe
-        {
-            ulong xLong;
-            ulong yLong;
-            Span<byte> xBuffer = new Span<byte>(&xLong, 8);
-            Span<byte> yBuffer = new Span<byte>(&yLong, 8);
-
-            int cmp;
-            int xCount;
-            int yCount;
-
-            do
-            {
-                xCount = FillBuffer(x, xBuffer);
-                yCount = FillBuffer(y, yBuffer);
-
-                if (xCount < sizeof(ulong) || yCount < sizeof(ulong))
-                    break;
-
-                cmp = xLong.CompareTo(yLong);
-                if (cmp != 0)
-                    return cmp;
-            } while (true);
-
-            return Compare((byte*)&xLong, (byte*)&yLong, xCount, yCount);
-        }
-    }
-#else
-    internal static int Compare32(Stream x, Stream y)
-    {
-        unsafe
-        {
-            byte[] xBuffer = ArrayPool<byte>.Shared.Rent(sizeof(uint));
-            byte[] yBuffer = ArrayPool<byte>.Shared.Rent(sizeof(uint));
-
-            try
-            {
-                fixed (byte* xPtr = xBuffer)
-                fixed (byte* yPtr = yBuffer)
-                {
-                    int cmp;
-                    int xCount;
-                    int yCount;
-
-                    do
-                    {
-                        xCount = FillBuffer(x, xBuffer, sizeof(uint));
-                        yCount = FillBuffer(y, yBuffer, sizeof(uint));
-
-                        if (xCount < sizeof(uint) || yCount < sizeof(uint))
-                            break;
-
-                        cmp = ((uint*)xPtr)->CompareTo(*(uint*)yPtr);
-                        if (cmp != 0)
-                            return cmp;
-                    } while (true);
-
-                    return Compare(xPtr, yPtr, xCount, yCount);
-                }
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(xBuffer);
-                ArrayPool<byte>.Shared.Return(yBuffer);
-            }
-        }
-    }
-
-    internal static int Compare64(Stream x, Stream y)
-    {
-        unsafe
-        {
-            byte[] xBuffer = ArrayPool<byte>.Shared.Rent(sizeof(ulong));
-            byte[] yBuffer = ArrayPool<byte>.Shared.Rent(sizeof(ulong));
-
-            try
-            {
-                fixed (byte* xPtr = xBuffer)
-                fixed (byte* yPtr = yBuffer)
-                {
-                    int cmp;
-                    int xCount;
-                    int yCount;
-
-                    do
-                    {
-                        xCount = FillBuffer(x, xBuffer, sizeof(ulong));
-                        yCount = FillBuffer(y, yBuffer, sizeof(ulong));
-
-                        if (xCount < sizeof(ulong) || yCount < sizeof(ulong))
-                            break;
-
-                        cmp = ((ulong*)xPtr)->CompareTo(*(ulong*)yPtr);
-                        if (cmp != 0)
-                            return cmp;
-                    } while (true);
-
-                    return Compare(xPtr, yPtr, xCount, yCount);
-                }
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(xBuffer);
-                ArrayPool<byte>.Shared.Return(yBuffer);
-            }
-        }
-    }
-#endif
-
-    internal static unsafe bool Equals(uint* x, uint* y, int count)
-    {
-        while (count >= sizeof(uint))
-        {
-            // Note: Parentheses left for clarity
-            if (*(x++) != *(y++))
-                return false;
-
-            count -= sizeof(uint);
-        }
-
-        return Equals((byte*)x, (byte*)y, count);
-    }
-
-    internal static unsafe bool Equals(ulong* x, ulong* y, int count)
-    {
-        while (count >= sizeof(ulong))
-        {
-            // Note: Parentheses left for clarity
-            if (*(x++) != *(y++))
-                return false;
-
-            count -= sizeof(ulong);
-        }
-
-        return Equals((byte*)x, (byte*)y, count);
-    }
-
-#if NETCOREAPP2_1_OR_GREATER
-    internal static bool Equals32(Stream x, Stream y)
-    {
-        unsafe
-        {
-            ulong xLong;
-            ulong yLong;
-            Span<byte> xBuffer = new Span<byte>(&xLong, 8);
-            Span<byte> yBuffer = new Span<byte>(&yLong, 8);
-
-            int xCount;
-            int yCount;
-
-            do
-            {
-                xCount = FillBuffer(x, xBuffer);
-                yCount = FillBuffer(y, yBuffer);
-
-                if (xCount < sizeof(ulong) || yCount < sizeof(ulong))
-                    break;
-
-                if (xLong != yLong)
-                    return false;
-            } while (true);
-
-            return Equals((byte*)&xLong, (byte*)&yLong, xCount, yCount);
-        }
-    }
-
-    internal static bool Equals64(Stream x, Stream y)
-    {
-        unsafe
-        {
-            ulong xLong;
-            ulong yLong;
-            Span<byte> xBuffer = new Span<byte>(&xLong, 8);
-            Span<byte> yBuffer = new Span<byte>(&yLong, 8);
-
-            int xCount;
-            int yCount;
-
-            do
-            {
-                xCount = FillBuffer(x, xBuffer);
-                yCount = FillBuffer(y, yBuffer);
-
-                if (xCount < sizeof(ulong) || yCount < sizeof(ulong))
-                    break;
-
-                if (xLong != yLong)
-                    return false;
-            } while (true);
-
-            return Equals((byte*)&xLong, (byte*)&yLong, xCount, yCount);
-        }
-    }
-#else
-    internal static bool Equals32(Stream x, Stream y)
-    {
-        unsafe
-        {
-            byte[] xBuffer = ArrayPool<byte>.Shared.Rent(sizeof(uint));
-            byte[] yBuffer = ArrayPool<byte>.Shared.Rent(sizeof(uint));
-
-            try
-            {
-                fixed (byte* xPtr = xBuffer)
-                fixed (byte* yPtr = yBuffer)
-                {
-                    int xCount;
-                    int yCount;
-
-                    do
-                    {
-                        xCount = FillBuffer(x, xBuffer, sizeof(uint));
-                        yCount = FillBuffer(y, yBuffer, sizeof(uint));
-
-                        if (xCount < sizeof(uint) || yCount < sizeof(uint))
-                            break;
-
-                        if ((*(uint*)xPtr) != (*(uint*)yPtr))
-                            return false;
-                    } while (true);
-
-                    return Equals(xPtr, yPtr, xCount, yCount);
-                }
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(xBuffer);
-                ArrayPool<byte>.Shared.Return(yBuffer);
-            }
-        }
-    }
-
-    internal static bool Equals64(Stream x, Stream y)
-    {
-        unsafe
-        {
-            byte[] xBuffer = ArrayPool<byte>.Shared.Rent(sizeof(ulong));
-            byte[] yBuffer = ArrayPool<byte>.Shared.Rent(sizeof(ulong));
-
-            try
-            {
-                fixed (byte* xPtr = xBuffer)
-                fixed (byte* yPtr = yBuffer)
-                {
-                    int xCount;
-                    int yCount;
-
-                    do
-                    {
-                        xCount = FillBuffer(x, xBuffer, sizeof(ulong));
-                        yCount = FillBuffer(y, yBuffer, sizeof(ulong));
-
-                        if (xCount < sizeof(ulong) || yCount < sizeof(ulong))
-                            break;
-
-                        if ((*(uint*)xPtr) != (*(uint*)yPtr))
-                            return false;
-                    } while (true);
-
-                    return Equals(xPtr, yPtr, xCount, yCount);
-                }
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(xBuffer);
-                ArrayPool<byte>.Shared.Return(yBuffer);
-            }
-        }
-    }
-#endif
 
     private static unsafe int Compare(byte* x, byte* y, int xCount, int yCount)
     {


### PR DESCRIPTION
- Refactor `BinaryComparer` using `nuint` for platform-agnostic implementations
- Fix nit-pick in `AsyncLazy<T>`