### PR TITLE
Fixes for Recent Sweetener Code

### DIFF
--- a/src/Core/Sweetener.Test/AsyncLazy.T.Test.cs
+++ b/src/Core/Sweetener.Test/AsyncLazy.T.Test.cs
@@ -120,14 +120,17 @@ public class AsyncLazyTest
 
         await Assert.ThrowsExceptionAsync<ObjectDisposedException>(() => executionAndPublication.GetValueAsync(default)).ConfigureAwait(false);
 
-        // Value always available after caching
+        // Even if created, disposal resets the instance
         using AsyncLazy<int> lazy = new AsyncLazy<int>(t => Task.FromResult(10), AsyncLazyThreadSafetyMode.None);
 
         Assert.AreEqual(10, await lazy.GetValueAsync(default).ConfigureAwait(false));
         Assert.IsTrue(lazy.IsValueCreated);
         lazy.Dispose();
 
-        Assert.AreEqual(10, await lazy.GetValueAsync(default).ConfigureAwait(false));
+        await Assert.ThrowsExceptionAsync<ObjectDisposedException>(() => lazy.GetValueAsync(default)).ConfigureAwait(false);
+        Assert.IsFalse(lazy.IsValueCreated);
+        Assert.IsFalse(lazy.IsValueFaulted);
+        Assert.AreEqual(default, lazy.ValueForDebugDisplay);
     }
 
     [TestMethod]

