### PR TITLE
Fix Error Type for Concurrent Exceptions in AsyncLazy<T>

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -185,7 +185,8 @@ dotnet_code_quality.dispose_analysis_kind                   = AllPaths
 dotnet_code_quality.enum_values_prefix_trigger              = AllEnumValues
 dotnet_code_quality.exclude_indirect_base_types             = false
 
-dotnet_code_quality.CA1802 = static # Use Literals Where Appropriate
+dotnet_code_quality.CA1002.api_surface = public, internal # Do not expose generic lists
+dotnet_code_quality.CA1802             = static           # Use Literals Where Appropriate
 
 dotnet_diagnostic.CA1031.severity = error # Do not catch general exception types
 dotnet_diagnostic.CA1032.severity = error # Implement standard exception constructors

--- a/src/Core/Sweetener/AsyncLazy.T.cs
+++ b/src/Core/Sweetener/AsyncLazy.T.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Sweetener.Threading;
@@ -195,7 +194,6 @@ public sealed class AsyncLazy<T> : IDisposable
         }
     }
 
-    [SuppressMessage("Performance", "CA1849:Call async methods when in an async method", Justification = "The _valueTask field is guaranteed to be complete.")]
     private async Task<T> ExecuteAndPublishThreadSafeAsync(CancellationToken cancellationToken)
     {
         Task<T>? valueTask = null;
@@ -216,7 +214,7 @@ public sealed class AsyncLazy<T> : IDisposable
                 return result;
             }
 
-            return _valueTask!.Result;
+            return await _valueTask!.ConfigureAwait(false);
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
@@ -230,7 +228,6 @@ public sealed class AsyncLazy<T> : IDisposable
         }
     }
 
-    [SuppressMessage("Performance", "CA1849:Call async methods when in an async method", Justification = "The _valueTask field is guaranteed to be complete.")]
     private async Task<T> ExecuteAndOnlyPublishThreadSafeAsync(AsyncFunc<CancellationToken, T> valueFactory, CancellationToken cancellationToken)
     {
         Task<T> valueTask = valueFactory.Invoke(cancellationToken);
@@ -243,7 +240,7 @@ public sealed class AsyncLazy<T> : IDisposable
             return result;
         }
 
-        return previous.Result;
+        return await previous.ConfigureAwait(false);
     }
 }
 


### PR DESCRIPTION
- Prevent AggregateException from being thrown instead of the underlying error
- Add new test cases