--- a/src/Core/Sweetener.Test/Collections/Generic/BinaryComparer.Test.cs
+++ b/src/Core/Sweetener.Test/Collections/Generic/BinaryComparer.Test.cs
@@ -29,8 +29,8 @@ public class BinaryComparerTest
         => Compare(
             (x, y) =>
             {
-                using Stream? xStream = x != null ? new IncompleteReadStream(x) : null;
-                using Stream? yStream = y != null ? new IncompleteReadStream(y) : null;
+                using Stream? xStream = x is not null ? new IncompleteReadStream(x) : null;
+                using Stream? yStream = y is not null ? new IncompleteReadStream(y) : null;
 
                 if (ReferenceEquals(x, y))
                     return BinaryComparer.Instance.Compare(xStream, xStream);
@@ -60,8 +60,8 @@ public class BinaryComparerTest
         => Equals(
             (x, y) =>
             {
-                using Stream? xStream = x != null ? new IncompleteReadStream(x) : null;
-                using Stream? yStream = y != null ? new IncompleteReadStream(y) : null;
+                using Stream? xStream = x is not null ? new IncompleteReadStream(x) : null;
+                using Stream? yStream = y is not null ? new IncompleteReadStream(y) : null;
 
                 if (ReferenceEquals(x, y))
                     return BinaryComparer.Instance.Equals(xStream, xStream);
@@ -84,8 +84,8 @@ public class BinaryComparerTest
     public void GetHashCode_Stream()
         => Equals((x, y) =>
         {
-            using Stream? xStream = x != null ? new IncompleteReadStream(x) : null;
-            using Stream? yStream = y != null ? new IncompleteReadStream(y) : null;
+            using Stream? xStream = x is not null ? new IncompleteReadStream(x) : null;
+            using Stream? yStream = y is not null ? new IncompleteReadStream(y) : null;
 
             return BinaryComparer.Instance.GetHashCode(xStream!) == BinaryComparer.Instance.GetHashCode(yStream!);
         });

--- a/src/Core/Sweetener.Test/Collections/Generic/BinaryComparer.Test.cs
+++ b/src/Core/Sweetener.Test/Collections/Generic/BinaryComparer.Test.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Sweetener.Collections.Generic;
 
@@ -27,8 +29,8 @@ public class BinaryComparerTest
         => Compare(
             (x, y) =>
             {
-                using Stream? xStream = x != null ? new MemoryStream(x) : null;
-                using Stream? yStream = y != null ? new MemoryStream(y) : null;
+                using Stream? xStream = x != null ? new IncompleteReadStream(x) : null;
+                using Stream? yStream = y != null ? new IncompleteReadStream(y) : null;
 
                 if (ReferenceEquals(x, y))
                     return BinaryComparer.Instance.Compare(xStream, xStream);
@@ -58,8 +60,8 @@ public class BinaryComparerTest
         => Equals(
             (x, y) =>
             {
-                using Stream? xStream = x != null ? new MemoryStream(x) : null;
-                using Stream? yStream = y != null ? new MemoryStream(y) : null;
+                using Stream? xStream = x != null ? new IncompleteReadStream(x) : null;
+                using Stream? yStream = y != null ? new IncompleteReadStream(y) : null;
 
                 if (ReferenceEquals(x, y))
                     return BinaryComparer.Instance.Equals(xStream, xStream);
@@ -82,8 +84,8 @@ public class BinaryComparerTest
     public void GetHashCode_Stream()
         => Equals((x, y) =>
         {
-            using Stream? xStream = x != null ? new MemoryStream(x) : null;
-            using Stream? yStream = y != null ? new MemoryStream(y) : null;
+            using Stream? xStream = x != null ? new IncompleteReadStream(x) : null;
+            using Stream? yStream = y != null ? new IncompleteReadStream(y) : null;
 
             return BinaryComparer.Instance.GetHashCode(xStream!) == BinaryComparer.Instance.GetHashCode(yStream!);
         });
@@ -214,5 +216,33 @@ public class BinaryComparerTest
         Skip,
         Include,
         SameAsEmpty,
+    }
+
+    private sealed class IncompleteReadStream : MemoryStream
+    {
+        private const int MaxReadBytes = 2;
+
+        public IncompleteReadStream(byte[] buffer)
+            : base(buffer)
+        { }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => base.Read(buffer, offset, Math.Min(count, MaxReadBytes));
+
+#if NET6_0_OR_GREATER
+        public override int Read(Span<byte> buffer)
+            => base.Read(buffer.Slice(0, Math.Min(buffer.Length, MaxReadBytes)));
+#endif
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => base.ReadAsync(buffer, offset, Math.Min(count, MaxReadBytes), cancellationToken);
+
+#if NET6_0_OR_GREATER
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => base.ReadAsync(buffer.Slice(0, Math.Min(buffer.Length, MaxReadBytes)), cancellationToken);
+#endif
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+            => base.BeginRead(buffer, offset, Math.Min(count, MaxReadBytes), callback!, state);
     }
 }

--- a/src/Core/Sweetener/AsyncLazy.T.cs
+++ b/src/Core/Sweetener/AsyncLazy.T.cs
@@ -55,7 +55,7 @@ public sealed class AsyncLazy<T> : IDisposable
         get
         {
             Task<T>? valueTask = _valueTask;
-            return valueTask != null
+            return valueTask is not null
                 && !ReferenceEquals(valueTask, DisposedTask)
 #if NETCOREAPP2_0_OR_GREATER
                 && valueTask.IsCompletedSuccessfully
@@ -185,7 +185,7 @@ public sealed class AsyncLazy<T> : IDisposable
     public override string? ToString()
     {
         Task<T>? valueTask = _valueTask;
-        return valueTask != null
+        return valueTask is not null
 #if NETCOREAPP2_0_OR_GREATER
             && valueTask.IsCompletedSuccessfully
 #else

--- a/src/Core/Sweetener/AsyncLazy.T.cs
+++ b/src/Core/Sweetener/AsyncLazy.T.cs
@@ -145,6 +145,9 @@ public sealed class AsyncLazy<T> : IDisposable
         if (valueFactory is null)
             return _valueTask!;
 
+        // Note: We preserve the value of the _valueFactory for the non-thread-safe execution paths.
+        // This way there are no errors like NullReferenceException when concurrently executing GetValueAsync for
+        // an instance with AsyncLazyThreadSafetyMode.None. The values may be unexpected, but it won't crash!
         return Mode switch
         {
             AsyncLazyThreadSafetyMode.None            => ExecuteAndPublishAsync              (valueFactory, cancellationToken),

--- a/src/Core/Sweetener/Collections/Generic/BinaryComparer.cs
+++ b/src/Core/Sweetener/Collections/Generic/BinaryComparer.cs
@@ -511,14 +511,14 @@ public sealed class BinaryComparer : IComparer<byte[]>, IComparer<Stream>, IEqua
     private static int FillBuffer(Stream stream, Span<byte> buffer)
     {
         int read = 0;
-        while (read < buffer.Length)
+        while (buffer.Length > 0)
         {
             int next = stream.Read(buffer);
             if (next == 0)
                 break;
 
             read += next;
-            buffer = buffer[read..];
+            buffer = buffer[next..];
         }
 
         return read;

--- a/src/Core/Sweetener/Sweetener.csproj
+++ b/src/Core/Sweetener/Sweetener.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
- Update `AsyncLazy<T>` disposal pattern to no longer cache results and aggressively remove references to the factory
- Dispose of more references in `AsyncLazy<T>`
- Refactor `AsyncLazy<T>`'s thread safety
- Fix `BinaryComparer` when reading from a `Stream` that results in fewer than the desired bytes